### PR TITLE
Partial publish domain to api

### DIFF
--- a/article-api/src/main/scala/no/ndla/articleapi/model/api/Availability.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/model/api/Availability.scala
@@ -1,0 +1,24 @@
+/*
+ * Part of NDLA article-api.
+ * Copyright (C) 2022 NDLA
+ *
+ * See LICENSE
+ */
+
+package no.ndla.articleapi.model.api
+
+object Availability extends Enumeration {
+  val everyone, teacher = Value
+
+  def valueOf(s: String): Option[Availability.Value] = {
+    Availability.values.find(_.toString == s)
+  }
+
+  def valueOf(s: Option[String]): Option[Availability.Value] = {
+    s match {
+      case None    => None
+      case Some(s) => valueOf(s)
+    }
+  }
+
+}

--- a/article-api/src/main/scala/no/ndla/articleapi/model/api/PartialPublishArticle.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/model/api/PartialPublishArticle.scala
@@ -8,18 +8,16 @@
 
 package no.ndla.articleapi.model.api
 
-import no.ndla.articleapi.model.domain
 import org.scalatra.swagger.annotations.{ApiModel, ApiModelProperty}
-
 import scala.annotation.meta.field
 
 // format: off
 @ApiModel(description = "Partial data about article to publish independently")
 case class PartialPublishArticle(
-    @(ApiModelProperty @field)(description = "Value that dictates who gets to see the article. Possible values are: everyone/teacher") availability: Option[domain.Availability.Value],
+    @(ApiModelProperty @field)(description = "Value that dictates who gets to see the article. Possible values are: everyone/teacher") availability: Option[Availability.Value],
     @(ApiModelProperty @field)(description = "A list of codes from GREP API connected to the article") grepCodes: Option[Seq[String]],
     @(ApiModelProperty @field)(description = "The name of the license") license: Option[String],
-    @(ApiModelProperty @field)(description = "A list of meta description objects") metaDescription: Option[Seq[domain.ArticleMetaDescription]],
+    @(ApiModelProperty @field)(description = "A list of meta description objects") metaDescription: Option[Seq[ArticleMetaDescription]],
     @(ApiModelProperty @field)(description = "A list of content related to the article") relatedContent: Option[Seq[RelatedContent]],
-    @(ApiModelProperty @field)(description = "A list of tag objects") tags: Option[Seq[domain.ArticleTag]],
+    @(ApiModelProperty @field)(description = "A list of tag objects") tags: Option[Seq[ArticleTag]],
 )

--- a/article-api/src/main/scala/no/ndla/articleapi/model/api/TSTypes.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/model/api/TSTypes.scala
@@ -1,12 +1,10 @@
 package no.ndla.articleapi.model.api
 
 import com.scalatsi._
-import no.ndla.articleapi.model.domain
 
 object TSTypes {
   // Type-aliases referencing generics doesn't not work without this in scala-tsi. See: https://github.com/scala-tsi/scala-tsi/issues/184
   implicit val relatedContent: TSIType[RelatedContentLink] = TSType.fromCaseClass[RelatedContentLink]
   // Scala2 enumerations doesn't work as expected in scala-tsi. See: https://github.com/scala-tsi/scala-tsi/issues/182
-  implicit val availability: TSType[domain.Availability.Value] =
-    TSType.sameAs[domain.Availability.Value, domain.Availability.type]
+  implicit val availability: TSType[Availability.Value] = TSType.sameAs[Availability.Value, Availability.type]
 }

--- a/article-api/src/test/scala/no/ndla/articleapi/controller/ArticleControllerV2Test.scala
+++ b/article-api/src/test/scala/no/ndla/articleapi/controller/ArticleControllerV2Test.scala
@@ -8,8 +8,7 @@
 
 package no.ndla.articleapi.controller
 
-import no.ndla.articleapi.model.api._
-import no.ndla.articleapi.model.domain._
+import no.ndla.articleapi.model.{api, domain}
 import no.ndla.articleapi.model.search.SearchResult
 import no.ndla.articleapi.{ArticleSwagger, TestData, TestEnvironment, UnitSuite}
 import org.json4s.ext.EnumNameSerializer
@@ -39,7 +38,7 @@ class ArticleControllerV2Test extends UnitSuite with TestEnvironment with Scalat
   val authHeaderWithWrongRole =
     "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6Ik9FSTFNVVU0T0RrNU56TTVNekkyTXpaRE9EazFOMFl3UXpkRE1EUXlPRFZDUXpRM1FUSTBNQSJ9.eyJodHRwczovL25kbGEubm8vY2xpZW50X2lkIjoieHh4eXl5IiwiaXNzIjoiaHR0cHM6Ly9uZGxhLmV1LmF1dGgwLmNvbS8iLCJzdWIiOiJ4eHh5eXlAY2xpZW50cyIsImF1ZCI6Im5kbGFfc3lzdGVtIiwiaWF0IjoxNTEwMzA1NzczLCJleHAiOjE1MTAzOTIxNzMsInNjb3BlIjoic29tZTpvdGhlciIsImd0eSI6ImNsaWVudC1jcmVkZW50aWFscyJ9.Hbmh9KX19nx7yT3rEcP9pyzRO0uQJBRucfqH9QEZtLyXjYj_fAyOhsoicOVEbHSES7rtdiJK43-gijSpWWmGWOkE6Ym7nHGhB_nLdvp_25PDgdKHo-KawZdAyIcJFr5_t3CJ2Z2IPVbrXwUd99vuXEBaV0dMwkT0kDtkwHuS-8E"
 
-  implicit val formats: Formats        = DefaultFormats + new EnumNameSerializer(Availability)
+  implicit val formats: Formats        = DefaultFormats + new EnumNameSerializer(api.Availability)
   implicit val swagger: ArticleSwagger = new ArticleSwagger
 
   lazy val controller = new ArticleControllerV2
@@ -51,7 +50,7 @@ class ArticleControllerV2Test extends UnitSuite with TestEnvironment with Scalat
   val articleId       = 1
 
   test("/<article_id> should return 200 if the cover was found withIdV2") {
-    when(readService.withIdV2(articleId, lang)).thenReturn(Success(Cachable.yes(TestData.sampleArticleV2)))
+    when(readService.withIdV2(articleId, lang)).thenReturn(Success(domain.Cachable.yes(TestData.sampleArticleV2)))
 
     get(s"/test/$articleId?language=$lang") {
       status should equal(200)
@@ -59,7 +58,7 @@ class ArticleControllerV2Test extends UnitSuite with TestEnvironment with Scalat
   }
 
   test("/<article_id> should return 404 if the article was not found withIdV2") {
-    when(readService.withIdV2(articleId, lang)).thenReturn(Failure(NotFoundException("Not found")))
+    when(readService.withIdV2(articleId, lang)).thenReturn(Failure(api.NotFoundException("Not found")))
 
     get(s"/test/$articleId?language=$lang") {
       status should equal(404)
@@ -75,16 +74,16 @@ class ArticleControllerV2Test extends UnitSuite with TestEnvironment with Scalat
   test("That scrollId is in header, and not in body") {
     val scrollId =
       "DnF1ZXJ5VGhlbkZldGNoCgAAAAAAAAC1Fi1jZU9hYW9EVDlpY1JvNEVhVlJMSFEAAAAAAAAAthYtY2VPYWFvRFQ5aWNSbzRFYVZSTEhRAAAAAAAAALcWLWNlT2Fhb0RUOWljUm80RWFWUkxIUQAAAAAAAAC4Fi1jZU9hYW9EVDlpY1JvNEVhVlJMSFEAAAAAAAAAuRYtY2VPYWFvRFQ5aWNSbzRFYVZSTEhRAAAAAAAAALsWLWNlT2Fhb0RUOWljUm80RWFWUkxIUQAAAAAAAAC9Fi1jZU9hYW9EVDlpY1JvNEVhVlJMSFEAAAAAAAAAuhYtY2VPYWFvRFQ5aWNSbzRFYVZSTEhRAAAAAAAAAL4WLWNlT2Fhb0RUOWljUm80RWFWUkxIUQAAAAAAAAC8Fi1jZU9hYW9EVDlpY1JvNEVhVlJMSFE="
-    val searchResponse = SearchResult[ArticleSummaryV2](
+    val searchResponse = SearchResult[api.ArticleSummaryV2](
       0,
       Some(1),
       10,
       "nb",
-      Seq.empty[ArticleSummaryV2],
+      Seq.empty[api.ArticleSummaryV2],
       Some(scrollId)
     )
     when(readService.search(any, any, any, any, any, any, any, any, any, any, any, any))
-      .thenReturn(Success(Cachable.yes(searchResponse)))
+      .thenReturn(Success(domain.Cachable.yes(searchResponse)))
 
     get(s"/test/") {
       status should be(200)
@@ -97,12 +96,12 @@ class ArticleControllerV2Test extends UnitSuite with TestEnvironment with Scalat
     reset(articleSearchService, readService)
     val scrollId =
       "DnF1ZXJ5VGhlbkZldGNoCgAAAAAAAAC1Fi1jZU9hYW9EVDlpY1JvNEVhVlJMSFEAAAAAAAAAthYtY2VPYWFvRFQ5aWNSbzRFYVZSTEhRAAAAAAAAALcWLWNlT2Fhb0RUOWljUm80RWFWUkxIUQAAAAAAAAC4Fi1jZU9hYW9EVDlpY1JvNEVhVlJMSFEAAAAAAAAAuRYtY2VPYWFvRFQ5aWNSbzRFYVZSTEhRAAAAAAAAALsWLWNlT2Fhb0RUOWljUm80RWFWUkxIUQAAAAAAAAC9Fi1jZU9hYW9EVDlpY1JvNEVhVlJMSFEAAAAAAAAAuhYtY2VPYWFvRFQ5aWNSbzRFYVZSTEhRAAAAAAAAAL4WLWNlT2Fhb0RUOWljUm80RWFWUkxIUQAAAAAAAAC8Fi1jZU9hYW9EVDlpY1JvNEVhVlJMSFE="
-    val searchResponse = SearchResult[ArticleSummaryV2](
+    val searchResponse = SearchResult[api.ArticleSummaryV2](
       0,
       Some(1),
       10,
       "nb",
-      Seq.empty[ArticleSummaryV2],
+      Seq.empty[api.ArticleSummaryV2],
       Some(scrollId)
     )
 
@@ -112,7 +111,7 @@ class ArticleControllerV2Test extends UnitSuite with TestEnvironment with Scalat
       status should be(200)
     }
 
-    verify(articleSearchService, times(0)).matchingQuery(any[SearchSettings])
+    verify(articleSearchService, times(0)).matchingQuery(any[domain.SearchSettings])
     verify(readService, times(0)).search(any, any, any, any, any, any, any, any, any, any, any, any)
     verify(articleSearchService, times(1)).scroll(eqTo(scrollId), any[String], any[Boolean])
   }
@@ -121,12 +120,12 @@ class ArticleControllerV2Test extends UnitSuite with TestEnvironment with Scalat
     reset(articleSearchService)
     val scrollId =
       "DnF1ZXJ5VGhlbkZldGNoCgAAAAAAAAC1Fi1jZU9hYW9EVDlpY1JvNEVhVlJMSFEAAAAAAAAAthYtY2VPYWFvRFQ5aWNSbzRFYVZSTEhRAAAAAAAAALcWLWNlT2Fhb0RUOWljUm80RWFWUkxIUQAAAAAAAAC4Fi1jZU9hYW9EVDlpY1JvNEVhVlJMSFEAAAAAAAAAuRYtY2VPYWFvRFQ5aWNSbzRFYVZSTEhRAAAAAAAAALsWLWNlT2Fhb0RUOWljUm80RWFWUkxIUQAAAAAAAAC9Fi1jZU9hYW9EVDlpY1JvNEVhVlJMSFEAAAAAAAAAuhYtY2VPYWFvRFQ5aWNSbzRFYVZSTEhRAAAAAAAAAL4WLWNlT2Fhb0RUOWljUm80RWFWUkxIUQAAAAAAAAC8Fi1jZU9hYW9EVDlpY1JvNEVhVlJMSFE="
-    val searchResponse = SearchResult[ArticleSummaryV2](
+    val searchResponse = SearchResult[api.ArticleSummaryV2](
       0,
       Some(1),
       10,
       "nb",
-      Seq.empty[ArticleSummaryV2],
+      Seq.empty[api.ArticleSummaryV2],
       Some(scrollId)
     )
 
@@ -136,7 +135,7 @@ class ArticleControllerV2Test extends UnitSuite with TestEnvironment with Scalat
       status should be(200)
     }
 
-    verify(articleSearchService, times(0)).matchingQuery(any[SearchSettings])
+    verify(articleSearchService, times(0)).matchingQuery(any[domain.SearchSettings])
     verify(articleSearchService, times(1)).scroll(eqTo(scrollId), any[String], any[Boolean])
   }
 
@@ -164,7 +163,7 @@ class ArticleControllerV2Test extends UnitSuite with TestEnvironment with Scalat
   test("That initial search-context doesn't scroll") {
     reset(articleSearchService, readService)
 
-    val result = SearchResult[ArticleSummaryV2](
+    val result = SearchResult[api.ArticleSummaryV2](
       totalCount = 0,
       page = None,
       pageSize = 10,
@@ -173,7 +172,7 @@ class ArticleControllerV2Test extends UnitSuite with TestEnvironment with Scalat
       scrollId = Some("heiheihei")
     )
     when(readService.search(any, any, any, any, any, any, any, any, any, any, any, any))
-      .thenReturn(Success(Cachable.yes(result)))
+      .thenReturn(Success(domain.Cachable.yes(result)))
 
     get("/test/?search-context=initial") {
       status should be(200)

--- a/article-api/src/test/scala/no/ndla/articleapi/service/ConverterServiceTest.scala
+++ b/article-api/src/test/scala/no/ndla/articleapi/service/ConverterServiceTest.scala
@@ -231,10 +231,10 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
     )
     val partialArticle =
       api.PartialPublishArticle(
-        availability = Some(Availability.teacher),
+        availability = Some(api.Availability.teacher),
         grepCodes = Some(Seq("New", "grep", "codes")),
         license = Some("newLicense"),
-        metaDescription = Some(Seq(ArticleMetaDescription("nyDesc", "nb"))),
+        metaDescription = Some(Seq(api.ArticleMetaDescription("nyDesc", "nb"))),
         relatedContent = Some(
           Seq(
             Left(api.RelatedContentLink("New Title", "New Url")),
@@ -242,7 +242,7 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
             Right(42L)
           )
         ),
-        tags = Some(Seq(ArticleTag(Seq("nye", "Tags"), "nb")))
+        tags = Some(Seq(api.ArticleTag(Seq("nye", "Tags"), "nb")))
       )
     val updatedArticle = TestData.sampleDomainArticle.copy(
       availability = Availability.teacher,
@@ -273,22 +273,22 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
     )
     val partialArticle =
       api.PartialPublishArticle(
-        availability = Some(Availability.teacher),
+        availability = Some(api.Availability.teacher),
         grepCodes = Some(Seq("New", "grep", "codes")),
         license = Some("newLicense"),
         metaDescription = Some(
           Seq(
-            ArticleMetaDescription("nyDesc", "nb"),
-            ArticleMetaDescription("newDesc", "en"),
-            ArticleMetaDescription("neuDesc", "de")
+            api.ArticleMetaDescription("nyDesc", "nb"),
+            api.ArticleMetaDescription("newDesc", "en"),
+            api.ArticleMetaDescription("neuDesc", "de")
           )
         ),
         relatedContent = Some(Seq(Right(42L), Right(420L), Right(4200L))),
         tags = Some(
           Seq(
-            ArticleTag(Seq("nye", "Tags"), "nb"),
-            ArticleTag(Seq("new", "Tagss"), "en"),
-            ArticleTag(Seq("Guten", "Tag"), "de")
+            api.ArticleTag(Seq("nye", "Tags"), "nb"),
+            api.ArticleTag(Seq("new", "Tagss"), "en"),
+            api.ArticleTag(Seq("Guten", "Tag"), "de")
           )
         )
       )

--- a/article-api/typescript/index.ts
+++ b/article-api/typescript/index.ts
@@ -21,11 +21,6 @@ export interface IArticleIntroduction {
 }
 
 export interface IArticleMetaDescription {
-  content: string
-  language: string
-}
-
-export interface IArticleMetaDescription {
   metaDescription: string
   language: string
 }

--- a/draft-api/src/main/scala/no/ndla/draftapi/integration/ArticleApiClient.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/integration/ArticleApiClient.scala
@@ -24,12 +24,12 @@ import scala.util.{Failure, Try}
 
 case class ArticleApiId(id: Long)
 case class PartialPublishArticle(
-    availability: Option[domain.Availability.Value],
+    availability: Option[api.Availability.Value],
     grepCodes: Option[Seq[String]],
     license: Option[String],
-    metaDescription: Option[Seq[domain.ArticleMetaDescription]],
-    relatedContent: Option[Seq[domain.RelatedContent]],
-    tags: Option[Seq[domain.ArticleTag]]
+    metaDescription: Option[Seq[api.ArticleMetaDescription]],
+    relatedContent: Option[Seq[api.RelatedContent]],
+    tags: Option[Seq[api.ArticleTag]]
 )
 
 trait ArticleApiClient {

--- a/draft-api/src/main/scala/no/ndla/draftapi/model/api/Availability.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/model/api/Availability.scala
@@ -1,0 +1,24 @@
+/*
+ * Part of NDLA draft-api.
+ * Copyright (C) 2022 NDLA
+ *
+ * See LICENSE
+ */
+
+package no.ndla.draftapi.model.api
+
+object Availability extends Enumeration {
+  val everyone, teacher = Value
+
+  def valueOf(s: String): Option[Availability.Value] = {
+    Availability.values.find(_.toString == s)
+  }
+
+  def valueOf(s: Option[String]): Option[Availability.Value] = {
+    s match {
+      case None    => None
+      case Some(s) => valueOf(s)
+    }
+  }
+
+}

--- a/draft-api/src/main/scala/no/ndla/draftapi/model/api/TSTypes.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/model/api/TSTypes.scala
@@ -9,7 +9,6 @@ package no.ndla.draftapi.model.api
 
 import com.scalatsi.TypescriptType.TSNull
 import com.scalatsi._
-import no.ndla.draftapi.model.domain
 
 /** The `scala-tsi` plugin is not always able to derive the types that are used in `Seq` or other generic types.
   * Therefore we need to explicitly load the case classes here. This is only necessary if the `sbt generateTypescript`
@@ -21,8 +20,7 @@ object TSTypes {
   implicit val nullTsType: TSType[Null] = TSType(TSNull)
 
   // Scala2 enumerations doesn't work as expected in scala-tsi. See: https://github.com/scala-tsi/scala-tsi/issues/182
-  implicit val availability: TSType[domain.Availability.Value] =
-    TSType.sameAs[domain.Availability.Value, domain.Availability.type]
+  implicit val availability: TSType[Availability.Value] = TSType.sameAs[Availability.Value, Availability.type]
 
   implicit val author              = TSType.fromCaseClass[Author]
   implicit val requiredLibrary     = TSType.fromCaseClass[RequiredLibrary]

--- a/draft-api/src/main/scala/no/ndla/draftapi/service/ConverterService.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/service/ConverterService.scala
@@ -693,6 +693,14 @@ trait ConverterService {
       }
     }
 
+    def toApiAvailability(availability: domain.Availability.Value): api.Availability.Value = {
+      availability match {
+        case domain.Availability.everyone => api.Availability.everyone
+        case domain.Availability.teacher  => api.Availability.teacher
+        case _                            => api.Availability.everyone
+      }
+    }
+
     private[service] def _stateTransitionsToApi(user: UserInfo, article: Option[Article]): Map[String, Seq[String]] = {
       StateTransitionRules.StateTransitions.groupBy(_.from).map { case (from, to) =>
         from.toString -> to

--- a/draft-api/src/test/scala/no/ndla/draftapi/service/WriteServiceTest.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/service/WriteServiceTest.scala
@@ -974,39 +974,39 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
     )
 
     val expectedPartialPublishFields = integration.PartialPublishArticle(
-      availability = Some(Availability.everyone),
+      availability = Some(api.Availability.everyone),
       grepCodes = Some(Seq("A", "B")),
       license = Some("CC-BY-4.0"),
-      metaDescription = Some(Seq(ArticleMetaDescription("oldDesc", "nb"))),
-      relatedContent = Some(Seq(Left(RelatedContentLink("title1", "url2")), Right(12L))),
-      tags = Some(Seq(ArticleTag(Seq("old", "tag"), "nb")))
+      metaDescription = Some(Seq(api.ArticleMetaDescription("oldDesc", "nb"))),
+      relatedContent = Some(Seq(Left(api.RelatedContentLink("title1", "url2")), Right(12L))),
+      tags = Some(Seq(api.ArticleTag(Seq("old", "tag"), "nb")))
     )
     val expectedPartialPublishFieldsLangEN = integration.PartialPublishArticle(
-      availability = Some(Availability.everyone),
+      availability = Some(api.Availability.everyone),
       grepCodes = Some(Seq("A", "B")),
       license = Some("CC-BY-4.0"),
       metaDescription = Some(Seq.empty),
-      relatedContent = Some(Seq(Left(RelatedContentLink("title1", "url2")), Right(12L))),
+      relatedContent = Some(Seq(Left(api.RelatedContentLink("title1", "url2")), Right(12L))),
       tags = Some(Seq.empty)
     )
     val expectedPartialPublishFieldsLangALL = integration.PartialPublishArticle(
-      availability = Some(Availability.everyone),
+      availability = Some(api.Availability.everyone),
       grepCodes = Some(Seq("A", "B")),
       license = Some("CC-BY-4.0"),
       metaDescription = Some(
         Seq(
-          ArticleMetaDescription("oldDesc", "nb"),
-          ArticleMetaDescription("oldDescc", "es"),
-          ArticleMetaDescription("oldDesccc", "ru"),
-          ArticleMetaDescription("oldDescccc", "nn")
+          api.ArticleMetaDescription("oldDesc", "nb"),
+          api.ArticleMetaDescription("oldDescc", "es"),
+          api.ArticleMetaDescription("oldDesccc", "ru"),
+          api.ArticleMetaDescription("oldDescccc", "nn")
         )
       ),
-      relatedContent = Some(Seq(Left(RelatedContentLink("title1", "url2")), Right(12L))),
+      relatedContent = Some(Seq(Left(api.RelatedContentLink("title1", "url2")), Right(12L))),
       tags = Some(
         Seq(
-          ArticleTag(Seq("old", "tag"), "nb"),
-          ArticleTag(Seq("guten", "tag"), "de"),
-          ArticleTag(Seq("oldd", "tagg"), "es")
+          api.ArticleTag(Seq("old", "tag"), "nb"),
+          api.ArticleTag(Seq("guten", "tag"), "de"),
+          api.ArticleTag(Seq("oldd", "tagg"), "es")
         )
       )
     )

--- a/project/articleapi.scala
+++ b/project/articleapi.scala
@@ -36,8 +36,7 @@ object articleapi extends Module {
   lazy val tsSettings: Seq[Def.Setting[_]] = typescriptSettings(
     imports = Seq(
       "no.ndla.articleapi.model.api._",
-      "no.ndla.articleapi.model.api.TSTypes._",
-      "no.ndla.articleapi.model.domain.Availability"
+      "no.ndla.articleapi.model.api.TSTypes._"
     ),
     exports = Seq(
       "ArticleV2",

--- a/project/draftapi.scala
+++ b/project/draftapi.scala
@@ -39,8 +39,7 @@ object draftapi extends Module {
   lazy val tsSettings: Seq[Def.Setting[_]] = typescriptSettings(
     imports = Seq(
       "no.ndla.draftapi.model.api._",
-      "no.ndla.draftapi.model.api.TSTypes._",
-      "no.ndla.draftapi.model.domain.Availability"
+      "no.ndla.draftapi.model.api.TSTypes._"
     ),
     exports = Seq(
       "Agreement",


### PR DESCRIPTION
Changed PartialPublish fields to use api instead of domain types, bnoth in article-api and draft-api. Generate new typescript types based on the changes.