### PR TITLE
#2930: Support translations from taxonomy + hide non-visible contexts

### DIFF
--- a/search-api/src/main/scala/no/ndla/searchapi/model/taxonomy/Relevance.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/model/taxonomy/Relevance.scala
@@ -7,4 +7,4 @@
 
 package no.ndla.searchapi.model.taxonomy
 
-case class Relevance(id: String, name: String)
+case class Relevance(id: String, name: String, translations: List[TaxonomyTranslation])

--- a/search-api/src/main/scala/no/ndla/searchapi/model/taxonomy/Resource.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/model/taxonomy/Resource.scala
@@ -14,6 +14,10 @@ sealed trait TaxonomyElement {
   val path: Option[String]
   val metadata: Option[Metadata]
   val translations: List[TaxonomyTranslation]
+
+  def getNameFromTranslationOrDefault(language: String): String = {
+    translations.find(_.language == language).map(_.name).getOrElse(name)
+  }
 }
 
 case class TaxonomyTranslation(name: String, language: String)

--- a/search-api/src/main/scala/no/ndla/searchapi/model/taxonomy/Resource.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/model/taxonomy/Resource.scala
@@ -13,19 +13,34 @@ sealed trait TaxonomyElement {
   val contentUri: Option[String]
   val path: Option[String]
   val metadata: Option[Metadata]
+  val translations: List[TaxonomyTranslation]
 }
 
-case class TaxSubject(id: String,
-                      name: String,
-                      contentUri: Option[String],
-                      path: Option[String],
-                      metadata: Option[Metadata])
-    extends TaxonomyElement
-case class Resource(id: String,
-                    name: String,
-                    contentUri: Option[String],
-                    path: Option[String],
-                    metadata: Option[Metadata])
-    extends TaxonomyElement
-case class Topic(id: String, name: String, contentUri: Option[String], path: Option[String], metadata: Option[Metadata])
-    extends TaxonomyElement
+case class TaxonomyTranslation(name: String, language: String)
+
+case class TaxSubject(
+    id: String,
+    name: String,
+    contentUri: Option[String],
+    path: Option[String],
+    metadata: Option[Metadata],
+    translations: List[TaxonomyTranslation],
+) extends TaxonomyElement
+
+case class Resource(
+    id: String,
+    name: String,
+    contentUri: Option[String],
+    path: Option[String],
+    metadata: Option[Metadata],
+    translations: List[TaxonomyTranslation]
+) extends TaxonomyElement
+
+case class Topic(
+    id: String,
+    name: String,
+    contentUri: Option[String],
+    path: Option[String],
+    metadata: Option[Metadata],
+    translations: List[TaxonomyTranslation]
+) extends TaxonomyElement

--- a/search-api/src/main/scala/no/ndla/searchapi/model/taxonomy/ResourceType.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/model/taxonomy/ResourceType.scala
@@ -7,4 +7,9 @@
 
 package no.ndla.searchapi.model.taxonomy
 
-case class ResourceType(id: String, name: String, subtypes: Option[List[ResourceType]])
+case class ResourceType(
+    id: String,
+    name: String,
+    subtypes: Option[List[ResourceType]],
+    translations: List[TaxonomyTranslation]
+)

--- a/search-api/src/main/scala/no/ndla/searchapi/model/taxonomy/TaxonomyBundle.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/model/taxonomy/TaxonomyBundle.scala
@@ -37,6 +37,7 @@ case class TaxonomyBundle(
   val topicById: Map[String, Topic] = Map.from(topics.map(t => t.id -> t))
   val resourceById: Map[String, Resource] = Map.from(resources.map(r => r.id -> r))
   val subjectsById: Map[String, TaxSubject] = Map.from(subjects.map(s => s.id -> s))
+  val relevancesById: Map[String, Relevance] = Map.from(relevances.map(r => r.id -> r))
 
   val topicsByContentUri: Map[String, List[Topic]] = {
     val contentUriToTopics = topics.flatMap(t => t.contentUri.map(cu => cu -> t))

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/MultiDraftSearchService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/MultiDraftSearchService.scala
@@ -126,17 +126,19 @@ trait MultiDraftSearchService {
 
         e4sClient.execute(searchWithScroll) match {
           case Success(response) =>
-            Success(
+            getHits(response.result, settings.language).map(hits => {
               SearchResult(
                 totalCount = response.result.totalHits,
                 page = Some(settings.page),
                 pageSize = numResults,
                 language = searchLanguage,
-                results = getHits(response.result, settings.language),
+                results = hits,
                 suggestions = getSuggestions(response.result),
                 aggregations = getAggregationsFromResult(response.result),
                 scrollId = response.result.scrollId
-              ))
+              )
+            })
+
           case Failure(ex) => Failure(ex)
         }
       }

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/MultiSearchService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/MultiSearchService.scala
@@ -114,17 +114,18 @@ trait MultiSearchService {
 
         e4sClient.execute(searchWithScroll) match {
           case Success(response) =>
-            Success(
+            getHits(response.result, settings.language).map(hits => {
               SearchResult(
                 totalCount = response.result.totalHits,
                 page = Some(settings.page),
                 pageSize = numResults,
                 language = searchLanguage,
-                results = getHits(response.result, settings.language),
+                results = hits,
                 suggestions = getSuggestions(response.result),
                 aggregations = getAggregationsFromResult(response.result),
                 scrollId = response.result.scrollId
-              ))
+              )
+            })
           case Failure(ex) => Failure(ex)
         }
       }

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
@@ -917,11 +917,7 @@ trait SearchConverterService {
                 visibleSubjects.map(subject => {
                   val pathIds = (topicPath :+ subject.id).reverse
                   val relevanceId = relevanceIds.headOption.getOrElse("urn.relevance.core")
-                  val relevanceName = bundle.relevances
-                    .find(r => r.id == relevanceId)
-                    .map(_.name)
-                    .getOrElse("")
-                  val relevance = SearchableLanguageValues(Seq(LanguageValue(DefaultLanguage, relevanceName)))
+                  val relevance = getRelevanceNames(relevanceId, bundle)
 
                   getSearchableTaxonomyContext(topic.id,
                                                pathIds,

--- a/search-api/src/test/scala/no/ndla/searchapi/TestData.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/TestData.scala
@@ -894,41 +894,46 @@ object TestData {
   )
 
   val subjects = List(
-    TaxSubject("urn:subject:1", "Matte", None, Some("/subject:1"), visibleMetadata),
-    TaxSubject("urn:subject:2", "Historie", None, Some("/subject:2"), visibleMetadata),
-    TaxSubject("urn:subject:3", "Religion", None, Some("/subject:3"), invisibleMetadata)
+    TaxSubject("urn:subject:1", "Matte", None, Some("/subject:1"), visibleMetadata, List.empty),
+    TaxSubject("urn:subject:2", "Historie", None, Some("/subject:2"), visibleMetadata, List.empty),
+    TaxSubject("urn:subject:3", "Religion", None, Some("/subject:3"), invisibleMetadata, List.empty)
   )
 
   val relevances = List(
-    Relevance("urn:relevance:core", "Kjernestoff"),
-    Relevance("urn:relevance:supplementary", "Tilleggsstoff")
+    Relevance("urn:relevance:core", "Kjernestoff", List.empty),
+    Relevance("urn:relevance:supplementary", "Tilleggsstoff", List.empty)
   )
 
   val resourceTypes = List(
-    ResourceType("urn:resourcetype:learningpath", "Læringssti", None),
+    ResourceType("urn:resourcetype:learningpath", "Læringssti", None, List.empty),
     ResourceType(
       "urn:resourcetype:subjectMaterial",
       "Fagstoff",
       Some(
         List(
-          ResourceType("urn:resourcetype:academicArticle", "Fagartikkel", None),
-          ResourceType("urn:resourcetype:guidance", "Veiledning", None)
-        ))
+          ResourceType("urn:resourcetype:academicArticle", "Fagartikkel", None, List.empty),
+          ResourceType("urn:resourcetype:guidance", "Veiledning", None, List.empty)
+        )),
+      List.empty
     ),
     ResourceType(
       "urn:resourcetype:reviewResource",
       "Vurderingsressurs",
       Some(
         List(
-          ResourceType("urn:resourcetype:teacherEvaluation", "Lærervurdering", None),
-          ResourceType("urn:resourcetype:selfEvaluation", "Egenvurdering", None),
-          ResourceType("urn:resourcetype:peerEvaluation",
-                       "Medelevvurdering",
-                       Some(
-                         List(
-                           ResourceType("urn:resourcetype:nested", "SuperNested ResourceType", None)
-                         )))
-        ))
+          ResourceType("urn:resourcetype:teacherEvaluation", "Lærervurdering", None, List.empty),
+          ResourceType("urn:resourcetype:selfEvaluation", "Egenvurdering", None, List.empty),
+          ResourceType(
+            "urn:resourcetype:peerEvaluation",
+            "Medelevvurdering",
+            Some(
+              List(
+                ResourceType("urn:resourcetype:nested", "SuperNested ResourceType", None, List.empty)
+              )),
+            List.empty
+          )
+        )),
+      List.empty
     )
   )
 
@@ -938,120 +943,148 @@ object TestData {
       article1.title.head.title,
       Some(s"urn:article:${article1.id.get}"),
       Some("/subject:3/topic:5/resource:1"),
-      visibleMetadata
+      visibleMetadata,
+      List.empty
     ),
     Resource(
       "urn:resource:2",
       article2.title.head.title,
       Some(s"urn:article:${article2.id.get}"),
       Some("/subject:1/topic:1/resource:2"),
-      visibleMetadata
+      visibleMetadata,
+      List.empty
     ),
     Resource(
       "urn:resource:3",
       article3.title.head.title,
       Some(s"urn:article:${article3.id.get}"),
       Some("/subject:1/topic:3/resource:3"),
-      visibleMetadata
+      visibleMetadata,
+      List.empty
     ),
     Resource(
       "urn:resource:4",
       article4.title.head.title,
       Some(s"urn:article:${article4.id.get}"),
       Some("/subject:1/topic:1/topic:2/resource:4"),
-      visibleMetadata
+      visibleMetadata,
+      List.empty
     ),
     Resource(
       "urn:resource:5",
       article5.title.head.title,
       Some(s"urn:article:${article5.id.get}"),
       Some("/subject:2/topic:4/resource:5"),
-      visibleMetadata
+      visibleMetadata,
+      List.empty
     ),
     Resource(
       "urn:resource:6",
       article6.title.head.title,
       Some(s"urn:article:${article6.id.get}"),
       Some("/subject:2/topic:4/resource:6"),
-      visibleMetadata
+      visibleMetadata,
+      List.empty
     ),
     Resource(
       "urn:resource:7",
       article7.title.head.title,
       Some(s"urn:article:${article7.id.get}"),
       Some("/subject:2/topic:4/resource:7"),
-      visibleMetadata
+      visibleMetadata,
+      List.empty
     ),
     Resource(
       "urn:resource:8",
       learningPath1.title.head.title,
       Some(s"urn:learningpath:${learningPath1.id.get}"),
       Some("/subject:1/topic:1/resource:8"),
-      visibleMetadata
+      visibleMetadata,
+      List.empty
     ),
     Resource(
       "urn:resource:9",
       learningPath2.title.head.title,
       Some(s"urn:learningpath:${learningPath2.id.get}"),
       Some("/subject:1/topic:1/resource:9"),
-      visibleMetadata
+      visibleMetadata,
+      List.empty
     ),
     Resource(
       "urn:resource:10",
       learningPath3.title.head.title,
       Some(s"urn:learningpath:${learningPath3.id.get}"),
       Some("/subject:1/topic:3/resource:10"),
-      visibleMetadata
+      visibleMetadata,
+      List.empty
     ),
     Resource(
       "urn:resource:11",
       learningPath4.title.head.title,
       Some(s"urn:learningpath:${learningPath4.id.get}"),
       Some("/subject:1/topic:1/topic:2/resource:11"),
-      visibleMetadata
+      visibleMetadata,
+      List.empty
     ),
     Resource(
       "urn:resource:12",
       learningPath5.title.head.title,
       Some(s"urn:learningpath:${learningPath5.id.get}"),
       Some("/subject:2/topic:4/resource:12"),
-      visibleMetadata
+      visibleMetadata,
+      List.empty
     ),
     Resource(
       "urn:resource:13",
       article12.title.head.title,
       Some(s"urn:article:${article12.id.get}"),
       Some("/subject:2/topic:4/resource:13"),
-      visibleMetadata
+      visibleMetadata,
+      List.empty
     )
   )
 
   val topics = List(
-    Topic("urn:topic:1",
-          article8.title.head.title,
-          Some(s"urn:article:${article8.id.get}"),
-          Some("/subject:1/topic:1"),
-          visibleMetadata),
-    Topic("urn:topic:2",
-          article9.title.head.title,
-          Some(s"urn:article:${article9.id.get}"),
-          Some("/subject:1/topic:1/topic:2"),
-          visibleMetadata),
-    Topic("urn:topic:3",
-          article10.title.head.title,
-          Some(s"urn:article:${article10.id.get}"),
-          Some("/subject:1/topic:3"),
-          visibleMetadata),
-    Topic("urn:topic:4",
-          article11.title.head.title,
-          Some(s"urn:article:${article11.id.get}"),
-          Some("/subject:2/topic:4"),
-          visibleMetadata),
-    Topic("urn:topic:5",
-          draft15.title.head.title,
-          Some(s"urn:article:${draft15.id.get}"),
-          Some("/subject:3/topic:5"),
-          invisibleMetadata)
+    Topic(
+      "urn:topic:1",
+      article8.title.head.title,
+      Some(s"urn:article:${article8.id.get}"),
+      Some("/subject:1/topic:1"),
+      visibleMetadata,
+      List.empty
+    ),
+    Topic(
+      "urn:topic:2",
+      article9.title.head.title,
+      Some(s"urn:article:${article9.id.get}"),
+      Some("/subject:1/topic:1/topic:2"),
+      visibleMetadata,
+      List.empty
+    ),
+    Topic(
+      "urn:topic:3",
+      article10.title.head.title,
+      Some(s"urn:article:${article10.id.get}"),
+      Some("/subject:1/topic:3"),
+      visibleMetadata,
+      List.empty
+    ),
+    Topic(
+      "urn:topic:4",
+      article11.title.head.title,
+      Some(s"urn:article:${article11.id.get}"),
+      Some("/subject:2/topic:4"),
+      visibleMetadata,
+      List.empty
+    ),
+    Topic(
+      "urn:topic:5",
+      draft15.title.head.title,
+      Some(s"urn:article:${draft15.id.get}"),
+      Some("/subject:3/topic:5"),
+      invisibleMetadata,
+      List.empty
+    )
   )
 
   val subjectTopicConnections = List(

--- a/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceAtomicTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceAtomicTest.scala
@@ -11,6 +11,17 @@ import no.ndla.scalatestsuite.IntegrationSuite
 import no.ndla.search.Elastic4sClientFactory
 import no.ndla.searchapi.TestData.blockUntil
 import no.ndla.searchapi.model.domain.article._
+import no.ndla.searchapi.model.taxonomy.{
+  Metadata,
+  Resource,
+  ResourceResourceTypeConnection,
+  SubjectTopicConnection,
+  TaxSubject,
+  TaxonomyBundle,
+  Topic,
+  TopicResourceConnection,
+  TopicSubtopicConnection
+}
 import no.ndla.searchapi.{TestData, TestEnvironment}
 import org.scalatest.Outcome
 
@@ -108,4 +119,163 @@ class MultiSearchServiceAtomicTest extends IntegrationSuite(EnableElasticsearchC
 
   }
 
+  test("That taxonomy contexts with hidden elements are ignored") {
+    val article1 = TestData.article1.copy(
+      id = Some(1),
+      content = Seq(
+        ArticleContent(
+          """<section><div data-type="related-content"><embed data-article-id="3" data-resource="related-content"></div></section>""",
+          "nb"
+        )
+      )
+    )
+
+    val visibleMeta = Some(Metadata(List.empty, visible = true))
+    val hiddenMeta = Some(Metadata(List.empty, visible = false))
+
+    val resources = List(
+      // Visible resource with hidden parent topic
+      Resource(
+        "urn:resource:1",
+        "Res1",
+        Some("urn:article:1"),
+        Some("/subject:1/topic:1/topic:2/resource:1"),
+        visibleMeta,
+        List.empty
+      ),
+      // Visible resource with visible parent topic
+      Resource(
+        "urn:resource:2",
+        "Res2",
+        Some("urn:article:1"),
+        Some("/subject:1/topic:3/resource:2"),
+        visibleMeta,
+        List.empty
+      )
+    )
+
+    val topics = List(
+      // Hidden topic with visible subject
+      Topic(
+        "urn:topic:1",
+        "Top1",
+        Some("urn:article:2"),
+        Some("/subject:1/topic:1"),
+        hiddenMeta,
+        List.empty
+      ),
+      // Visible subtopic
+      Topic(
+        "urn:topic:2",
+        "Top1",
+        Some("urn:article:3"),
+        Some("/subject:1/topic:1/topic:2"),
+        visibleMeta,
+        List.empty
+      ),
+      // Visible topic
+      Topic(
+        "urn:topic:3",
+        "Top1",
+        Some("urn:article:4"),
+        Some("/subject:1/topic:3"),
+        visibleMeta,
+        List.empty
+      )
+    )
+
+    val subjects = List(
+      // Visible subject
+      TaxSubject(
+        "urn:subject:1",
+        "Sub1",
+        None,
+        Some("/subject:1"),
+        visibleMeta,
+        List.empty
+      )
+    )
+
+    val resourceResourceTypeConnections = List(
+      ResourceResourceTypeConnection("urn:resource:1",
+                                     "urn:resourcetype:subjectMaterial",
+                                     "urn:resourceresourcetype:1"),
+      ResourceResourceTypeConnection("urn:resource:2", "urn:resourcetype:subjectMaterial", "urn:resourceresourcetype:1")
+    )
+
+    val subjectTopicConnections = List(
+      SubjectTopicConnection(
+        "urn:subject:1",
+        "urn:topic:1",
+        "urn:subjecttopic:1",
+        primary = true,
+        1,
+        Some("urn:relevance:core")
+      ),
+      SubjectTopicConnection(
+        "urn:subject:1",
+        "urn:topic:3",
+        "urn:subjecttopic:2",
+        primary = true,
+        1,
+        Some("urn:relevance:core")
+      )
+    )
+
+    val topicSubtopicConnections = List(
+      TopicSubtopicConnection(
+        "urn:topic:1",
+        "urn:topic:2",
+        "urn:topicsubtopic:1",
+        primary = true,
+        1,
+        Some("urn:relevance:core")
+      )
+    )
+
+    val topicResourceConnections = List(
+      TopicResourceConnection(
+        "urn:topic:2",
+        "urn:resource:1",
+        "urn:topicresource:1",
+        primary = true,
+        1,
+        Some("urn:relevance:core")
+      ),
+      TopicResourceConnection(
+        "urn:topic:3",
+        "urn:resource:2",
+        "urn:topicresource:2",
+        primary = true,
+        1,
+        Some("urn:relevance:core")
+      )
+    )
+
+    val taxonomyBundle = TaxonomyBundle(
+      resources = resources,
+      topics = topics,
+      subjects = subjects,
+      relevances = TestData.relevances,
+      resourceResourceTypeConnections = resourceResourceTypeConnections,
+      resourceTypes = TestData.resourceTypes,
+      subjectTopicConnections = subjectTopicConnections,
+      topicResourceConnections = topicResourceConnections,
+      topicSubtopicConnections = topicSubtopicConnections,
+    )
+
+    articleIndexService.indexDocument(article1, taxonomyBundle, Some(TestData.grepBundle)).get
+
+    blockUntil(() => {
+      articleIndexService.countDocuments == 1
+    })
+
+    val result = multiSearchService
+      .matchingQuery(
+        TestData.searchSettings.copy(
+          ))
+      .get
+
+    result.results.head.contexts.map(_.id) should be(Seq("urn:resource:2"))
+  }
 }

--- a/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceAtomicTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceAtomicTest.scala
@@ -150,7 +150,7 @@ class MultiSearchServiceAtomicTest extends IntegrationSuite(EnableElasticsearchC
         // Visible subtopic
         Topic(
           "urn:topic:2",
-          "Top1",
+          "Top2",
           Some("urn:article:3"),
           Some("/subject:1/topic:1/topic:2"),
           visibleMeta,

--- a/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceAtomicTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceAtomicTest.scala
@@ -112,139 +112,143 @@ class MultiSearchServiceAtomicTest extends IntegrationSuite(EnableElasticsearchC
   test("That resource taxonomy contexts with hidden elements are ignored") {
     val article1 = TestData.article1.copy(id = Some(1))
 
-    val visibleMeta = Some(Metadata(List.empty, visible = true))
-    val hiddenMeta = Some(Metadata(List.empty, visible = false))
+    val taxonomyBundle = {
+      val visibleMeta = Some(Metadata(List.empty, visible = true))
+      val hiddenMeta = Some(Metadata(List.empty, visible = false))
 
-    val resources = List(
-      // Visible resource with hidden parent topic
-      Resource(
-        "urn:resource:1",
-        "Res1",
-        Some("urn:article:1"),
-        Some("/subject:1/topic:1/topic:2/resource:1"),
-        visibleMeta,
-        List.empty
-      ),
-      // Visible resource with visible parent topic
-      Resource(
-        "urn:resource:2",
-        "Res2",
-        Some("urn:article:1"),
-        Some("/subject:1/topic:3/resource:2"),
-        visibleMeta,
-        List.empty
+      val resources = List(
+        // Visible resource with hidden parent topic
+        Resource(
+          "urn:resource:1",
+          "Res1",
+          Some("urn:article:1"),
+          Some("/subject:1/topic:1/topic:2/resource:1"),
+          visibleMeta,
+          List.empty
+        ),
+        // Visible resource with visible parent topic
+        Resource(
+          "urn:resource:2",
+          "Res2",
+          Some("urn:article:1"),
+          Some("/subject:1/topic:3/resource:2"),
+          visibleMeta,
+          List.empty
+        )
       )
-    )
 
-    val topics = List(
-      // Hidden topic with visible subject
-      Topic(
-        "urn:topic:1",
-        "Top1",
-        Some("urn:article:2"),
-        Some("/subject:1/topic:1"),
-        hiddenMeta,
-        List.empty
-      ),
-      // Visible subtopic
-      Topic(
-        "urn:topic:2",
-        "Top1",
-        Some("urn:article:3"),
-        Some("/subject:1/topic:1/topic:2"),
-        visibleMeta,
-        List.empty
-      ),
-      // Visible topic
-      Topic(
-        "urn:topic:3",
-        "Top1",
-        Some("urn:article:4"),
-        Some("/subject:1/topic:3"),
-        visibleMeta,
-        List.empty
+      val topics = List(
+        // Hidden topic with visible subject
+        Topic(
+          "urn:topic:1",
+          "Top1",
+          Some("urn:article:2"),
+          Some("/subject:1/topic:1"),
+          hiddenMeta,
+          List.empty
+        ),
+        // Visible subtopic
+        Topic(
+          "urn:topic:2",
+          "Top1",
+          Some("urn:article:3"),
+          Some("/subject:1/topic:1/topic:2"),
+          visibleMeta,
+          List.empty
+        ),
+        // Visible topic
+        Topic(
+          "urn:topic:3",
+          "Top1",
+          Some("urn:article:4"),
+          Some("/subject:1/topic:3"),
+          visibleMeta,
+          List.empty
+        )
       )
-    )
 
-    val subjects = List(
-      // Visible subject
-      TaxSubject(
-        "urn:subject:1",
-        "Sub1",
-        None,
-        Some("/subject:1"),
-        visibleMeta,
-        List.empty
+      val subjects = List(
+        // Visible subject
+        TaxSubject(
+          "urn:subject:1",
+          "Sub1",
+          None,
+          Some("/subject:1"),
+          visibleMeta,
+          List.empty
+        )
       )
-    )
 
-    val resourceResourceTypeConnections = List(
-      ResourceResourceTypeConnection("urn:resource:1",
-                                     "urn:resourcetype:subjectMaterial",
-                                     "urn:resourceresourcetype:1"),
-      ResourceResourceTypeConnection("urn:resource:2", "urn:resourcetype:subjectMaterial", "urn:resourceresourcetype:1")
-    )
-
-    val subjectTopicConnections = List(
-      SubjectTopicConnection(
-        "urn:subject:1",
-        "urn:topic:1",
-        "urn:subjecttopic:1",
-        primary = true,
-        1,
-        Some("urn:relevance:core")
-      ),
-      SubjectTopicConnection(
-        "urn:subject:1",
-        "urn:topic:3",
-        "urn:subjecttopic:2",
-        primary = true,
-        1,
-        Some("urn:relevance:core")
+      val resourceResourceTypeConnections = List(
+        ResourceResourceTypeConnection("urn:resource:1",
+                                       "urn:resourcetype:subjectMaterial",
+                                       "urn:resourceresourcetype:1"),
+        ResourceResourceTypeConnection("urn:resource:2",
+                                       "urn:resourcetype:subjectMaterial",
+                                       "urn:resourceresourcetype:1")
       )
-    )
 
-    val topicSubtopicConnections = List(
-      TopicSubtopicConnection(
-        "urn:topic:1",
-        "urn:topic:2",
-        "urn:topicsubtopic:1",
-        primary = true,
-        1,
-        Some("urn:relevance:core")
+      val subjectTopicConnections = List(
+        SubjectTopicConnection(
+          "urn:subject:1",
+          "urn:topic:1",
+          "urn:subjecttopic:1",
+          primary = true,
+          1,
+          Some("urn:relevance:core")
+        ),
+        SubjectTopicConnection(
+          "urn:subject:1",
+          "urn:topic:3",
+          "urn:subjecttopic:2",
+          primary = true,
+          1,
+          Some("urn:relevance:core")
+        )
       )
-    )
 
-    val topicResourceConnections = List(
-      TopicResourceConnection(
-        "urn:topic:2",
-        "urn:resource:1",
-        "urn:topicresource:1",
-        primary = true,
-        1,
-        Some("urn:relevance:core")
-      ),
-      TopicResourceConnection(
-        "urn:topic:3",
-        "urn:resource:2",
-        "urn:topicresource:2",
-        primary = true,
-        1,
-        Some("urn:relevance:core")
+      val topicSubtopicConnections = List(
+        TopicSubtopicConnection(
+          "urn:topic:1",
+          "urn:topic:2",
+          "urn:topicsubtopic:1",
+          primary = true,
+          1,
+          Some("urn:relevance:core")
+        )
       )
-    )
 
-    val taxonomyBundle = TaxonomyBundle(
-      resources = resources,
-      topics = topics,
-      subjects = subjects,
-      relevances = TestData.relevances,
-      resourceResourceTypeConnections = resourceResourceTypeConnections,
-      resourceTypes = TestData.resourceTypes,
-      subjectTopicConnections = subjectTopicConnections,
-      topicResourceConnections = topicResourceConnections,
-      topicSubtopicConnections = topicSubtopicConnections,
-    )
+      val topicResourceConnections = List(
+        TopicResourceConnection(
+          "urn:topic:2",
+          "urn:resource:1",
+          "urn:topicresource:1",
+          primary = true,
+          1,
+          Some("urn:relevance:core")
+        ),
+        TopicResourceConnection(
+          "urn:topic:3",
+          "urn:resource:2",
+          "urn:topicresource:2",
+          primary = true,
+          1,
+          Some("urn:relevance:core")
+        )
+      )
+
+      TaxonomyBundle(
+        resources = resources,
+        topics = topics,
+        subjects = subjects,
+        relevances = TestData.relevances,
+        resourceResourceTypeConnections = resourceResourceTypeConnections,
+        resourceTypes = TestData.resourceTypes,
+        subjectTopicConnections = subjectTopicConnections,
+        topicResourceConnections = topicResourceConnections,
+        topicSubtopicConnections = topicSubtopicConnections,
+      )
+    }
 
     articleIndexService.indexDocument(article1, taxonomyBundle, Some(TestData.grepBundle)).get
 
@@ -264,92 +268,94 @@ class MultiSearchServiceAtomicTest extends IntegrationSuite(EnableElasticsearchC
   test("That topic taxonomy contexts with hidden elements are ignored") {
     val article1 = TestData.article1.copy(id = Some(1))
 
-    val visibleMeta = Some(Metadata(List.empty, visible = true))
-    val hiddenMeta = Some(Metadata(List.empty, visible = false))
+    val taxonomyBundle = {
+      val visibleMeta = Some(Metadata(List.empty, visible = true))
+      val hiddenMeta = Some(Metadata(List.empty, visible = false))
 
-    val topics = List(
-      // Hidden topic with visible subject
-      Topic(
-        "urn:topic:1",
-        "Top1",
-        Some("urn:article:1"),
-        Some("/subject:1/topic:1"),
-        hiddenMeta,
-        List.empty
-      ),
-      // Visible subtopic
-      Topic(
-        "urn:topic:2",
-        "Top1",
-        Some("urn:article:1"),
-        Some("/subject:1/topic:1/topic:2"),
-        visibleMeta,
-        List.empty
-      ),
-      // Visible topic
-      Topic(
-        "urn:topic:3",
-        "Top1",
-        Some("urn:article:1"),
-        Some("/subject:1/topic:3"),
-        visibleMeta,
-        List.empty
+      val topics = List(
+        // Hidden topic with visible subject
+        Topic(
+          "urn:topic:1",
+          "Top1",
+          Some("urn:article:1"),
+          Some("/subject:1/topic:1"),
+          hiddenMeta,
+          List.empty
+        ),
+        // Visible subtopic
+        Topic(
+          "urn:topic:2",
+          "Top1",
+          Some("urn:article:1"),
+          Some("/subject:1/topic:1/topic:2"),
+          visibleMeta,
+          List.empty
+        ),
+        // Visible topic
+        Topic(
+          "urn:topic:3",
+          "Top1",
+          Some("urn:article:1"),
+          Some("/subject:1/topic:3"),
+          visibleMeta,
+          List.empty
+        )
       )
-    )
 
-    val subjects = List(
-      // Visible subject
-      TaxSubject(
-        "urn:subject:1",
-        "Sub1",
-        None,
-        Some("/subject:1"),
-        visibleMeta,
-        List.empty
+      val subjects = List(
+        // Visible subject
+        TaxSubject(
+          "urn:subject:1",
+          "Sub1",
+          None,
+          Some("/subject:1"),
+          visibleMeta,
+          List.empty
+        )
       )
-    )
 
-    val subjectTopicConnections = List(
-      SubjectTopicConnection(
-        "urn:subject:1",
-        "urn:topic:1",
-        "urn:subjecttopic:1",
-        primary = true,
-        1,
-        Some("urn:relevance:core")
-      ),
-      SubjectTopicConnection(
-        "urn:subject:1",
-        "urn:topic:3",
-        "urn:subjecttopic:2",
-        primary = true,
-        1,
-        Some("urn:relevance:core")
+      val subjectTopicConnections = List(
+        SubjectTopicConnection(
+          "urn:subject:1",
+          "urn:topic:1",
+          "urn:subjecttopic:1",
+          primary = true,
+          1,
+          Some("urn:relevance:core")
+        ),
+        SubjectTopicConnection(
+          "urn:subject:1",
+          "urn:topic:3",
+          "urn:subjecttopic:2",
+          primary = true,
+          1,
+          Some("urn:relevance:core")
+        )
       )
-    )
 
-    val topicSubtopicConnections = List(
-      TopicSubtopicConnection(
-        "urn:topic:1",
-        "urn:topic:2",
-        "urn:topicsubtopic:1",
-        primary = true,
-        1,
-        Some("urn:relevance:core")
+      val topicSubtopicConnections = List(
+        TopicSubtopicConnection(
+          "urn:topic:1",
+          "urn:topic:2",
+          "urn:topicsubtopic:1",
+          primary = true,
+          1,
+          Some("urn:relevance:core")
+        )
       )
-    )
 
-    val taxonomyBundle = TaxonomyBundle(
-      resources = List.empty,
-      topics = topics,
-      subjects = subjects,
-      relevances = TestData.relevances,
-      resourceResourceTypeConnections = List.empty,
-      resourceTypes = TestData.resourceTypes,
-      subjectTopicConnections = subjectTopicConnections,
-      topicResourceConnections = List.empty,
-      topicSubtopicConnections = topicSubtopicConnections,
-    )
+      TaxonomyBundle(
+        resources = List.empty,
+        topics = topics,
+        subjects = subjects,
+        relevances = TestData.relevances,
+        resourceResourceTypeConnections = List.empty,
+        resourceTypes = TestData.resourceTypes,
+        subjectTopicConnections = subjectTopicConnections,
+        topicResourceConnections = List.empty,
+        topicSubtopicConnections = topicSubtopicConnections,
+      )
+    }
 
     articleIndexService.indexDocument(article1, taxonomyBundle, Some(TestData.grepBundle)).get
 

--- a/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceAtomicTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceAtomicTest.scala
@@ -159,7 +159,7 @@ class MultiSearchServiceAtomicTest extends IntegrationSuite(EnableElasticsearchC
         // Visible topic
         Topic(
           "urn:topic:3",
-          "Top1",
+          "Top3",
           Some("urn:article:4"),
           Some("/subject:1/topic:3"),
           visibleMeta,

--- a/search-api/src/test/scala/no/ndla/searchapi/service/search/SearchConverterServiceTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/service/search/SearchConverterServiceTest.scala
@@ -58,14 +58,24 @@ class SearchConverterServiceTest extends UnitSuite with TestEnvironment {
   val invisibleMetadata: Option[Metadata] = Some(Metadata(Seq.empty, visible = false))
 
   val resources = List(
-    Resource("urn:resource:1",
-             "Resource1",
-             Some("urn:article:1"),
-             Some("/subject:1/topic:10/resource:1"),
-             visibleMetadata))
+    Resource(
+      "urn:resource:1",
+      "Resource1",
+      Some("urn:article:1"),
+      Some("/subject:1/topic:10/resource:1"),
+      visibleMetadata,
+      List.empty
+    ))
 
   val topics = List(
-    Topic("urn:topic:10", "Topic1", Some("urn:article:10"), Some("/subject:1/topic:10"), visibleMetadata))
+    Topic(
+      "urn:topic:10",
+      "Topic1",
+      Some("urn:article:10"),
+      Some("/subject:1/topic:10"),
+      visibleMetadata,
+      List.empty
+    ))
 
   val topicResourceConnections = List(
     TopicResourceConnection("urn:topic:10",
@@ -74,7 +84,15 @@ class SearchConverterServiceTest extends UnitSuite with TestEnvironment {
                             primary = true,
                             1,
                             Some("urn:relevance:core")))
-  val subject1: TaxSubject = TaxSubject("urn:subject:1", "Subject1", None, Some("/subject:1"), visibleMetadata)
+
+  val subject1: TaxSubject = TaxSubject(
+    "urn:subject:1",
+    "Subject1",
+    None,
+    Some("/subject:1"),
+    visibleMetadata,
+    List.empty
+  )
   val subjects = List(subject1)
 
   val subjectTopicConnections = List(

--- a/search-api/src/test/scala/no/ndla/searchapi/service/search/SearchConverterServiceTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/service/search/SearchConverterServiceTest.scala
@@ -7,7 +7,7 @@
 
 package no.ndla.searchapi.service.search
 
-import no.ndla.search.model.{SearchableLanguageList, SearchableLanguageValues}
+import no.ndla.search.model.{LanguageValue, SearchableLanguageList, SearchableLanguageValues}
 import no.ndla.searchapi.caching.Memoize
 import no.ndla.searchapi.model.domain.article.{Article, ArticleContent}
 import no.ndla.searchapi.model.domain.{Tag, Title}
@@ -446,6 +446,21 @@ class SearchConverterServiceTest extends UnitSuite with TestEnvironment {
     val draft = searchConverterService.asSearchableDraft(TestData.draft5, emptyBundle, Some(TestData.emptyGrepBundle))
     draft.get.users.length should be(2)
     draft.get.users should be(List("ndalId54321", "ndalId12345"))
+  }
+
+  test("That `getSearchableLanguageValues` has translations win if one exists for default language") {
+    val translations = List(
+      TaxonomyTranslation("Nynorsk", "nn"),
+      TaxonomyTranslation("Default language name", "nb")
+    )
+
+    searchConverterService.getSearchableLanguageValues("The default name", translations) should be(
+      SearchableLanguageValues(
+        Seq(
+          LanguageValue("nn", "Nynorsk"),
+          LanguageValue("nb", "Default language name")
+        ))
+    )
   }
 
   private def verifyTitles(searchableArticle: SearchableArticle): Unit = {


### PR DESCRIPTION
Fixes NDLANO/Issues#2930
Depends on https://github.com/NDLANO/taxonomy-api/pull/130

Kan testes ved å sjekke at brødsmulestier blir oversatt og at taxonomy-contexts som har en `visible: false` topic ikke vil bli indeksert for vanlige artikler (Fortsatt med for drafts).

