### PR TITLE
#2875: concept-api validation of `visualElement` + migrations

### DIFF
--- a/concept-api/src/main/scala/db/migration/R__MetaImageAsVisualElement.scala
+++ b/concept-api/src/main/scala/db/migration/R__MetaImageAsVisualElement.scala
@@ -1,0 +1,136 @@
+/*
+ * Part of NDLA concept-api
+ * Copyright (C) 2022 NDLA
+ *
+ * See LICENSE
+ */
+
+package db.migration
+
+import org.flywaydb.core.api.migration.{BaseJavaMigration, Context}
+import org.json4s.JsonAST.JObject
+import org.json4s.native.JsonMethods.{compact, parse, render}
+import org.json4s.{DefaultFormats, Extraction}
+import org.postgresql.util.PGobject
+import scalikejdbc.{DB, DBSession, _}
+
+class R__MetaImageAsVisualElement extends BaseJavaMigration {
+  implicit val formats: DefaultFormats.type = DefaultFormats
+
+  override def getChecksum: Integer = 0 // Increment this number to re-run
+
+  override def migrate(context: Context): Unit = {
+    val db = DB(context.getConnection)
+    db.autoClose(false)
+
+    db.withinTx { implicit session =>
+      migrateConcepts()
+      migratePublishedConcepts()
+    }
+  }
+
+  def migratePublishedConcepts()(implicit session: DBSession): Unit = {
+    val count = countAllPublishedConcepts.get
+    var numPagesLeft = (count / 1000) + 1
+    var offset = 0L
+
+    while (numPagesLeft > 0) {
+      allPublishedConcepts(offset * 1000).map {
+        case (id, document) => updatePublishedConcept(convertToNewConcept(document), id)
+      }
+      numPagesLeft -= 1
+      offset += 1
+    }
+  }
+
+  def migrateConcepts()(implicit session: DBSession): Unit = {
+    val count = countAllConcepts.get
+    var numPagesLeft = (count / 1000) + 1
+    var offset = 0L
+
+    while (numPagesLeft > 0) {
+      allConcepts(offset * 1000).map {
+        case (id, document) => updateConcept(convertToNewConcept(document), id)
+      }
+      numPagesLeft -= 1
+      offset += 1
+    }
+  }
+
+  def countAllPublishedConcepts(implicit session: DBSession): Option[Long] = {
+    sql"select count(*) from publishedconceptdata where document is not NULL"
+      .map(rs => rs.long("count"))
+      .single()
+  }
+
+  def countAllConcepts(implicit session: DBSession): Option[Long] = {
+    sql"select count(*) from conceptdata where document is not NULL"
+      .map(rs => rs.long("count"))
+      .single()
+  }
+
+  def allPublishedConcepts(offset: Long)(implicit session: DBSession): Seq[(Long, String)] = {
+    sql"select id, document from publishedconceptdata where document is not null order by id limit 1000 offset $offset"
+      .map(rs => {
+        (rs.long("id"), rs.string("document"))
+      })
+      .list()
+  }
+
+  def allConcepts(offset: Long)(implicit session: DBSession): Seq[(Long, String)] = {
+    sql"select id, document from conceptdata where document is not null order by id limit 1000 offset $offset"
+      .map(rs => {
+        (rs.long("id"), rs.string("document"))
+      })
+      .list()
+  }
+
+  def updatePublishedConcept(document: String, id: Long)(implicit session: DBSession): Int = {
+    val dataObject = new PGobject()
+    dataObject.setType("jsonb")
+    dataObject.setValue(document)
+
+    sql"update publishedconceptdata set document = $dataObject where id = $id"
+      .update()
+  }
+
+  def updateConcept(document: String, id: Long)(implicit session: DBSession): Int = {
+    val dataObject = new PGobject()
+    dataObject.setType("jsonb")
+    dataObject.setValue(document)
+
+    sql"update conceptdata set document = $dataObject where id = $id"
+      .update()
+  }
+
+  private def mergeFields(
+      existing: Seq[NewVisualElement],
+      updated: Seq[NewVisualElement]
+  ): Seq[NewVisualElement] = {
+    val toKeep = existing.filterNot(item => updated.map(_.language).contains(item.language))
+    (toKeep ++ updated).filterNot(_.visualElement.isEmpty)
+  }
+
+  def convertMetaImageToVisualElement(image: OldMetaImage): Option[NewVisualElement] = {
+    if (image.imageId.isEmpty) None
+    else {
+      val embedString =
+        s"""<embed data-resource="image" data-resource_id="${image.imageId}" data-alt="${image.altText}" data-size="full" data-align="" />"""
+      Some(NewVisualElement(embedString, image.language))
+    }
+  }
+
+  def convertToNewConcept(document: String): String = {
+    val concept = parse(document)
+    val metaImages = (concept \ "metaImage").extract[Seq[OldMetaImage]]
+    val visualElements = (concept \ "visualElement").extract[Seq[NewVisualElement]]
+    val convertedVisualElements = metaImages.flatMap(convertMetaImageToVisualElement)
+    val newVisualElements = mergeFields(convertedVisualElements, visualElements)
+    val newConcept = concept.merge(JObject("visualElement" -> Extraction.decompose(newVisualElements)))
+
+    compact(render(newConcept))
+  }
+
+  case class OldMetaImage(imageId: String, altText: String, language: String)
+  case class NewVisualElement(visualElement: String, language: String)
+}

--- a/concept-api/src/main/scala/db/migration/V10__RemoveImageVisualElementsWithoutIds.scala
+++ b/concept-api/src/main/scala/db/migration/V10__RemoveImageVisualElementsWithoutIds.scala
@@ -1,0 +1,149 @@
+/*
+ * Part of NDLA concept-api
+ * Copyright (C) 2022 NDLA
+ *
+ * See LICENSE
+ */
+
+package db.migration
+
+import org.flywaydb.core.api.migration.{BaseJavaMigration, Context}
+import org.json4s.JsonAST.{JArray, JObject}
+import org.json4s.native.JsonMethods.{compact, parse, render}
+import org.json4s.{DefaultFormats, Extraction}
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Element
+import org.jsoup.nodes.Entities.EscapeMode
+import org.postgresql.util.PGobject
+import scalikejdbc.{DB, DBSession, _}
+
+class V10__RemoveImageVisualElementsWithoutIds extends BaseJavaMigration {
+  implicit val formats: DefaultFormats.type = DefaultFormats
+
+  override def migrate(context: Context): Unit = {
+    val db = DB(context.getConnection)
+    db.autoClose(false)
+
+    db.withinTx { implicit session =>
+      migrateConcepts()
+      migratePublishedConcepts()
+    }
+  }
+
+  def migratePublishedConcepts()(implicit session: DBSession): Unit = {
+    val count = countAllPublishedConcepts.get
+    var numPagesLeft = (count / 1000) + 1
+    var offset = 0L
+
+    while (numPagesLeft > 0) {
+      allPublishedConcepts(offset * 1000).map {
+        case (id, document) => updatePublishedConcept(convertToNewConcept(document, id), id)
+      }
+      numPagesLeft -= 1
+      offset += 1
+    }
+  }
+
+  def migrateConcepts()(implicit session: DBSession): Unit = {
+    val count = countAllConcepts.get
+    var numPagesLeft = (count / 1000) + 1
+    var offset = 0L
+
+    while (numPagesLeft > 0) {
+      allConcepts(offset * 1000).map {
+        case (id, document) => updateConcept(convertToNewConcept(document, id), id)
+      }
+      numPagesLeft -= 1
+      offset += 1
+    }
+  }
+
+  def countAllPublishedConcepts(implicit session: DBSession): Option[Long] = {
+    sql"select count(*) from publishedconceptdata where document is not NULL"
+      .map(rs => rs.long("count"))
+      .single()
+  }
+
+  def countAllConcepts(implicit session: DBSession): Option[Long] = {
+    sql"select count(*) from conceptdata where document is not NULL"
+      .map(rs => rs.long("count"))
+      .single()
+  }
+
+  def allPublishedConcepts(offset: Long)(implicit session: DBSession): Seq[(Long, String)] = {
+    sql"select id, document from publishedconceptdata where document is not null order by id limit 1000 offset $offset"
+      .map(rs => {
+        (rs.long("id"), rs.string("document"))
+      })
+      .list()
+  }
+
+  def allConcepts(offset: Long)(implicit session: DBSession): Seq[(Long, String)] = {
+    sql"select id, document from conceptdata where document is not null order by id limit 1000 offset $offset"
+      .map(rs => {
+        (rs.long("id"), rs.string("document"))
+      })
+      .list()
+  }
+
+  def updatePublishedConcept(document: String, id: Long)(implicit session: DBSession): Int = {
+    val dataObject = new PGobject()
+    dataObject.setType("jsonb")
+    dataObject.setValue(document)
+
+    sql"update publishedconceptdata set document = $dataObject where id = $id"
+      .update()
+  }
+
+  def updateConcept(document: String, id: Long)(implicit session: DBSession): Int = {
+    val dataObject = new PGobject()
+    dataObject.setType("jsonb")
+    dataObject.setValue(document)
+
+    sql"update conceptdata set document = $dataObject where id = $id"
+      .update()
+  }
+
+  private def stringToJsoupDocument(htmlString: String): Element = {
+    val document = Jsoup.parseBodyFragment(htmlString)
+    document.outputSettings().escapeMode(EscapeMode.xhtml).prettyPrint(false)
+    document.select("body").first()
+  }
+
+  def convertVisualElement(oldVisualElement: NewVisualElement, id: Long): Option[NewVisualElement] = {
+    if (oldVisualElement.visualElement.nonEmpty) {
+      val x = stringToJsoupDocument(oldVisualElement.visualElement)
+      val embed = Option(x.select("embed").first())
+      embed match {
+        case Some(oldEmbed) =>
+          val resourceType = oldEmbed.attr("data-resource")
+          val imageId = oldEmbed.attr("data-resource_id")
+          if (resourceType == "image" && imageId.isEmpty) {
+            println(s"Hello team we did a good with $id -> ${oldVisualElement.visualElement}")
+            None
+          } else {
+            Some(oldVisualElement)
+          }
+        case _ => Some(oldVisualElement)
+
+      }
+    } else {
+      Some(oldVisualElement)
+    }
+  }
+
+  def convertToNewConcept(document: String, id: Long): String = {
+    val concept = parse(document)
+    val newConcept = concept
+      .mapField {
+        case ("visualElement", visualElement: JArray) =>
+          val visualElements = visualElement.extract[Seq[NewVisualElement]]
+          val newVisualElements = visualElements.flatMap(ve => convertVisualElement(ve, id))
+          "visualElement" -> Extraction.decompose(newVisualElements)
+        case x => x
+      }
+    compact(render(newConcept))
+  }
+
+  case class NewVisualElement(visualElement: String, language: String)
+}

--- a/concept-api/src/main/scala/db/migration/V10__RemoveImageVisualElementsWithoutIds.scala
+++ b/concept-api/src/main/scala/db/migration/V10__RemoveImageVisualElementsWithoutIds.scala
@@ -119,7 +119,8 @@ class V10__RemoveImageVisualElementsWithoutIds extends BaseJavaMigration {
           val resourceType = oldEmbed.attr("data-resource")
           val imageId = oldEmbed.attr("data-resource_id")
           if (resourceType == "image" && imageId.isEmpty) {
-            println(s"Hello team we did a good with $id -> ${oldVisualElement.visualElement}")
+            println(
+              s"Concept '$id' had empty-id visualelement image in language '${oldVisualElement.language}', removing...")
             None
           } else {
             Some(oldVisualElement)

--- a/concept-api/src/main/scala/db/migration/V11__RemoveEmptyStringMetaImages.scala
+++ b/concept-api/src/main/scala/db/migration/V11__RemoveEmptyStringMetaImages.scala
@@ -1,0 +1,127 @@
+/*
+ * Part of NDLA concept-api
+ * Copyright (C) 2022 NDLA
+ *
+ * See LICENSE
+ */
+
+package db.migration
+
+import org.flywaydb.core.api.migration.{BaseJavaMigration, Context}
+import org.json4s.JsonAST.JArray
+import org.json4s.native.JsonMethods.{compact, parse, render}
+import org.json4s.{DefaultFormats, Extraction}
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Element
+import org.jsoup.nodes.Entities.EscapeMode
+import org.postgresql.util.PGobject
+import scalikejdbc.{DB, DBSession, _}
+
+class V11__RemoveEmptyStringMetaImages extends BaseJavaMigration {
+  implicit val formats: DefaultFormats.type = DefaultFormats
+
+  override def migrate(context: Context): Unit = {
+    val db = DB(context.getConnection)
+    db.autoClose(false)
+
+    db.withinTx { implicit session =>
+      migrateConcepts()
+      migratePublishedConcepts()
+    }
+  }
+
+  def migratePublishedConcepts()(implicit session: DBSession): Unit = {
+    val count = countAllPublishedConcepts.get
+    var numPagesLeft = (count / 1000) + 1
+    var offset = 0L
+
+    while (numPagesLeft > 0) {
+      allPublishedConcepts(offset * 1000).map {
+        case (id, document) => updatePublishedConcept(convertToNewConcept(document), id)
+      }
+      numPagesLeft -= 1
+      offset += 1
+    }
+  }
+
+  def migrateConcepts()(implicit session: DBSession): Unit = {
+    val count = countAllConcepts.get
+    var numPagesLeft = (count / 1000) + 1
+    var offset = 0L
+
+    while (numPagesLeft > 0) {
+      allConcepts(offset * 1000).map {
+        case (id, document) => updateConcept(convertToNewConcept(document), id)
+      }
+      numPagesLeft -= 1
+      offset += 1
+    }
+  }
+
+  def countAllPublishedConcepts(implicit session: DBSession): Option[Long] = {
+    sql"select count(*) from publishedconceptdata where document is not NULL"
+      .map(rs => rs.long("count"))
+      .single()
+  }
+
+  def countAllConcepts(implicit session: DBSession): Option[Long] = {
+    sql"select count(*) from conceptdata where document is not NULL"
+      .map(rs => rs.long("count"))
+      .single()
+  }
+
+  def allPublishedConcepts(offset: Long)(implicit session: DBSession): Seq[(Long, String)] = {
+    sql"select id, document from publishedconceptdata where document is not null order by id limit 1000 offset $offset"
+      .map(rs => {
+        (rs.long("id"), rs.string("document"))
+      })
+      .list()
+  }
+
+  def allConcepts(offset: Long)(implicit session: DBSession): Seq[(Long, String)] = {
+    sql"select id, document from conceptdata where document is not null order by id limit 1000 offset $offset"
+      .map(rs => {
+        (rs.long("id"), rs.string("document"))
+      })
+      .list()
+  }
+
+  def updatePublishedConcept(document: String, id: Long)(implicit session: DBSession): Int = {
+    val dataObject = new PGobject()
+    dataObject.setType("jsonb")
+    dataObject.setValue(document)
+
+    sql"update publishedconceptdata set document = $dataObject where id = $id"
+      .update()
+  }
+
+  def updateConcept(document: String, id: Long)(implicit session: DBSession): Int = {
+    val dataObject = new PGobject()
+    dataObject.setType("jsonb")
+    dataObject.setValue(document)
+
+    sql"update conceptdata set document = $dataObject where id = $id"
+      .update()
+  }
+
+  private def stringToJsoupDocument(htmlString: String): Element = {
+    val document = Jsoup.parseBodyFragment(htmlString)
+    document.outputSettings().escapeMode(EscapeMode.xhtml).prettyPrint(false)
+    document.select("body").first()
+  }
+
+  def convertToNewConcept(document: String): String = {
+    val concept = parse(document)
+    val newConcept = concept
+      .mapField {
+        case ("metaImage", metaImage: JArray) =>
+          val metaImages = metaImage.extract[Seq[OldMetaImage]]
+          val newMetaImages = metaImages.filter(_.imageId.nonEmpty)
+          "metaImage" -> Extraction.decompose(newMetaImages)
+        case x => x
+      }
+    compact(render(newConcept))
+  }
+
+  case class OldMetaImage(imageId: String, altText: String, language: String)
+}

--- a/concept-api/src/main/scala/no/ndla/conceptapi/validation/ContentValidator.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/validation/ContentValidator.scala
@@ -39,6 +39,7 @@ trait ContentValidator {
       val validationErrors =
         concept.content.flatMap(c => validateConceptContent(c)) ++
           concept.visualElement.flatMap(ve => validateVisualElement(ve)) ++
+          concept.metaImage.flatMap(mi => validateMetaImage(mi)) ++
           validateTitles(concept.title)
 
       if (validationErrors.isEmpty) {
@@ -46,6 +47,10 @@ trait ContentValidator {
       } else {
         Failure(new ValidationException(errors = validationErrors))
       }
+    }
+
+    private def validateMetaImage(metaImage: ConceptMetaImage): Seq[ValidationMessage] = {
+      validateMinimumLength(s"metaImage.id", metaImage.imageId, 1).toSeq
     }
 
     private def validateVisualElement(content: VisualElement): Seq[ValidationMessage] = {

--- a/concept-api/src/main/scala/no/ndla/conceptapi/validation/ContentValidator.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/validation/ContentValidator.scala
@@ -50,7 +50,9 @@ trait ContentValidator {
 
     private def validateVisualElement(content: VisualElement): Seq[ValidationMessage] = {
       HtmlValidator
-        .validate("visualElement", content.visualElement, requiredToOptional = Map("image" -> Seq("data-caption")))
+        .validateVisualElement("visualElement",
+                               content.visualElement,
+                               requiredToOptional = Map("image" -> Seq("data-caption")))
         .toList ++
         validateLanguage("language", content.language)
     }

--- a/concept-api/src/test/scala/db/migration/R__MetaImageAsVisualElementTest.scala
+++ b/concept-api/src/test/scala/db/migration/R__MetaImageAsVisualElementTest.scala
@@ -1,0 +1,43 @@
+/*
+ * Part of NDLA concept-api
+ * Copyright (C) 2022 NDLA
+ *
+ * See LICENSE
+ */
+
+package db.migration
+
+import no.ndla.conceptapi.{TestEnvironment, UnitSuite}
+
+class R__MetaImageAsVisualElementTest extends UnitSuite with TestEnvironment {
+  val migration = new R__MetaImageAsVisualElement
+
+  private val metaImage = (id: String, alt: String, lang: String) => {
+    s"""{"imageId":"$id","altText":"$alt","language":"$lang"}"""
+  }
+
+  test("Meta images without ids should not affect visual elements") {
+    val oldMetaImage = """{"imageId":"","altText":"","language":"nb"}"""
+    val oldVisualElement = """"""
+    val old =
+      s"""{"metaImage":[$oldMetaImage],"visualElement":[$oldVisualElement]}"""
+    val expected = old
+    migration.convertToNewConcept(old) should be(expected)
+  }
+
+  test("Meta images with ids should become visual elements") {
+    val oldMetaImage = """{"imageId":"1","altText":"alt","language":"nb"}"""
+    val oldVisualElement = """"""
+    val old =
+      s"""{"metaImage":[$oldMetaImage],"visualElement":[$oldVisualElement]}"""
+
+    val visualElementString =
+      s"""<embed data-resource=\\"image\\" data-resource_id=\\"1\\" data-alt=\\"alt\\" data-size=\\"full\\" data-align=\\"\\" />"""
+    val expectedVisualElement = s"""{"visualElement":"$visualElementString","language":"nb"}"""
+
+    val expected =
+      s"""{"metaImage":[$oldMetaImage],"visualElement":[$expectedVisualElement]}"""
+    migration.convertToNewConcept(old) should be(expected)
+  }
+
+}

--- a/concept-api/src/test/scala/db/migration/V10__RemoveImageVisualElementsWithoutIdsTest.scala
+++ b/concept-api/src/test/scala/db/migration/V10__RemoveImageVisualElementsWithoutIdsTest.scala
@@ -1,0 +1,24 @@
+/*
+ * Part of NDLA concept-api
+ * Copyright (C) 2022 NDLA
+ *
+ * See LICENSE
+ */
+
+package db.migration
+
+import no.ndla.conceptapi.{TestEnvironment, UnitSuite}
+
+class V10__RemoveImageVisualElementsWithoutIdsTest extends UnitSuite with TestEnvironment {
+  val migration = new V10__RemoveImageVisualElementsWithoutIds
+
+  test("Image visual elements without id should be removed") {
+    val old =
+      """{"visualElement":[{"visualElement":"<embed data-resource_id=\"\" data-resource=\"image\" />","language":"nb"},{"visualElement":"<embed data-resource_id=\"2\" data-resource=\"image\" />","language":"nn"}]}"""
+    val expected =
+      """{"visualElement":[{"visualElement":"<embed data-resource_id=\"2\" data-resource=\"image\" />","language":"nn"}]}"""
+
+    migration.convertToNewConcept(old, 1) should be(expected)
+  }
+
+}

--- a/concept-api/src/test/scala/db/migration/V11__RemoveEmptyStringMetaImagesTest.scala
+++ b/concept-api/src/test/scala/db/migration/V11__RemoveEmptyStringMetaImagesTest.scala
@@ -1,0 +1,31 @@
+/*
+ * Part of NDLA concept-api
+ * Copyright (C) 2022 NDLA
+ *
+ * See LICENSE
+ */
+
+package db.migration
+
+import no.ndla.conceptapi.{TestEnvironment, UnitSuite}
+
+class V11__RemoveEmptyStringMetaImagesTest extends UnitSuite with TestEnvironment {
+  val migration = new V11__RemoveEmptyStringMetaImages
+
+  private val metaImage = (id: String, alt: String, lang: String) => {
+    s"""{"imageId":"$id","altText":"$alt","language":"$lang"}"""
+  }
+
+  test("MetaImages without ids should be removed") {
+    val old =
+      s"""{"metaImage":[${metaImage("", "alt", "nb")},${metaImage("1", "", "en")},${metaImage("", "", "nn")},${metaImage(
+        "2",
+        "alt",
+        "zh")}]}"""
+    val expected =
+      s"""{"metaImage":[${metaImage("1", "", "en")},${metaImage("2", "alt", "zh")}]}"""
+
+    migration.convertToNewConcept(old) should be(expected)
+  }
+
+}

--- a/concept-api/src/test/scala/no/ndla/conceptapi/TestData.scala
+++ b/concept-api/src/test/scala/no/ndla/conceptapi/TestData.scala
@@ -32,6 +32,9 @@ object TestData {
   val today = DateTime.now().minusDays(0).toDate
   val yesterday = DateTime.now().minusDays(1).toDate
 
+  val visualElementString =
+    """<embed data-caption="some capt" data-align="" data-resource_id="1" data-resource="image" data-alt="some alt" data-size="full" />"""
+
   val sampleNbApiConcept = api.Concept(
     1.toLong,
     1,
@@ -51,7 +54,7 @@ object TestData {
       current = "DRAFT",
       other = Seq.empty
     ),
-    Some(api.VisualElement("VisueltElement", "nb"))
+    Some(api.VisualElement(visualElementString, "nb"))
   )
 
   val sampleNbDomainConcept = domain.Concept(
@@ -69,7 +72,7 @@ object TestData {
     subjectIds = Set("urn:subject:3", "urn:subject:4"),
     articleIds = Seq(42),
     status = Status.default,
-    visualElement = Seq(domain.VisualElement("VisueltElement", "nb"))
+    visualElement = Seq(domain.VisualElement(visualElementString, "nb"))
   )
 
   val sampleConcept = domain.Concept(
@@ -105,7 +108,7 @@ object TestData {
     subjectIds = Set("urn:subject:3", "urn:subject:4"),
     articleIds = Seq(42),
     status = Status.default,
-    visualElement = Seq(domain.VisualElement("VisueltElement", "nb"))
+    visualElement = Seq(domain.VisualElement(visualElementString, "nb"))
   )
 
   val domainConcept_toDomainUpdateWithId = domain.Concept(
@@ -145,7 +148,7 @@ object TestData {
       current = "DRAFT",
       other = Seq.empty
     ),
-    Some(api.VisualElement("VisueltElement", "nb"))
+    Some(api.VisualElement(visualElementString, "nb"))
   )
 
   val emptyApiUpdatedConcept = api.UpdatedConcept(

--- a/draft-api/src/main/scala/no/ndla/draftapi/validation/ContentValidator.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/validation/ContentValidator.scala
@@ -133,9 +133,10 @@ trait ContentValidator {
 
     private def validateVisualElement(content: VisualElement): List[ValidationMessage] = {
       HtmlValidator
-        .validate("visualElement", content.resource, requiredToOptional = Map("image" -> Seq("data-caption")))
-        .toList ++
-        validateLanguage("language", content.language)
+        .validateVisualElement("visualElement",
+                               content.resource,
+                               requiredToOptional = Map("image" -> Seq("data-caption")))
+        .toList ++ validateLanguage("language", content.language)
     }
 
     private def validateIntroduction(content: ArticleIntroduction): List[ValidationMessage] = {

--- a/project/Module.scala
+++ b/project/Module.scala
@@ -71,6 +71,7 @@ trait Module {
     assembly / assemblyMergeStrategy := {
       case "module-info.class"                                           => MergeStrategy.discard
       case x if x.endsWith("/module-info.class")                         => MergeStrategy.discard
+      case x if x.endsWith("io.netty.versions.properties")               => MergeStrategy.discard
       case "mime.types"                                                  => MergeStrategy.filterDistinctLines
       case PathList("org", "joda", "convert", "ToString.class")          => MergeStrategy.first
       case PathList("org", "joda", "convert", "FromString.class")        => MergeStrategy.first

--- a/project/languagelib.scala
+++ b/project/languagelib.scala
@@ -11,14 +11,9 @@ object languagelib extends Module {
       "org.mockito" % "mockito-all" % "1.10.19" % "test"
     ))
 
-  private val scala213 = ScalaV
-  private val scala212 = "2.12.10"
-  private val supportedScalaVersions = List(scala213, scala212)
-
   override lazy val settings: Seq[Def.Setting[_]] = Seq(
     name := "language",
     libraryDependencies ++= dependencies,
-    crossScalaVersions := supportedScalaVersions
   ) ++
     commonSettings ++
     fmtSettings

--- a/project/mappinglib.scala
+++ b/project/mappinglib.scala
@@ -7,14 +7,9 @@ import Dependencies._
 object mappinglib extends Module {
   lazy val dependencies: Seq[ModuleID] = Seq("org.scalatest" %% "scalatest" % ScalaTestV % "test")
 
-  private val scala213 = ScalaV
-  private val scala212 = "2.12.10"
-  private val supportedScalaVersions = List(scala213, scala212)
-
   override lazy val settings: Seq[Def.Setting[_]] = Seq(
     name := "mapping",
     libraryDependencies ++= dependencies,
-    crossScalaVersions := supportedScalaVersions
   ) ++
     commonSettings ++
     fmtSettings

--- a/project/networklib.scala
+++ b/project/networklib.scala
@@ -16,14 +16,9 @@ object networklib extends Module {
     "com.github.jwt-scala" %% "jwt-json4s-native" % "9.0.2"
   ) ++ vulnerabilityOverrides
 
-  private val scala213 = ScalaV
-  private val scala212 = "2.12.10"
-  private val supportedScalaVersions = List(scala213, scala212)
-
   override lazy val settings: Seq[Def.Setting[_]] = Seq(
     name := "network",
     libraryDependencies ++= dependencies,
-    crossScalaVersions := supportedScalaVersions
   ) ++
     commonSettings ++
     fmtSettings

--- a/project/scalatestsuitelib.scala
+++ b/project/scalatestsuitelib.scala
@@ -14,14 +14,9 @@ object scalatestsuitelib extends Module {
     jodaTime,
   ) ++ database ++ vulnerabilityOverrides
 
-  private val scala213 = ScalaV
-  private val scala212 = "2.12.10"
-  private val supportedScalaVersions = List(scala213, scala212)
-
   override lazy val settings: Seq[Def.Setting[_]] = Seq(
     name := "scalatestsuite",
     libraryDependencies ++= dependencies,
-    crossScalaVersions := supportedScalaVersions
   ) ++
     commonSettings ++
     fmtSettings

--- a/project/validationlib.scala
+++ b/project/validationlib.scala
@@ -12,14 +12,9 @@ object validationlib extends Module {
     scalaUri
   )
 
-  private val scala213 = ScalaV
-  private val scala212 = "2.12.10"
-  private val supportedScalaVersions = List(scala213, scala212)
-
   override lazy val settings: Seq[Def.Setting[_]] = Seq(
     name := "validation",
     libraryDependencies ++= dependencies,
-    crossScalaVersions := supportedScalaVersions
   ) ++
     commonSettings ++
     fmtSettings

--- a/validation/src/main/resources/embed-tag-rules.json
+++ b/validation/src/main/resources/embed-tag-rules.json
@@ -26,6 +26,9 @@
       ]
     },
     "audio": {
+      "requiredNonEmpty": [
+        "data-resource_id"
+      ],
       "required": [
         "data-resource",
         "data-resource_id",
@@ -66,6 +69,9 @@
       ]
     },
     "image": {
+      "requiredNonEmpty": [
+        "data-resource_id"
+      ],
       "required": [
         "data-resource",
         "data-resource_id",
@@ -87,6 +93,9 @@
       ]
     },
     "concept": {
+      "requiredNonEmpty": [
+        "data-content-id",
+      ],
       "required": [
         "data-resource",
         "data-content-id",

--- a/validation/src/main/scala/no/ndla/validation/HtmlTagRules.scala
+++ b/validation/src/main/scala/no/ndla/validation/HtmlTagRules.scala
@@ -14,7 +14,7 @@ import org.jsoup.nodes.Element
 import org.jsoup.nodes.Entities.EscapeMode
 import scala.io.Source
 import scala.language.postfixOps
-import scala.collection.JavaConverters._ // TODO: Replace with `import scala.jdk.CollectionConverters._` when removing 2.12 support
+import scala.jdk.CollectionConverters._
 
 object HtmlTagRules {
 

--- a/validation/src/main/scala/no/ndla/validation/TagRules.scala
+++ b/validation/src/main/scala/no/ndla/validation/TagRules.scala
@@ -5,12 +5,15 @@ import org.json4s.native.JsonMethods._
 import org.json4s.ext._
 
 object TagRules {
-  case class TagAttributeRules(required: Set[TagAttributes.Value],
-                               optional: Seq[Set[TagAttributes.Value]],
-                               validSrcDomains: Option[Seq[String]],
-                               mustBeDirectChildOf: Option[ParentTag],
-                               mustContainAtLeastOneOptionalAttribute: Boolean = false) {
-    lazy val all: Set[TagAttributes.Value] = required ++ optional.flatten
+  case class TagAttributeRules(
+      required: Set[TagAttributes.Value],
+      requiredNonEmpty: Set[TagAttributes.Value],
+      optional: Seq[Set[TagAttributes.Value]],
+      validSrcDomains: Option[Seq[String]],
+      mustBeDirectChildOf: Option[ParentTag],
+      mustContainAtLeastOneOptionalAttribute: Boolean = false
+  ) {
+    lazy val all: Set[TagAttributes.Value] = required ++ requiredNonEmpty ++ optional.flatten
 
     def withOptionalRequired(toBeOptional: Seq[String]) = {
       val toBeOptionalEnums = toBeOptional.flatMap(TagAttributes.valueOf)
@@ -28,7 +31,7 @@ object TagRules {
   case class Condition(childCount: String)
 
   object TagAttributeRules {
-    def empty = TagAttributeRules(Set.empty, Seq.empty, None, None)
+    def empty = TagAttributeRules(Set.empty, Set.empty, Seq.empty, None, None)
   }
 
   def convertJsonStrToAttributeRules(jsonStr: String): Map[String, TagAttributeRules] = {

--- a/validation/src/main/scala/no/ndla/validation/TagValidator.scala
+++ b/validation/src/main/scala/no/ndla/validation/TagValidator.scala
@@ -12,7 +12,7 @@ import no.ndla.validation.EmbedTagRules.ResourceHtmlEmbedTag
 import no.ndla.validation.TagRules.TagAttributeRules
 import org.jsoup.nodes.{Element, Node}
 
-import scala.collection.JavaConverters._ // TODO: Replace with `import scala.jdk.CollectionConverters._` when removing 2.12 support
+import scala.jdk.CollectionConverters._
 import scala.util.{Success, Try}
 
 class TagValidator {

--- a/validation/src/main/scala/no/ndla/validation/TextValidator.scala
+++ b/validation/src/main/scala/no/ndla/validation/TextValidator.scala
@@ -23,7 +23,6 @@ class TextValidator(allowHtml: Boolean) {
     *
     * @param fieldPath Path to return in the [[ValidationMessage]]'s if there are any
     * @param text Text to validate
-    * @param validateEmbedTagParent Whether to validate parents of embed tags where those are required.
     * @param requiredToOptional Map from resource-type to Seq of embed tag attributes to treat as optional rather than required for this validation.
     *                           Example Map("image" -> Seq("data-caption")) to make data-caption optional for "image" on this validation.
     * @return Seq of [[ValidationMessage]]'s describing issues with validation
@@ -31,11 +30,10 @@ class TextValidator(allowHtml: Boolean) {
   def validate(
       fieldPath: String,
       text: String,
-      validateEmbedTagParent: Boolean = true,
       requiredToOptional: Map[String, Seq[String]] = Map.empty
   ): Seq[ValidationMessage] = {
     allowHtml match {
-      case true  => validateOnlyBasicHtmlTags(fieldPath, text, validateEmbedTagParent, requiredToOptional)
+      case true  => validateOnlyBasicHtmlTags(fieldPath, text, requiredToOptional)
       case false => validateNoHtmlTags(fieldPath, text).toList
     }
   }
@@ -43,7 +41,6 @@ class TextValidator(allowHtml: Boolean) {
   private def validateOnlyBasicHtmlTags(
       fieldPath: String,
       text: String,
-      validateParent: Boolean,
       requiredToOptional: Map[String, Seq[String]]
   ): Seq[ValidationMessage] = {
     val whiteList = new Whitelist().addTags(HtmlTagRules.allLegalTags.toSeq: _*)
@@ -59,7 +56,7 @@ class TextValidator(allowHtml: Boolean) {
           case true  => None
           case false => Some(ValidationMessage(fieldPath, IllegalContentInBasicText))
         }
-        TagValidator.validate(fieldPath, text, validateParent, requiredToOptional) ++ jsoupValidatorMessages.toSeq
+        TagValidator.validate(fieldPath, text, requiredToOptional) ++ jsoupValidatorMessages.toSeq
       }
 
     }

--- a/validation/src/test/scala/no/ndla/validation/EmbedTagRulesTest.scala
+++ b/validation/src/test/scala/no/ndla/validation/EmbedTagRulesTest.scala
@@ -50,4 +50,24 @@ class EmbedTagRulesTest extends UnitSuite {
     )
   }
 
+  test("RequiredNonEmpty fields should not be allowed to be empty-strings") {
+    val embedString =
+      """<embed
+        | data-resource="image"
+        | data-resource_id=""
+        | data-size=""
+        | data-align=""
+        | data-alt=""
+        | data-caption=""
+        |/>""".stripMargin
+    val embedTagValidator = new TagValidator()
+
+    val result = embedTagValidator.validate("test", embedString)
+    result should be(
+      Seq(
+        ValidationMessage(
+          "test",
+          "An embed HTML tag with data-resource=image must contain non-empty attributes: data-resource_id.")))
+  }
+
 }

--- a/validation/src/test/scala/no/ndla/validation/EmbedTagValidatorTest.scala
+++ b/validation/src/test/scala/no/ndla/validation/EmbedTagValidatorTest.scala
@@ -398,15 +398,6 @@ class EmbedTagValidatorTest extends UnitSuite {
       """Embed tag with 'related-content' requires a parent 'div', with attributes: 'data-type="related-content"'""")
   }
 
-  test("validate should not return error if parent does not exists and validateParent is false") {
-    val validRelatedExternalEmbed =
-      """<embed data-resource="related-content" data-url="http://example.com" data-title="Eksempel tittel right here, yo">"""
-
-    val res =
-      embedTagValidator.validate("content", s"""<div>$validRelatedExternalEmbed</div>""", validateParent = false)
-    res.size should be(0)
-  }
-
   test("checkParentConditions should work for < operator") {
     val result1 = embedTagValidator.checkParentConditions("test", Condition("apekatt<2"), 3)
     result1 should be(Left(childCountValidationMessage("test")))

--- a/validation/src/test/scala/no/ndla/validation/HtmlValidatorTest.scala
+++ b/validation/src/test/scala/no/ndla/validation/HtmlValidatorTest.scala
@@ -5,11 +5,42 @@ import no.ndla.mapping.UnitSuite
 class HtmlValidatorTest extends UnitSuite {
   val htmlValidator = new TextValidator(allowHtml = true)
 
+  private val getValidImageEmbed = (id: String) => {
+    s"""<embed data-caption="some capt" data-align="" data-resource_id="$id" data-resource="image" data-alt="some alt" data-size="full" />"""
+  }
+
   test("validate should allow math tags with styling") {
     val mathContent =
       "<section><p>Formel: <math style=\"font-family:'Courier New'\" xmlns=\"http://www.w3.org/1998/Math/MathML\"><mmultiscripts><mn>22</mn><mprescripts/><mn>22</mn><mn>22</mn></mmultiscripts><mo>&#xA0;</mo><mi>h</mi><mi>a</mi><mi>l</mi><mi>l</mi><mi>o</mi><mrow style=\"font-family:'Courier New'\"><mi>a</mi><mi>s</mi><mi>d</mi><mi>f</mi></mrow></math></p></section>"
     val messages =
       htmlValidator.validate(fieldPath = "content", text = mathContent)
     messages.length should be(0)
+  }
+
+  test("Validating visual elements should fail if the tag is not an embed") {
+    htmlValidator.validateVisualElement("test", "") should be(
+      Seq(ValidationMessage("test", "The root html element for visual elements needs to be `embed`."))
+    )
+    htmlValidator.validateVisualElement("test", "apekatt") should be(
+      Seq(ValidationMessage("test", "The root html element for visual elements needs to be `embed`."))
+    )
+  }
+
+  test("Passing multiple embeds when validating visual element should fail") {
+    htmlValidator.validateVisualElement(
+      "test",
+      s"""${getValidImageEmbed("1")}${getValidImageEmbed("2")}"""
+    ) should be(
+      Seq(ValidationMessage("test", "Visual element must be a string containing only a single embed element."))
+    )
+  }
+
+  test("Passing a single valid embed should work") {
+    htmlValidator.validateVisualElement(
+      "test",
+      getValidImageEmbed("1")
+    ) should be(
+      Seq.empty
+    )
   }
 }


### PR DESCRIPTION
Fixes NDLANO/Issues#2875

concept-api:
- Legger til migrering for å fjerne visuelt element bilder uten id (tom streng)
- Legger til migrering for å fjerne metabilder med tom streng som id
- Legger til repeterbar migrering for å bruke metabilde som visuelt element (Nå uten å bruke de som har tom streng som id :smile:)

validation:
- Fikse deprecation warnings
- Legger til en ny feature for embed-validering `requiredNonEmpty` som validerer at en attribute er tilstede OG ikke er tom streng
- Legger til ny metode for å validere visuelle elementer
  - Denne sjekker at strengen er kun ett `embed` element og ikke noe annet (La den til i draft-api og concept-api)

Kan testes ved å sjekke at man ikke har igjen noen `visualElement`'s med `data-resource_id=""` etter migrering og ved  å teste at man ikke kan lage noen tom-streng metaimage-id'er eller visualelements med "feil" utforming.