### PR TITLE
Adds `articleIds` and `created` fields to concept-summary and indexes

### DIFF
--- a/concept-api/src/main/scala/no/ndla/conceptapi/model/api/ConceptSummary.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/model/api/ConceptSummary.scala
@@ -23,9 +23,12 @@ case class ConceptSummary(
     @(ApiModelProperty @field)(description = "Taxonomy subject ids the concept is connected to") subjectIds: Option[Set[String]],
     @(ApiModelProperty @field)(description = "All available languages of the current concept") supportedLanguages: Seq[String],
     @(ApiModelProperty @field)(description = "The time when the article was last updated") lastUpdated: Date,
+    @(ApiModelProperty @field)(description = "When the concept was created") created: Date,
     @(ApiModelProperty @field)(description = "Status information of the concept") status: Status,
     @(ApiModelProperty @field)(description = "List of people that edited the concept") updatedBy: Seq[String],
     @(ApiModelProperty @field)(description = "Describes the license of the concept") license: Option[String],
     @(ApiModelProperty @field)(description = "Describes the copyright of the concept") copyright: Option[Copyright],
-    @(ApiModelProperty @field)(description = "A visual element for the concept") visualElement: Option[VisualElement])
+    @(ApiModelProperty @field)(description = "A visual element for the concept") visualElement: Option[VisualElement],
+    @(ApiModelProperty @field)(description = "Article ids to which the concept is connected to") articleIds: Seq[Long]
+)
 // format: on

--- a/concept-api/src/main/scala/no/ndla/conceptapi/model/search/SearchableConcept.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/model/search/SearchableConcept.scala
@@ -25,5 +25,7 @@ case class SearchableConcept(
     license: Option[String],
     copyright: Option[SearchableCopyright],
     embedResourcesAndIds: List[EmbedValues],
-    visualElement: SearchableLanguageValues
+    visualElement: SearchableLanguageValues,
+    articleIds: Seq[Long],
+    created: DateTime
 )

--- a/concept-api/src/main/scala/no/ndla/conceptapi/service/search/DraftConceptIndexService.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/service/search/DraftConceptIndexService.scala
@@ -56,6 +56,8 @@ trait DraftConceptIndexService {
           keywordField("language")
         ),
         dateField("lastUpdated"),
+        dateField("created"),
+        longField("articleIds"),
         keywordField("status.current"),
         keywordField("status.other"),
         keywordField("updatedBy"),

--- a/concept-api/src/main/scala/no/ndla/conceptapi/service/search/PublishedConceptIndexService.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/service/search/PublishedConceptIndexService.scala
@@ -54,6 +54,8 @@ trait PublishedConceptIndexService {
           keywordField("language")
         ),
         dateField("lastUpdated"),
+        dateField("created"),
+        longField("articleIds"),
         keywordField("license"),
         keywordField("origin"),
         nestedField("copyright").fields(

--- a/concept-api/src/main/scala/no/ndla/conceptapi/service/search/SearchConverterService.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/service/search/SearchConverterService.scala
@@ -157,7 +157,9 @@ trait SearchConverterService {
         embedResourcesAndIds = embedResourcesAndIds,
         visualElement = SearchableLanguageValues(
           c.visualElement.map(element => LanguageValue(element.language, element.visualElement))
-        )
+        ),
+        articleIds = c.articleIds,
+        created = new DateTime(c.created)
       )
     }
 
@@ -175,7 +177,7 @@ trait SearchConverterService {
       val title = findByLanguageOrBestEffort(titles, language)
         .map(converterService.toApiConceptTitle)
         .getOrElse(api.ConceptTitle("", UnknownLanguage.toString()))
-      val concept = findByLanguageOrBestEffort(contents, language)
+      val content = findByLanguageOrBestEffort(contents, language)
         .map(converterService.toApiConceptContent)
         .getOrElse(api.ConceptContent("", UnknownLanguage.toString()))
       val metaImage = findByLanguageOrBestEffort(searchableConcept.metaImage, language)
@@ -202,7 +204,7 @@ trait SearchConverterService {
       api.ConceptSummary(
         id = searchableConcept.id,
         title = title,
-        content = concept,
+        content = content,
         metaImage = metaImage,
         tags = tag,
         subjectIds = subjectIds,
@@ -212,7 +214,9 @@ trait SearchConverterService {
         updatedBy = searchableConcept.updatedBy,
         license = searchableConcept.license,
         copyright = copyright,
-        visualElement = visualElement
+        visualElement = visualElement,
+        articleIds = searchableConcept.articleIds,
+        created = searchableConcept.created.toDate
       )
     }
 


### PR DESCRIPTION
Krever en reindeksering (men den kan kjøres før deploy med `ndla index build test --version <versjonmednyefelterher>`). 
Kan testes ved å sjekke at `created` og `articleIds` dukker opp i søkeresultater :^)