### PR TITLE
Return 404 when remote returns 404

### DIFF
--- a/oembed-proxy/src/main/scala/ScalatraBootstrap.scala
+++ b/oembed-proxy/src/main/scala/ScalatraBootstrap.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA oembed_proxy.
+ * Part of NDLA oembed-proxy.
  * Copyright (C) 2016 NDLA
  *
  * See LICENSE

--- a/oembed-proxy/src/main/scala/no/ndla/oembedproxy/ComponentRegistry.scala
+++ b/oembed-proxy/src/main/scala/no/ndla/oembedproxy/ComponentRegistry.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA oembed_proxy.
+ * Part of NDLA oembed-proxy.
  * Copyright (C) 2016 NDLA
  *
  * See LICENSE

--- a/oembed-proxy/src/main/scala/no/ndla/oembedproxy/JettyLauncher.scala
+++ b/oembed-proxy/src/main/scala/no/ndla/oembedproxy/JettyLauncher.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA oembed_proxy.
+ * Part of NDLA oembed-proxy.
  * Copyright (C) 2016 NDLA
  *
  * See LICENSE

--- a/oembed-proxy/src/main/scala/no/ndla/oembedproxy/OEmbedProxyProperties.scala
+++ b/oembed-proxy/src/main/scala/no/ndla/oembedproxy/OEmbedProxyProperties.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA oembed_proxy.
+ * Part of NDLA oembed-proxy.
  * Copyright (C) 2016 NDLA
  *
  * See LICENSE

--- a/oembed-proxy/src/main/scala/no/ndla/oembedproxy/OEmbedSwagger.scala
+++ b/oembed-proxy/src/main/scala/no/ndla/oembedproxy/OEmbedSwagger.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA oembed_proxy.
+ * Part of NDLA oembed-proxy.
  * Copyright (C) 2016 NDLA
  *
  * See LICENSE

--- a/oembed-proxy/src/main/scala/no/ndla/oembedproxy/controller/CorrelationIdSupport.scala
+++ b/oembed-proxy/src/main/scala/no/ndla/oembedproxy/controller/CorrelationIdSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA oembed_proxy.
+ * Part of NDLA oembed-proxy.
  * Copyright (C) 2016 NDLA
  *
  * See LICENSE

--- a/oembed-proxy/src/main/scala/no/ndla/oembedproxy/controller/HealthController.scala
+++ b/oembed-proxy/src/main/scala/no/ndla/oembedproxy/controller/HealthController.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA oembed_proxy.
+ * Part of NDLA oembed-proxy.
  * Copyright (C) 2016 NDLA
  *
  * See LICENSE

--- a/oembed-proxy/src/main/scala/no/ndla/oembedproxy/controller/OEmbedProxyController.scala
+++ b/oembed-proxy/src/main/scala/no/ndla/oembedproxy/controller/OEmbedProxyController.scala
@@ -15,7 +15,7 @@ import no.ndla.oembedproxy.model._
 import no.ndla.oembedproxy.service.OEmbedServiceComponent
 import org.json4s.ext.EnumNameSerializer
 import org.json4s.{DefaultFormats, Formats}
-import org.scalatra.{BadGateway, BadRequest, InternalServerError, NotImplemented, ScalatraServlet}
+import org.scalatra.{BadGateway, BadRequest, InternalServerError, NotFound, NotImplemented, ScalatraServlet}
 import org.scalatra.json.NativeJsonSupport
 import org.scalatra.swagger.{ResponseMessage, Swagger, SwaggerSupport, SwaggerSupportSyntax}
 import org.scalatra.util.NotNothing
@@ -35,12 +35,13 @@ trait OEmbedProxyController {
     protected implicit override val jsonFormats: Formats = DefaultFormats
 
     protected val applicationDescription =
-      "API for accessing Learningpaths from ndla.no."
+      "API wrapper for oembed.com adding support for ndla.no."
 
     registerModel[Error]()
 
     val response400: ResponseMessage = ResponseMessage(400, "Validation error", Some("Error"))
     val response401: ResponseMessage = ResponseMessage(401, "Unauthorized")
+    val response404: ResponseMessage = ResponseMessage(404, "Url not found")
     val response500: ResponseMessage = ResponseMessage(500, "Unknown error", Some("Error"))
 
     val response501: ResponseMessage =
@@ -81,6 +82,9 @@ trait OEmbedProxyController {
         BadRequest(Error(Error.PARAMETER_MISSING, pme.getMessage))
       case pnse: ProviderNotSupportedException =>
         NotImplemented(Error(Error.PROVIDER_NOT_SUPPORTED, pnse.getMessage))
+      case hre: HttpRequestException if hre.is404 =>
+        logger.info(s"Could not fetch remote: '${hre.getMessage}'")
+        NotFound(Error(Error.REMOTE_ERROR, hre.getMessage))
       case hre: HttpRequestException =>
         val msg = hre.httpResponse.map(response =>
           s": Received '${response.code}' '${response.statusLine}'. Body was '${response.body}'")

--- a/oembed-proxy/src/main/scala/no/ndla/oembedproxy/controller/OEmbedProxyController.scala
+++ b/oembed-proxy/src/main/scala/no/ndla/oembedproxy/controller/OEmbedProxyController.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA oembed_proxy.
+ * Part of NDLA oembed-proxy.
  * Copyright (C) 2016 NDLA
  *
  * See LICENSE

--- a/oembed-proxy/src/main/scala/no/ndla/oembedproxy/model/NDLAErrors.scala
+++ b/oembed-proxy/src/main/scala/no/ndla/oembedproxy/model/NDLAErrors.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA oembed_proxy.
+ * Part of NDLA oembed-proxy.
  * Copyright (C) 2016 NDLA
  *
  * See LICENSE

--- a/oembed-proxy/src/main/scala/no/ndla/oembedproxy/model/OEmbed.scala
+++ b/oembed-proxy/src/main/scala/no/ndla/oembedproxy/model/OEmbed.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA oembed_proxy.
+ * Part of NDLA oembed-proxy.
  * Copyright (C) 2016 NDLA
  *
  * See LICENSE

--- a/oembed-proxy/src/main/scala/no/ndla/oembedproxy/model/OEmbedEndpoint.scala
+++ b/oembed-proxy/src/main/scala/no/ndla/oembedproxy/model/OEmbedEndpoint.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA oembed_proxy.
+ * Part of NDLA oembed-proxy.
  * Copyright (C) 2016 NDLA
  *
  * See LICENSE

--- a/oembed-proxy/src/main/scala/no/ndla/oembedproxy/model/OEmbedProvider.scala
+++ b/oembed-proxy/src/main/scala/no/ndla/oembedproxy/model/OEmbedProvider.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA oembed_proxy.
+ * Part of NDLA oembed-proxy.
  * Copyright (C) 2016 NDLA
  *
  * See LICENSE

--- a/oembed-proxy/src/main/scala/no/ndla/oembedproxy/service/OEmbedServiceComponent.scala
+++ b/oembed-proxy/src/main/scala/no/ndla/oembedproxy/service/OEmbedServiceComponent.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA oembed_proxy.
+ * Part of NDLA oembed-proxy.
  * Copyright (C) 2016 NDLA
  *
  * See LICENSE

--- a/oembed-proxy/src/main/scala/no/ndla/oembedproxy/service/ProviderService.scala
+++ b/oembed-proxy/src/main/scala/no/ndla/oembedproxy/service/ProviderService.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA oembed_proxy.
+ * Part of NDLA oembed-proxy.
  * Copyright (C) 2016 NDLA
  *
  * See LICENSE

--- a/oembed-proxy/src/test/scala/no/ndla/oembedproxy/TestEnvironment.scala
+++ b/oembed-proxy/src/test/scala/no/ndla/oembedproxy/TestEnvironment.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA oembed_proxy.
+ * Part of NDLA oembed-proxy.
  * Copyright (C) 2016 NDLA
  *
  * See LICENSE

--- a/oembed-proxy/src/test/scala/no/ndla/oembedproxy/UnitSuite.scala
+++ b/oembed-proxy/src/test/scala/no/ndla/oembedproxy/UnitSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA oembed_proxy.
+ * Part of NDLA oembed-proxy.
  * Copyright (C) 2016 NDLA
  *
  * See LICENSE

--- a/oembed-proxy/src/test/scala/no/ndla/oembedproxy/controller/HealthControllerTest.scala
+++ b/oembed-proxy/src/test/scala/no/ndla/oembedproxy/controller/HealthControllerTest.scala
@@ -1,13 +1,14 @@
 /*
- * Part of NDLA oembed_proxy.
+ * Part of NDLA oembed-proxy.
  * Copyright (C) 2016 NDLA
  *
  * See LICENSE
  *
  */
 
-package no.ndla.oembedproxy
+package no.ndla.oembedproxy.controller
 
+import no.ndla.oembedproxy.{OEmbedProxyProperties, TestEnvironment, UnitSuite}
 import org.scalatra.test.scalatest.ScalatraFunSuite
 
 class HealthControllerTest extends UnitSuite with TestEnvironment with ScalatraFunSuite {

--- a/oembed-proxy/src/test/scala/no/ndla/oembedproxy/controller/OEmbedProxyControllerTest.scala
+++ b/oembed-proxy/src/test/scala/no/ndla/oembedproxy/controller/OEmbedProxyControllerTest.scala
@@ -1,0 +1,62 @@
+/*
+ * Part of NDLA oembed-proxy.
+ * Copyright (C) 2022 NDLA
+ *
+ * See LICENSE
+ *
+ */
+
+package no.ndla.oembedproxy.controller
+
+import no.ndla.network.model.HttpRequestException
+import no.ndla.oembedproxy.model.OEmbed
+import no.ndla.oembedproxy.{OEmbedProxyProperties, OEmbedSwagger, TestEnvironment, UnitSuite}
+import org.mockito.ArgumentMatchers.anyString
+import org.scalatra.test.scalatest.ScalatraFunSuite
+
+import java.net.http.HttpResponse
+import scala.util.{Failure, Success}
+
+class OEmbedProxyControllerTest extends UnitSuite with TestEnvironment with ScalatraFunSuite {
+  implicit val swagger = new OEmbedSwagger
+  lazy val controller = new OEmbedProxyController
+  addServlet(controller, OEmbedProxyProperties.OembedProxyControllerMountPoint)
+
+  val oembed = OEmbed(
+    `type` = "rich",
+    version = "1.0",
+    title = Some("Title"),
+    description = None,
+    authorName = None,
+    authorUrl = None,
+    providerName = None,
+    providerUrl = None,
+    cacheAge = None,
+    thumbnailUrl = None,
+    thumbnailWidth = None,
+    thumbnailHeight = None,
+    url = None,
+    width = Some(800L),
+    height = Some(600L),
+    html = Some(
+      "<div><iframe loading=\"lazy\" width=\"800\" height=\"600\" allowfullscreen=\"allowfullscreen\" src=\"https://h5p-test.ndla.no/resource/bae851c6-0e98-411d-bd92-ec2ab8fce730\"></iframe><script src=\"https://h5p.org/sites/all/modules/h5p/library/js/h5p-resizer.js\"></script></div>\"")
+  )
+
+  test("h5p url should return ok if found") {
+    when(oEmbedService.get(anyString, any[Option[String]], any[Option[String]])).thenReturn(Success(oembed))
+    get("/oembed-proxy/v1/oembed?url=https://h5p-test.ndla.no/resource/bae851c6-0e98-411d-bd92-ec2ab8fce730") {
+      status should equal(200)
+    }
+  }
+
+  test("h5p url should return 404 if not found") {
+    val exception = mock[HttpRequestException]
+    when(exception.is404).thenReturn(true)
+    when(exception.getMessage).thenReturn("")
+    when(oEmbedService.get(anyString, any[Option[String]], any[Option[String]])).thenReturn(Failure(exception))
+    get("/oembed-proxy/v1/oembed?url=https://h5p-test.ndla.no/resource/bae851c6-0e98-411d-bd92-ec2ab8fce730") {
+      status should equal(404)
+    }
+  }
+
+}

--- a/oembed-proxy/src/test/scala/no/ndla/oembedproxy/model/OEmbedEndpointTest.scala
+++ b/oembed-proxy/src/test/scala/no/ndla/oembedproxy/model/OEmbedEndpointTest.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA oembed_proxy.
+ * Part of NDLA oembed-proxy.
  * Copyright (C) 2016 NDLA
  *
  * See LICENSE

--- a/oembed-proxy/src/test/scala/no/ndla/oembedproxy/model/OEmbedProviderTest.scala
+++ b/oembed-proxy/src/test/scala/no/ndla/oembedproxy/model/OEmbedProviderTest.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA oembed_proxy.
+ * Part of NDLA oembed-proxy.
  * Copyright (C) 2016 NDLA
  *
  * See LICENSE

--- a/oembed-proxy/src/test/scala/no/ndla/oembedproxy/service/OEmbedServiceTest.scala
+++ b/oembed-proxy/src/test/scala/no/ndla/oembedproxy/service/OEmbedServiceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA oembed_proxy.
+ * Part of NDLA oembed-proxy.
  * Copyright (C) 2016 NDLA
  *
  * See LICENSE

--- a/oembed-proxy/src/test/scala/no/ndla/oembedproxy/service/ProviderServiceTest.scala
+++ b/oembed-proxy/src/test/scala/no/ndla/oembedproxy/service/ProviderServiceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA oembed_proxy.
+ * Part of NDLA oembed-proxy.
  * Copyright (C) 2016 NDLA
  *
  * See LICENSE


### PR DESCRIPTION
Fixes NDLANO/Issues#2989

Dersom remote provider returnerer 404 så videresendes dette til klienten. Ref 2.3.5. Errors i https://oembed.com/#section2