### PR TITLE
Set `track_total_hits` to true for all elasticsearch searches

### DIFF
--- a/article-api/src/main/scala/no/ndla/articleapi/service/search/ArticleSearchService.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/service/search/ArticleSearchService.scala
@@ -122,6 +122,7 @@ trait ArticleSearchService {
         val searchToExecute = search(searchIndex)
           .size(numResults)
           .from(startAt)
+          .trackTotalHits(true)
           .query(filteredSearch)
           .highlighting(highlight("*"))
           .sortBy(getSortDefinition(settings.sort, searchLanguage))

--- a/audio-api/src/main/scala/no/ndla/audioapi/service/search/AudioSearchService.scala
+++ b/audio-api/src/main/scala/no/ndla/audioapi/service/search/AudioSearchService.scala
@@ -102,6 +102,7 @@ trait AudioSearchService {
           search(searchIndex)
             .size(numResults)
             .from(startAt)
+            .trackTotalHits(true)
             .query(filteredSearch)
             .highlighting(highlight("*"))
             .sortBy(getSortDefinition(settings.sort, searchLanguage))

--- a/audio-api/src/main/scala/no/ndla/audioapi/service/search/SeriesSearchService.scala
+++ b/audio-api/src/main/scala/no/ndla/audioapi/service/search/SeriesSearchService.scala
@@ -88,6 +88,7 @@ trait SeriesSearchService {
           search(searchIndex)
             .size(numResults)
             .from(startAt)
+            .trackTotalHits(true)
             .query(filteredSearch)
             .highlighting(highlight("*"))
             .sortBy(getSortDefinition(settings.sort, searchLanguage))

--- a/audio-api/src/main/scala/no/ndla/audioapi/service/search/TagSearchService.scala
+++ b/audio-api/src/main/scala/no/ndla/audioapi/service/search/TagSearchService.scala
@@ -87,6 +87,7 @@ trait TagSearchService {
         val searchToExecute = search(searchIndex)
           .size(numResults)
           .from(startAt)
+          .trackTotalHits(true)
           .query(filteredSearch)
           .sortBy(fieldSort("_score").sortOrder(SortOrder.Desc))
 

--- a/concept-api/src/main/scala/no/ndla/conceptapi/service/search/DraftConceptSearchService.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/service/search/DraftConceptSearchService.scala
@@ -160,6 +160,7 @@ trait DraftConceptSearchService {
           search(searchIndex)
             .size(numResults)
             .from(startAt)
+            .trackTotalHits(true)
             .query(filteredSearch)
             .highlighting(highlight("*"))
             .sortBy(getSortDefinition(settings.sort, searchLanguage))

--- a/concept-api/src/main/scala/no/ndla/conceptapi/service/search/PublishedConceptSearchService.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/service/search/PublishedConceptSearchService.scala
@@ -163,6 +163,7 @@ trait PublishedConceptSearchService {
           search(searchIndex)
             .size(numResults)
             .from(startAt)
+            .trackTotalHits(true)
             .query(filteredSearch)
             .highlighting(highlight("*"))
             .sortBy(getSortDefinition(settings.sort, searchLanguage))

--- a/draft-api/src/main/scala/no/ndla/draftapi/service/search/AgreementSearchService.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/service/search/AgreementSearchService.scala
@@ -78,6 +78,7 @@ trait AgreementSearchService {
         val searchToExecute = search(searchIndex)
           .size(numResults)
           .from(startAt)
+          .trackTotalHits(true)
           .query(filteredSearch)
           .sortBy(getSortDefinition(settings.sort))
 

--- a/draft-api/src/main/scala/no/ndla/draftapi/service/search/ArticleSearchService.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/service/search/ArticleSearchService.scala
@@ -108,6 +108,7 @@ trait ArticleSearchService {
         val searchToExecute = search(searchIndex)
           .size(numResults)
           .from(startAt)
+          .trackTotalHits(true)
           .query(filteredSearch)
           .highlighting(highlight("*"))
           .sortBy(getSortDefinition(settings.sort, searchLanguage))

--- a/draft-api/src/main/scala/no/ndla/draftapi/service/search/GrepCodesSearchService.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/service/search/GrepCodesSearchService.scala
@@ -75,6 +75,7 @@ trait GrepCodesSearchService {
         val searchToExecute = search(searchIndex)
           .size(numResults)
           .from(startAt)
+          .trackTotalHits(true)
           .query(queryBuilder)
           .sortBy(fieldSort("_score").sortOrder(SortOrder.Desc))
 

--- a/draft-api/src/main/scala/no/ndla/draftapi/service/search/TagSearchService.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/service/search/TagSearchService.scala
@@ -90,6 +90,7 @@ trait TagSearchService {
         val searchToExecute = search(searchIndex)
           .size(numResults)
           .from(startAt)
+          .trackTotalHits(true)
           .query(filteredSearch)
           .sortBy(fieldSort("_score").sortOrder(SortOrder.Desc))
 

--- a/image-api/src/main/scala/no/ndla/imageapi/service/search/ImageSearchService.scala
+++ b/image-api/src/main/scala/no/ndla/imageapi/service/search/ImageSearchService.scala
@@ -136,6 +136,7 @@ trait ImageSearchService {
         val searchToExecute =
           search(searchIndex)
             .size(numResults)
+            .trackTotalHits(true)
             .from(startAt)
             .highlighting(highlight("*"))
             .query(filteredSearch)

--- a/image-api/src/main/scala/no/ndla/imageapi/service/search/TagSearchService.scala
+++ b/image-api/src/main/scala/no/ndla/imageapi/service/search/TagSearchService.scala
@@ -105,6 +105,7 @@ trait TagSearchService {
         val searchToExecute = search(searchIndex)
           .size(numResults)
           .from(startAt)
+          .trackTotalHits(true)
           .query(filteredSearch)
           .sortBy(getSortDefinition(sort, searchLanguage))
 

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/search/SearchService.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/search/SearchService.scala
@@ -195,6 +195,7 @@ trait SearchService extends LazyLogging {
         val searchToExecute = search(LearningpathApiProperties.SearchIndex)
           .size(numResults)
           .from(startAt)
+          .trackTotalHits(true)
           .query(filteredSearch)
           .highlighting(highlight("*"))
           .sortBy(getSortDefinition(settings.sort, searchLanguage))

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/MultiDraftSearchService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/MultiDraftSearchService.scala
@@ -111,6 +111,7 @@ trait MultiDraftSearchService {
         val searchToExecute = search(searchIndex)
           .query(filteredSearch)
           .suggestions(suggestions(settings.query, searchLanguage, settings.fallback))
+          .trackTotalHits(true)
           .from(startAt)
           .size(numResults)
           .highlighting(highlight("*"))

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/MultiSearchService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/MultiSearchService.scala
@@ -100,6 +100,7 @@ trait MultiSearchService {
           .query(filteredSearch)
           .suggestions(suggestions(settings.query, searchLanguage, settings.fallback))
           .from(startAt)
+          .trackTotalHits(true)
           .size(numResults)
           .highlighting(highlight("*"))
           .aggs(aggregations)


### PR DESCRIPTION
Setter `track_total_hits` parameteret ved søk slik at vi får tilbake nøyaktige antall resultater.
Kan testes ved å sjekke at `totalHits` i søkene gir riktige resultater (og ikke bare er cappet på 10.000)