### PR TITLE
Move validation of correlation between license and author to article-api

### DIFF
--- a/draft-api/src/main/scala/no/ndla/draftapi/validation/ContentValidator.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/validation/ContentValidator.scala
@@ -175,28 +175,18 @@ trait ContentValidator {
 
     private def validateCopyright(copyright: Copyright): Seq[ValidationMessage] = {
       val licenseMessage = copyright.license.map(validateLicense).toSeq.flatten
-      val allAuthors = copyright.creators ++ copyright.processors ++ copyright.rightsholders
-      val licenseCorrelationMessage = validateAuthorLicenseCorrelation(copyright.license, allAuthors)
       val contributorsMessages = copyright.creators.flatMap(validateAuthor) ++ copyright.processors.flatMap(
         validateAuthor) ++ copyright.rightsholders.flatMap(validateAuthor)
       val originMessage =
         copyright.origin.map(origin => NoHtmlValidator.validate("copyright.origin", origin)).toSeq.flatten
 
-      licenseMessage ++ licenseCorrelationMessage ++ contributorsMessages ++ originMessage
+      licenseMessage ++ contributorsMessages ++ originMessage
     }
 
     private def validateLicense(license: String): Seq[ValidationMessage] = {
       getLicense(license) match {
         case None => Seq(ValidationMessage("license.license", s"$license is not a valid license"))
         case _    => Seq()
-      }
-    }
-
-    private def validateAuthorLicenseCorrelation(license: Option[String], authors: Seq[Author]) = {
-      val errorMessage = (lic: String) => ValidationMessage("license.license", s"At least one copyright holder is required when license is $lic")
-      license match {
-        case None => Seq()
-        case Some(lic) => if(lic == "N/A" || authors.nonEmpty) Seq() else Seq(errorMessage(lic))
       }
     }
 

--- a/draft-api/src/test/scala/no/ndla/draftapi/validation/ContentValidatorTest.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/validation/ContentValidatorTest.scala
@@ -254,24 +254,4 @@ class ContentValidatorTest extends UnitSuite with TestEnvironment {
     res.errors.head.message should be("Meta image ID must be a number")
   }
 
-  test("validation should fail if license is chosen and no copyright holders are provided") {
-    val copyright = Copyright(Some(CC_BY_SA.toString), None, Seq(), Seq(), Seq(), None, None, None)
-    val Failure(res: ValidationException) = contentValidator.validateArticle(
-      TestData.sampleArticleWithByNcSa.copy(copyright = Option(copyright)
-      ))
-    res.errors.length should be(1)
-    res.errors.head.field should be("license.license")
-    res.errors.head.message should be("At least one copyright holder is required when license is CC-BY-SA-4.0")
-  }
-
-  test("an article with no copyright holders can pass validation if license is N/A") {
-    val article = TestData.sampleArticleWithByNcSa
-    contentValidator.validateArticle(article).isSuccess should be(true)
-  }
-
-  test("an article with one or more copyright holder can pass validation, regardless of license") {
-    val copyright = Copyright(Some("N/A"), None, Seq(), Seq(), Seq(), None, None, None)
-    val article = TestData.sampleArticleWithByNcSa.copy(copyright = Option(copyright))
-    contentValidator.validateArticle(article).isSuccess should be(true)
-  }
 }


### PR DESCRIPTION
Flytter funksjonaliteten over til article-api, slik at den kun utføres når vi publiserer en artikkel.