### PR TITLE
Add includeOtherStatuses param to concept-api search

### DIFF
--- a/concept-api/src/main/scala/no/ndla/conceptapi/controller/DraftConceptController.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/controller/DraftConceptController.scala
@@ -57,11 +57,6 @@ trait DraftConceptController {
          |A draft only needs to have one of the available statuses to appear in result (OR).
        """.stripMargin
     )
-    private val includeOtherStatuses =
-      Param[Option[Boolean]](
-        "include-other-statuses",
-        s"Whether or not to include the 'other' status field when filtering with '${statusFilter.paramName}' param.")
-
 
     private def scrollSearchOr(scrollId: Option[String], language: String)(orFunction: => Any): Any =
       scrollId match {
@@ -92,7 +87,6 @@ trait DraftConceptController {
         shouldScroll: Boolean,
         embedResource: Option[String],
         embedId: Option[String],
-        includeOtherStatuses: Boolean
     ) = {
       val settings = DraftSearchSettings(
         withIdIn = idList,
@@ -107,8 +101,7 @@ trait DraftConceptController {
         userFilter = userFilter,
         shouldScroll = shouldScroll,
         embedResource = embedResource,
-        embedId = embedId,
-        includeOtherStatuses = includeOtherStatuses
+        embedId = embedId
       )
 
       val result = query match {
@@ -173,7 +166,6 @@ trait DraftConceptController {
             asQueryParam(userFilter),
             asQueryParam(embedResource),
             asQueryParam(embedId),
-            asQueryParam(includeOtherStatuses)
           )
           .authorizations("oauth2")
           .responseMessages(response500))
@@ -195,7 +187,6 @@ trait DraftConceptController {
         val shouldScroll = paramOrNone(this.scrollId.paramName).exists(InitialScrollContextKeywords.contains)
         val embedResource = paramOrNone(this.embedResource.paramName)
         val embedId = paramOrNone(this.embedId.paramName)
-        val includeOtherStatuses = booleanOrDefault(this.includeOtherStatuses.paramName, default = false)
 
         search(
           query,
@@ -211,8 +202,7 @@ trait DraftConceptController {
           usersToFilterBy,
           shouldScroll,
           embedResource,
-          embedId,
-          includeOtherStatuses
+          embedId
         )
 
       }
@@ -300,7 +290,6 @@ trait DraftConceptController {
             val shouldScroll = searchParams.scrollId.exists(InitialScrollContextKeywords.contains)
             val embedResource = searchParams.embedResource
             val embedId = searchParams.embedId
-            val includeOtherStatuses = booleanOrDefault(this.includeOtherStatuses.paramName, default = false)
 
             search(
               query,
@@ -317,7 +306,6 @@ trait DraftConceptController {
               shouldScroll,
               embedResource,
               embedId,
-              includeOtherStatuses
             )
           case Failure(ex) => errorHandler(ex)
         }

--- a/concept-api/src/main/scala/no/ndla/conceptapi/controller/DraftConceptController.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/controller/DraftConceptController.scala
@@ -57,6 +57,11 @@ trait DraftConceptController {
          |A draft only needs to have one of the available statuses to appear in result (OR).
        """.stripMargin
     )
+    private val includeOtherStatuses =
+      Param[Option[Boolean]](
+        "include-other-statuses",
+        s"Whether or not to include the 'other' status field when filtering with '${statusFilter.paramName}' param.")
+
 
     private def scrollSearchOr(scrollId: Option[String], language: String)(orFunction: => Any): Any =
       scrollId match {
@@ -86,7 +91,8 @@ trait DraftConceptController {
         userFilter: Seq[String],
         shouldScroll: Boolean,
         embedResource: Option[String],
-        embedId: Option[String]
+        embedId: Option[String],
+        includeOtherStatuses: Boolean
     ) = {
       val settings = DraftSearchSettings(
         withIdIn = idList,
@@ -101,7 +107,8 @@ trait DraftConceptController {
         userFilter = userFilter,
         shouldScroll = shouldScroll,
         embedResource = embedResource,
-        embedId = embedId
+        embedId = embedId,
+        includeOtherStatuses = includeOtherStatuses
       )
 
       val result = query match {
@@ -165,7 +172,8 @@ trait DraftConceptController {
             asQueryParam(statusFilter),
             asQueryParam(userFilter),
             asQueryParam(embedResource),
-            asQueryParam(embedId)
+            asQueryParam(embedId),
+            asQueryParam(includeOtherStatuses)
           )
           .authorizations("oauth2")
           .responseMessages(response500))
@@ -187,6 +195,7 @@ trait DraftConceptController {
         val shouldScroll = paramOrNone(this.scrollId.paramName).exists(InitialScrollContextKeywords.contains)
         val embedResource = paramOrNone(this.embedResource.paramName)
         val embedId = paramOrNone(this.embedId.paramName)
+        val includeOtherStatuses = booleanOrDefault(this.includeOtherStatuses.paramName, default = false)
 
         search(
           query,
@@ -202,7 +211,8 @@ trait DraftConceptController {
           usersToFilterBy,
           shouldScroll,
           embedResource,
-          embedId
+          embedId,
+          includeOtherStatuses
         )
 
       }
@@ -290,6 +300,7 @@ trait DraftConceptController {
             val shouldScroll = searchParams.scrollId.exists(InitialScrollContextKeywords.contains)
             val embedResource = searchParams.embedResource
             val embedId = searchParams.embedId
+            val includeOtherStatuses = booleanOrDefault(this.includeOtherStatuses.paramName, default = false)
 
             search(
               query,
@@ -305,7 +316,8 @@ trait DraftConceptController {
               userFilter,
               shouldScroll,
               embedResource,
-              embedId
+              embedId,
+              includeOtherStatuses
             )
           case Failure(ex) => errorHandler(ex)
         }

--- a/concept-api/src/main/scala/no/ndla/conceptapi/controller/DraftConceptController.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/controller/DraftConceptController.scala
@@ -86,7 +86,7 @@ trait DraftConceptController {
         userFilter: Seq[String],
         shouldScroll: Boolean,
         embedResource: Option[String],
-        embedId: Option[String],
+        embedId: Option[String]
     ) = {
       val settings = DraftSearchSettings(
         withIdIn = idList,

--- a/concept-api/src/main/scala/no/ndla/conceptapi/model/api/DraftConceptSearchParams.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/model/api/DraftConceptSearchParams.scala
@@ -27,5 +27,6 @@ case class DraftConceptSearchParams(
   @(ApiModelProperty @field)(description = "A comma-separated list of statuses that should appear in the search.") status: Set[String],
   @(ApiModelProperty @field)(description = "A comma-separated list of users to filter the search by.") users: Seq[String],
   @(ApiModelProperty @field)(description = "Embed resource type that should exist in the concepts.") embedResource: Option[String],
-  @(ApiModelProperty @field)(description = "Embed id attribute that should exist in the concepts.") embedId: Option[String]
+  @(ApiModelProperty @field)(description = "Embed id attribute that should exist in the concepts.") embedId: Option[String],
+  @(ApiModelProperty @field)(description = "Whether or not to include the other status field when filtering with status param.") includeOtherStatuses: Option[Boolean]
 )

--- a/concept-api/src/main/scala/no/ndla/conceptapi/model/api/DraftConceptSearchParams.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/model/api/DraftConceptSearchParams.scala
@@ -28,5 +28,4 @@ case class DraftConceptSearchParams(
   @(ApiModelProperty @field)(description = "A comma-separated list of users to filter the search by.") users: Seq[String],
   @(ApiModelProperty @field)(description = "Embed resource type that should exist in the concepts.") embedResource: Option[String],
   @(ApiModelProperty @field)(description = "Embed id attribute that should exist in the concepts.") embedId: Option[String],
-  @(ApiModelProperty @field)(description = "Whether or not to include the other status field when filtering with status param.") includeOtherStatuses: Option[Boolean]
 )

--- a/concept-api/src/main/scala/no/ndla/conceptapi/model/search/DraftSearchSettings.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/model/search/DraftSearchSettings.scala
@@ -23,7 +23,8 @@ case class DraftSearchSettings(
     userFilter: Seq[String],
     shouldScroll: Boolean,
     embedResource: Option[String],
-    embedId: Option[String]
+    embedId: Option[String],
+    includeOtherStatuses: Boolean
 )
 
 object DraftSearchSettings {
@@ -42,7 +43,8 @@ object DraftSearchSettings {
       userFilter = Seq.empty,
       shouldScroll = false,
       embedResource = None,
-      embedId = None
+      embedId = None,
+      includeOtherStatuses = false
     )
   }
 }

--- a/concept-api/src/main/scala/no/ndla/conceptapi/model/search/DraftSearchSettings.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/model/search/DraftSearchSettings.scala
@@ -24,7 +24,6 @@ case class DraftSearchSettings(
     shouldScroll: Boolean,
     embedResource: Option[String],
     embedId: Option[String],
-    includeOtherStatuses: Boolean
 )
 
 object DraftSearchSettings {
@@ -44,7 +43,6 @@ object DraftSearchSettings {
       shouldScroll = false,
       embedResource = None,
       embedId = None,
-      includeOtherStatuses = false
     )
   }
 }

--- a/concept-api/src/main/scala/no/ndla/conceptapi/service/search/DraftConceptSearchService.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/service/search/DraftConceptSearchService.scala
@@ -14,7 +14,7 @@ import com.typesafe.scalalogging.LazyLogging
 import no.ndla.conceptapi.ConceptApiProperties
 import no.ndla.conceptapi.model.api
 import no.ndla.conceptapi.model.api.{OperationNotAllowedException, ResultWindowTooLargeException, SubjectTags}
-import no.ndla.conceptapi.model.domain.{Language, SearchResult}
+import no.ndla.conceptapi.model.domain.{ConceptStatus, Language, SearchResult}
 import no.ndla.conceptapi.model.search.DraftSearchSettings
 import no.ndla.conceptapi.service.ConverterService
 import no.ndla.search.Elastic4sClient
@@ -121,7 +121,7 @@ trait DraftConceptSearchService {
 
     def executeSearch(queryBuilder: BoolQuery, settings: DraftSearchSettings): Try[SearchResult[api.ConceptSummary]] = {
       val idFilter = if (settings.withIdIn.isEmpty) None else Some(idsQuery(settings.withIdIn))
-      val statusFilter = orFilter(settings.statusFilter, "status.current", "status.other")
+      val statusFilter = boolStatusFilter(settings.statusFilter, settings.includeOtherStatuses)
       val subjectFilter = orFilter(settings.subjects, "subjectIds")
       val tagFilter = languageOrFilter(settings.tagsToFilterBy, "tags", settings.searchLanguage, settings.fallback)
       val userFilter = orFilter(settings.userFilter, "updatedBy")
@@ -181,6 +181,21 @@ trait DraftConceptSearchService {
               ))
           case Failure(ex) => errorHandler(ex)
         }
+      }
+    }
+
+    private def boolStatusFilter(statuses: Set[String], includeOthers: Boolean): Some[BoolQuery] = {
+      if (statuses.isEmpty) {
+        Some(
+          boolQuery().not(termQuery("status.current", ConceptStatus.ARCHIVED.toString))
+        )
+      } else {
+        val draftStatuses =
+          if (includeOthers) Seq("status.current", "status.other")
+          else Seq("status.current")
+        Some(
+          boolQuery().should(draftStatuses.flatMap(ds => statuses.map(s => termQuery(ds, s.toString))))
+        )
       }
     }
 

--- a/concept-api/src/test/scala/no/ndla/conceptapi/service/search/DraftConceptSearchServiceTest.scala
+++ b/concept-api/src/test/scala/no/ndla/conceptapi/service/search/DraftConceptSearchServiceTest.scala
@@ -164,7 +164,8 @@ class DraftConceptSearchServiceTest extends IntegrationSuite(EnableElasticsearch
     userFilter = Seq.empty,
     shouldScroll = false,
     embedResource = None,
-    embedId = None
+    embedId = None,
+    includeOtherStatuses = false
   )
 
   override def beforeAll(): Unit = {
@@ -578,17 +579,21 @@ class DraftConceptSearchServiceTest extends IntegrationSuite(EnableElasticsearch
 
   test("Filtering by statuses works as expected with OR filtering") {
     val Success(statusSearch1) = draftConceptSearchService.all(searchSettings.copy(statusFilter = Set("PUBLISHED")))
-    statusSearch1.totalCount should be(2)
-    statusSearch1.results.map(_.id) should be(Seq(9, 10))
+    statusSearch1.totalCount should be(1)
+    statusSearch1.results.map(_.id) should be(Seq(9))
 
-    val Success(statusSearch2) = draftConceptSearchService.all(searchSettings.copy(statusFilter = Set("TRANSLATED")))
-    statusSearch2.totalCount should be(1)
-    statusSearch2.results.map(_.id) should be(Seq(10))
+    val Success(statusSearch2) = draftConceptSearchService.all(searchSettings.copy(statusFilter = Set("PUBLISHED"), includeOtherStatuses = true))
+    statusSearch2.totalCount should be(2)
+    statusSearch2.results.map(_.id) should be(Seq(9, 10))
 
-    val Success(statusSearch3) =
+    val Success(statusSearch3) = draftConceptSearchService.all(searchSettings.copy(statusFilter = Set("TRANSLATED")))
+    statusSearch3.totalCount should be(1)
+    statusSearch3.results.map(_.id) should be(Seq(10))
+
+    val Success(statusSearch4) =
       draftConceptSearchService.all(searchSettings.copy(statusFilter = Set("TRANSLATED", "QUALITY_ASSURED")))
-    statusSearch3.totalCount should be(2)
-    statusSearch3.results.map(_.id) should be(Seq(8, 10))
+    statusSearch4.totalCount should be(2)
+    statusSearch4.results.map(_.id) should be(Seq(8, 10))
   }
 
   test("Filtering by users works as expected with OR filtering") {

--- a/concept-api/src/test/scala/no/ndla/conceptapi/service/search/DraftConceptSearchServiceTest.scala
+++ b/concept-api/src/test/scala/no/ndla/conceptapi/service/search/DraftConceptSearchServiceTest.scala
@@ -172,7 +172,6 @@ class DraftConceptSearchServiceTest extends IntegrationSuite(EnableElasticsearch
     shouldScroll = false,
     embedResource = None,
     embedId = None,
-    includeOtherStatuses = false
   )
 
   override def beforeAll(): Unit = {
@@ -587,31 +586,28 @@ class DraftConceptSearchServiceTest extends IntegrationSuite(EnableElasticsearch
 
   test("Filtering by statuses works as expected with OR filtering") {
     val Success(statusSearch1) = draftConceptSearchService.all(searchSettings.copy(statusFilter = Set("PUBLISHED")))
-    statusSearch1.totalCount should be(1)
-    statusSearch1.results.map(_.id) should be(Seq(9))
+    statusSearch1.totalCount should be(2)
+    statusSearch1.results.map(_.id) should be(Seq(9, 10))
 
-    val Success(statusSearch2) = draftConceptSearchService.all(searchSettings.copy(statusFilter = Set("PUBLISHED"), includeOtherStatuses = true))
-    statusSearch2.totalCount should be(2)
-    statusSearch2.results.map(_.id) should be(Seq(9, 10))
+    val Success(statusSearch2) = draftConceptSearchService.all(searchSettings.copy(statusFilter = Set("TRANSLATED")))
+    statusSearch2.totalCount should be(1)
+    statusSearch2.results.map(_.id) should be(Seq(10))
 
-    val Success(statusSearch3) = draftConceptSearchService.all(searchSettings.copy(statusFilter = Set("TRANSLATED")))
-    statusSearch3.totalCount should be(1)
-    statusSearch3.results.map(_.id) should be(Seq(10))
-
-    val Success(statusSearch4) =
+    val Success(statusSearch3) =
       draftConceptSearchService.all(searchSettings.copy(statusFilter = Set("TRANSLATED", "QUALITY_ASSURED")))
-    statusSearch4.totalCount should be(2)
-    statusSearch4.results.map(_.id) should be(Seq(8, 10))
+    statusSearch3.totalCount should be(2)
+    statusSearch3.results.map(_.id) should be(Seq(8, 10))
   }
 
   test("ARCHIVED concepts should only be returned if filtered by ARCHIVED") {
     val query = "slettet"
     val Success(search1) =
-      draftConceptSearchService.matchingQuery(query = query,
-        searchSettings.copy( withIdIn = List(12), statusFilter = Set(ConceptStatus.ARCHIVED.toString)))
+      draftConceptSearchService.matchingQuery(
+        query = query,
+        searchSettings.copy(withIdIn = List(12), statusFilter = Set(ConceptStatus.ARCHIVED.toString)))
     val Success(search2) =
       draftConceptSearchService.matchingQuery(query = query,
-        searchSettings.copy( withIdIn = List(12), statusFilter = Set.empty))
+                                              searchSettings.copy(withIdIn = List(12), statusFilter = Set.empty))
 
     search1.results.map(_.id) should be(Seq(12))
     search2.results.map(_.id) should be(Seq.empty)


### PR DESCRIPTION
Fixes NDLANO/Issues#2946

Slettede forklaringer skal ikke returneres i søk med mindre brukeren spesifiserer det.