### PR TITLE
Make text in concept embed optional

### DIFF
--- a/validation/src/main/resources/embed-tag-rules.json
+++ b/validation/src/main/resources/embed-tag-rules.json
@@ -99,8 +99,10 @@
       "required": [
         "data-resource",
         "data-content-id",
-        "data-link-text",
-        "data-type"
+        "data-type",
+      ],
+      "optional": [
+        ["data-link-text"]
       ]
     },
     "concept-list": {


### PR DESCRIPTION
Relatert til https://github.com/NDLANO/Issues/issues/3016

Tekst er ikke relevant for blokkvisning av forklaring og burde derfor være optional