### PR TITLE
Adds search functionality for revisions

### DIFF
--- a/search-api/src/main/scala/no/ndla/searchapi/controller/NdlaController.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/controller/NdlaController.scala
@@ -26,7 +26,7 @@ import no.ndla.searchapi.model.domain.draft.ArticleStatus
 import no.ndla.searchapi.model.domain.learningpath._
 import org.apache.logging.log4j.ThreadContext
 import org.json4s.Formats
-import org.json4s.ext.EnumNameSerializer
+import org.json4s.ext.{EnumNameSerializer, JavaTimeSerializers}
 import org.json4s.native.Serialization.read
 import org.scalatra._
 import org.scalatra.json.NativeJsonSupport
@@ -44,7 +44,8 @@ abstract class NdlaController extends ScalatraServlet with NativeJsonSupport wit
       new EnumNameSerializer(StepStatus) +
       new EnumNameSerializer(EmbedType) +
       new EnumNameSerializer(LearningResourceType) ++
-      org.json4s.ext.JodaTimeSerializers.all
+      org.json4s.ext.JodaTimeSerializers.all ++
+      JavaTimeSerializers.all
 
   private val currentTimeBeforeRequest = new ThreadLocal[Long]
 
@@ -72,7 +73,7 @@ abstract class NdlaController extends ScalatraServlet with NativeJsonSupport wit
       Option(request.getQueryString).map(s => s"?$s").getOrElse(""),
       Option(currentTimeBeforeRequest.get())
         .map(ct => System.currentTimeMillis() - ct)
-        .map(s => s" in ${s}ms")
+        .map(s => s"${s}ms")
         .getOrElse(""),
       response.getStatus
     )

--- a/search-api/src/main/scala/no/ndla/searchapi/controller/NdlaController.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/controller/NdlaController.scala
@@ -31,6 +31,8 @@ import org.json4s.native.Serialization.read
 import org.scalatra._
 import org.scalatra.json.NativeJsonSupport
 
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 import javax.servlet.http.HttpServletRequest
 import scala.util.{Failure, Success, Try}
 
@@ -110,13 +112,31 @@ abstract class NdlaController extends ScalatraServlet with NativeJsonSupport wit
   def paramOrNone(paramName: String)(implicit request: HttpServletRequest): Option[String] =
     params.get(paramName).map(_.trim).filterNot(_.isEmpty())
 
+  private val dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'")
+  def paramAsDateOrNone(paramName: String)(implicit request: HttpServletRequest): Option[LocalDateTime] = {
+    paramOrNone(paramName).map(dateString => {
+      Try(LocalDateTime.parse(dateString, dateFormatter)) match {
+        case Success(date) => date
+        case Failure(_) =>
+          throw new ValidationException(
+            errors = Seq(
+              ValidationMessage(
+                paramName,
+                s"Invalid date passed. Expected format is \"${LocalDateTime.now().format(dateFormatter)}\""
+              )
+            )
+          )
+      }
+    })
+  }
+
   def paramOrDefault(paramName: String, default: String)(implicit request: HttpServletRequest): String =
     paramOrNone(paramName).getOrElse(default)
 
   def intOrNone(paramName: String)(implicit request: HttpServletRequest): Option[Int] =
     paramOrNone(paramName).flatMap(i => Try(i.toInt).toOption)
 
-  def intOrDefault(paramName: String, default: Int): Int =
+  def intOrDefault(paramName: String, default: Int)(implicit request: HttpServletRequest): Int =
     intOrNone(paramName).getOrElse(default)
 
   def paramAsListOfString(paramName: String)(implicit request: HttpServletRequest): List[String] = {

--- a/search-api/src/main/scala/no/ndla/searchapi/controller/SearchController.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/controller/SearchController.scala
@@ -32,6 +32,7 @@ import no.ndla.searchapi.service.search.{
   SearchService
 }
 import no.ndla.searchapi.service.{ApiSearchService, SearchClients}
+import org.json4s.ext.JavaTimeSerializers
 import org.json4s.{DefaultFormats, Formats}
 import org.scalatra.Ok
 import org.scalatra.swagger.{ResponseMessage, Swagger, SwaggerSupport}
@@ -58,7 +59,7 @@ trait SearchController {
   val searchController: SearchController
 
   class SearchController(implicit val swagger: Swagger) extends NdlaController with SwaggerSupport {
-    protected implicit override val jsonFormats: Formats = DefaultFormats
+    protected implicit override val jsonFormats: Formats = DefaultFormats ++ JavaTimeSerializers.all
 
     protected val applicationDescription = "API for searching across NDLA APIs"
 

--- a/search-api/src/main/scala/no/ndla/searchapi/integration/SearchApiClient.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/integration/SearchApiClient.scala
@@ -18,7 +18,7 @@ import no.ndla.searchapi.model.domain.draft.ArticleStatus
 import no.ndla.searchapi.model.domain.learningpath._
 import no.ndla.searchapi.model.domain.{ApiSearchResults, DomainDumpResults, SearchParams}
 import org.json4s.Formats
-import org.json4s.ext.EnumNameSerializer
+import org.json4s.ext.{EnumNameSerializer, JavaTimeSerializers}
 import scalaj.http.Http
 
 import scala.concurrent.Await
@@ -95,7 +95,8 @@ trait SearchApiClient {
           new EnumNameSerializer(EmbedType) +
           new EnumNameSerializer(LearningResourceType) +
           new EnumNameSerializer(Availability) ++
-          org.json4s.ext.JodaTimeSerializers.all
+          org.json4s.ext.JodaTimeSerializers.all ++
+          JavaTimeSerializers.all
       ndlaClient.fetchWithForwardedAuth[T](Http((baseUrl / path).toString).timeout(timeout, timeout).params(params))
     }
 

--- a/search-api/src/main/scala/no/ndla/searchapi/model/api/MultiSearchSummary.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/model/api/MultiSearchSummary.scala
@@ -36,5 +36,6 @@ case class MultiSearchSummary(
     @(ApiModelProperty @field)(description = "The taxonomy paths for the resource") paths: List[String],
     @(ApiModelProperty @field)(description = "The time and date of last update") lastUpdated: Date,
     @(ApiModelProperty @field)(description = "Describes the license of the resource") license: Option[String],
+    @(ApiModelProperty @field)(description = "A list of revisions planned for the article") revisions: Seq[RevisionMeta]
 )
 // format: on

--- a/search-api/src/main/scala/no/ndla/searchapi/model/api/RevisionMeta.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/model/api/RevisionMeta.scala
@@ -1,0 +1,20 @@
+/*
+ * Part of NDLA draft-api.
+ * Copyright (C) 2022 NDLA
+ *
+ * See LICENSE
+ */
+
+package no.ndla.searchapi.model.api
+
+import org.scalatra.swagger.annotations.{ApiModel, ApiModelProperty}
+
+import java.time.LocalDateTime
+
+// format: off
+@ApiModel(description = "Information about the editorial notes")
+case class RevisionMeta(
+    @ApiModelProperty(description = "A date on which the article would need to be revised") revisionDate: LocalDateTime,
+    @ApiModelProperty(description = "Notes to keep track of what needs to happen before revision") note: String,
+    @ApiModelProperty(description = "Status of a revision, either 'revised' or 'needs-revision'", allowableValues = "revised,needs-revision") status: String
+)

--- a/search-api/src/main/scala/no/ndla/searchapi/model/domain/Sort.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/model/domain/Sort.scala
@@ -18,16 +18,18 @@ object Sort extends Enum[Sort] {
 
   val all: Seq[String] = values.map(_.entryName)
 
-  case object ByRelevanceDesc   extends Sort("-relevance")
-  case object ByRelevanceAsc    extends Sort("relevance")
-  case object ByTitleDesc       extends Sort("-title")
-  case object ByTitleAsc        extends Sort("title")
-  case object ByLastUpdatedDesc extends Sort("-lastUpdated")
-  case object ByLastUpdatedAsc  extends Sort("lastUpdated")
-  case object ByIdDesc          extends Sort("-id")
-  case object ByIdAsc           extends Sort("id")
-  case object ByDurationDesc    extends Sort("-duration")
-  case object ByDurationAsc     extends Sort("duration")
+  case object ByRelevanceDesc    extends Sort("-relevance")
+  case object ByRelevanceAsc     extends Sort("relevance")
+  case object ByTitleDesc        extends Sort("-title")
+  case object ByTitleAsc         extends Sort("title")
+  case object ByLastUpdatedDesc  extends Sort("-lastUpdated")
+  case object ByLastUpdatedAsc   extends Sort("lastUpdated")
+  case object ByIdDesc           extends Sort("-id")
+  case object ByIdAsc            extends Sort("id")
+  case object ByDurationDesc     extends Sort("-duration")
+  case object ByDurationAsc      extends Sort("duration")
+  case object ByRevisionDateAsc  extends Sort("revisionDate")
+  case object ByRevisionDateDesc extends Sort("-revisionDate")
 
   def valueOf(s: String): Option[Sort] = Sort.values.find(_.entryName == s)
 

--- a/search-api/src/main/scala/no/ndla/searchapi/model/domain/draft/Draft.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/model/domain/draft/Draft.scala
@@ -32,5 +32,6 @@ case class Draft(
     articleType: article.LearningResourceType.Value,
     notes: List[EditorNote],
     previousVersionsNotes: List[EditorNote],
-    grepCodes: Seq[String]
+    grepCodes: Seq[String],
+    revisionMeta: Seq[RevisionMeta]
 ) extends Content

--- a/search-api/src/main/scala/no/ndla/searchapi/model/domain/draft/RevisionMeta.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/model/domain/draft/RevisionMeta.scala
@@ -1,0 +1,9 @@
+package no.ndla.searchapi.model.domain.draft
+
+import java.time.LocalDateTime
+
+case class RevisionMeta(
+    revisionDate: LocalDateTime,
+    note: String,
+    status: String
+)

--- a/search-api/src/main/scala/no/ndla/searchapi/model/search/SearchableDraft.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/model/search/SearchableDraft.scala
@@ -9,6 +9,7 @@ package no.ndla.searchapi.model.search
 
 import no.ndla.search.model.{SearchableLanguageList, SearchableLanguageValues}
 import no.ndla.searchapi.model.domain.article.ArticleMetaImage
+import no.ndla.searchapi.model.domain.draft.RevisionMeta
 import org.joda.time.DateTime
 
 case class SearchableDraft(
@@ -34,5 +35,7 @@ case class SearchableDraft(
     grepContexts: List[SearchableGrepContext],
     traits: List[String],
     embedAttributes: SearchableLanguageList,
-    embedResourcesAndIds: List[EmbedValues]
+    embedResourcesAndIds: List[EmbedValues],
+    revisionMeta: List[RevisionMeta],
+    nextRevision: Option[RevisionMeta]
 )

--- a/search-api/src/main/scala/no/ndla/searchapi/model/search/settings/MultiDraftSearchSettings.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/model/search/settings/MultiDraftSearchSettings.scala
@@ -11,6 +11,8 @@ import no.ndla.searchapi.model.domain.Sort
 import no.ndla.searchapi.model.domain.article.LearningResourceType
 import no.ndla.searchapi.model.domain.draft.ArticleStatus
 
+import java.time.LocalDateTime
+
 case class MultiDraftSearchSettings(
     query: Option[String],
     noteQuery: Option[String],
@@ -35,5 +37,7 @@ case class MultiDraftSearchSettings(
     aggregatePaths: List[String],
     embedResource: List[String],
     embedId: Option[String],
-    includeOtherStatuses: Boolean
+    includeOtherStatuses: Boolean,
+    revisionDateFilterFrom: Option[LocalDateTime],
+    revisionDateFilterTo: Option[LocalDateTime]
 )

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/ArticleIndexService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/ArticleIndexService.scala
@@ -71,7 +71,8 @@ trait ArticleIndexService {
           keywordField("imageId"),
           keywordField("altText"),
           keywordField("language")
-        )
+        ),
+        dateField("nextRevision.revisionDate") // This is needed for sorting, even if it is never used for articles
       )
       val dynamics = generateLanguageSupportedDynamicTemplates("title", keepRaw = true) ++
         generateLanguageSupportedDynamicTemplates("metaDescription") ++

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/DraftIndexService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/DraftIndexService.scala
@@ -75,7 +75,13 @@ trait DraftIndexService {
           keywordField("imageId"),
           keywordField("altText"),
           keywordField("language")
-        )
+        ),
+        nestedField("revisionMeta").fields(
+          dateField("revisionDate"),
+          keywordField("note"),
+          keywordField("status")
+        ),
+        dateField("nextRevision.revisionDate")
       )
       val dynamics = generateLanguageSupportedDynamicTemplates("title", keepRaw = true) ++
         generateLanguageSupportedDynamicTemplates("metaDescription") ++

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/LearningPathIndexService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/LearningPathIndexService.scala
@@ -89,7 +89,8 @@ trait LearningPathIndexService {
           keywordField("resource"),
           keywordField("id"),
           keywordField("language")
-        )
+        ),
+        dateField("nextRevision.revisionDate") // This is needed for sorting, even if it is never used for learningpaths
       )
       val dynamics = generateLanguageSupportedDynamicTemplates("title", keepRaw = true) ++
         generateLanguageSupportedDynamicTemplates("content") ++

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/MultiDraftSearchService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/MultiDraftSearchService.scala
@@ -9,7 +9,7 @@ package no.ndla.searchapi.service.search
 
 import java.util.concurrent.Executors
 import com.sksamuel.elastic4s.ElasticDsl.{simpleStringQuery, _}
-import com.sksamuel.elastic4s.requests.searches.queries.Query
+import com.sksamuel.elastic4s.requests.searches.queries.{Query, RangeQuery}
 import com.sksamuel.elastic4s.requests.searches.queries.compound.BoolQuery
 import com.typesafe.scalalogging.LazyLogging
 import no.ndla.language.Language.AllLanguages
@@ -28,6 +28,7 @@ import no.ndla.searchapi.model.domain.{SearchResult, draft}
 import no.ndla.searchapi.model.search.SearchType
 import no.ndla.searchapi.model.search.settings.MultiDraftSearchSettings
 
+import java.time.{LocalDateTime, ZoneOffset}
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutor, Future}
 import scala.util.{Failure, Success, Try}
 
@@ -71,7 +72,7 @@ trait MultiDraftSearchService {
             simpleStringQuery(queryString).field("previousVersionsNotes", 1),
             simpleStringQuery(queryString).field("grepContexts.title", 1),
             idsQuery(queryString),
-            nestedQuery("revisionMeta", simpleStringQuery(queryString).field("revisionMeta.note"))
+            nestedQuery("revisionMeta", simpleStringQuery(queryString).field("revisionMeta.note")).ignoreUnmapped(true)
           ) ++
             buildNestedEmbedField(List(queryString), None, settings.language, settings.fallback) ++
             buildNestedEmbedField(List.empty, Some(queryString), settings.language, settings.fallback)
@@ -156,10 +157,9 @@ trait MultiDraftSearchService {
       */
     private def getSearchFilters(settings: MultiDraftSearchSettings): List[Query] = {
       val languageFilter = settings.language match {
-        case "" | AllLanguages =>
-          None
-        case lang =>
-          if (settings.fallback) None else Some(existsQuery(s"title.$lang"))
+        case "" | AllLanguages         => None
+        case lang if settings.fallback => None
+        case lang                      => Some(existsQuery(s"title.$lang"))
       }
 
       val idFilter = if (settings.withIdIn.isEmpty) None else Some(idsQuery(settings.withIdIn))
@@ -177,6 +177,7 @@ trait MultiDraftSearchService {
 
       val statusFilter = draftStatusFilter(settings.statusFilter, settings.includeOtherStatuses)
       val usersFilter  = boolUsersFilter(settings.userFilter)
+      val dateFilter   = revisionDateFilter(settings.revisionDateFilterFrom, settings.revisionDateFilterTo)
 
       val taxonomyContextFilter       = contextTypeFilter(settings.learningResourceTypes)
       val taxonomyResourceTypesFilter = resourceTypeFilter(settings.resourceTypes, filterByNoResourceType = false)
@@ -206,8 +207,23 @@ trait MultiDraftSearchService {
         statusFilter,
         usersFilter,
         grepCodesFilter,
-        embedResourceAndIdFilter
+        embedResourceAndIdFilter,
+        dateFilter
       ).flatten
+    }
+
+    private def dateToEs(date: LocalDateTime): Long = date.toEpochSecond(ZoneOffset.UTC) * 1000
+    private def revisionDateFilter(from: Option[LocalDateTime], to: Option[LocalDateTime]): Option[RangeQuery] = {
+      val fromDate = from.map(dateToEs)
+      val toDate   = to.map(dateToEs)
+
+      Option.when(fromDate.nonEmpty || toDate.nonEmpty)(
+        RangeQuery(
+          field = "nextRevision.revisionDate",
+          gte = fromDate,
+          lte = toDate
+        )
+      )
     }
 
     private def draftStatusFilter(statuses: Seq[draft.ArticleStatus.Value], includeOthers: Boolean): Some[BoolQuery] = {

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/MultiDraftSearchService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/MultiDraftSearchService.scala
@@ -70,7 +70,8 @@ trait MultiDraftSearchService {
             simpleStringQuery(queryString).field("notes", 1),
             simpleStringQuery(queryString).field("previousVersionsNotes", 1),
             simpleStringQuery(queryString).field("grepContexts.title", 1),
-            idsQuery(queryString)
+            idsQuery(queryString),
+            nestedQuery("revisionMeta", simpleStringQuery(queryString).field("revisionMeta.note"))
           ) ++
             buildNestedEmbedField(List(queryString), None, settings.language, settings.fallback) ++
             buildNestedEmbedField(List.empty, Some(queryString), settings.language, settings.fallback)

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
@@ -322,6 +322,7 @@ trait SearchConverterService {
       val notes: List[String] = draft.notes.map(_.note)
       val users: List[String] =
         List(draft.updatedBy) ++ draft.notes.map(_.user) ++ draft.previousVersionsNotes.map(_.user)
+      val nextRevision = draft.revisionMeta.filter(_.status == "needs-revision").sortBy(_.revisionDate).headOption
 
       Success(
         SearchableDraft(
@@ -357,7 +358,9 @@ trait SearchConverterService {
           grepContexts = getGrepContexts(draft.grepCodes, grepBundle),
           traits = traits.toList.distinct,
           embedAttributes = embedAttributes,
-          embedResourcesAndIds = embedResourcesAndIds
+          embedResourcesAndIds = embedResourcesAndIds,
+          revisionMeta = draft.revisionMeta.toList,
+          nextRevision = nextRevision
         )
       )
 

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
@@ -603,7 +603,8 @@ trait SearchConverterService {
         highlights = getHighlights(hit.highlight),
         paths = getPathsFromContext(searchableArticle.contexts),
         lastUpdated = searchableArticle.lastUpdated.toDate,
-        license = Some(searchableArticle.license)
+        license = Some(searchableArticle.license),
+        revisions = Seq.empty
       )
     }
 
@@ -630,11 +631,10 @@ trait SearchConverterService {
       val metaDescription = findByLanguageOrBestEffort(metaDescriptions, language).getOrElse(
         api.MetaDescription("", UnknownLanguage.toString)
       )
-      val metaImage = findByLanguageOrBestEffort(metaImages, language)
-
+      val metaImage          = findByLanguageOrBestEffort(metaImages, language)
       val supportedLanguages = getSupportedLanguages(titles, visualElements, introductions, metaDescriptions)
-
-      val url = s"${SearchApiProperties.ExternalApiUrls("draft-api")}/${searchableDraft.id}"
+      val url                = s"${SearchApiProperties.ExternalApiUrls("draft-api")}/${searchableDraft.id}"
+      val revisions          = searchableDraft.revisionMeta.map(m => api.RevisionMeta(m.revisionDate, m.note, m.status))
 
       MultiSearchSummary(
         id = searchableDraft.id,
@@ -651,7 +651,8 @@ trait SearchConverterService {
         highlights = getHighlights(hit.highlight),
         paths = getPathsFromContext(searchableDraft.contexts),
         lastUpdated = searchableDraft.lastUpdated.toDate,
-        license = searchableDraft.license
+        license = searchableDraft.license,
+        revisions = revisions
       )
     }
 
@@ -699,7 +700,8 @@ trait SearchConverterService {
         highlights = getHighlights(hit.highlight),
         paths = getPathsFromContext(searchableLearningPath.contexts),
         lastUpdated = searchableLearningPath.lastUpdated.toDate,
-        license = Some(searchableLearningPath.license)
+        license = Some(searchableLearningPath.license),
+        revisions = Seq.empty
       )
     }
 

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/SearchService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/SearchService.scala
@@ -367,6 +367,9 @@ trait SearchService {
         case Sort.ByLastUpdatedDesc => fieldSort("lastUpdated").sortOrder(SortOrder.Desc).missing("_last")
         case Sort.ByIdAsc           => fieldSort("id").sortOrder(SortOrder.Asc).missing("_last")
         case Sort.ByIdDesc          => fieldSort("id").sortOrder(SortOrder.Desc).missing("_last")
+        case Sort.ByRevisionDateAsc => fieldSort("nextRevision.revisionDate").sortOrder(SortOrder.Asc).missing("_last")
+        case Sort.ByRevisionDateDesc =>
+          fieldSort("nextRevision.revisionDate").sortOrder(SortOrder.Desc).missing("_last")
       }
     }
 

--- a/search-api/src/test/scala/no/ndla/searchapi/TestData.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/TestData.scala
@@ -1405,7 +1405,9 @@ object TestData {
     aggregatePaths = List.empty,
     embedResource = List.empty,
     embedId = None,
-    includeOtherStatuses = false
+    includeOtherStatuses = false,
+    revisionDateFilterFrom = None,
+    revisionDateFilterTo = None
   )
 
   val searchableResourceTypes = List(

--- a/search-api/src/test/scala/no/ndla/searchapi/TestData.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/TestData.scala
@@ -506,7 +506,8 @@ object TestData {
     articleType = LearningResourceType.Article,
     notes = List.empty,
     previousVersionsNotes = List.empty,
-    grepCodes = Seq.empty
+    grepCodes = Seq.empty,
+    Seq.empty
   )
 
   val draftStatus         = draft.Status(draft.ArticleStatus.DRAFT, Set.empty)
@@ -557,6 +558,7 @@ object TestData {
     LearningResourceType.Article,
     List.empty,
     List.empty,
+    Seq.empty,
     Seq.empty
   )
 

--- a/search-api/src/test/scala/no/ndla/searchapi/controller/SearchControllerTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/controller/SearchControllerTest.scala
@@ -17,6 +17,8 @@ import no.ndla.searchapi.model.search.settings.{MultiDraftSearchSettings, Search
 import no.ndla.searchapi.{SearchSwagger, TestData, TestEnvironment, UnitSuite}
 import org.scalatra.test.scalatest.ScalatraFunSuite
 
+import java.time.{LocalDateTime, Month}
+import javax.servlet.http.HttpServletRequest
 import scala.util.Success
 
 class SearchControllerTest extends UnitSuite with TestEnvironment with ScalatraFunSuite {
@@ -217,6 +219,19 @@ class SearchControllerTest extends UnitSuite with TestEnvironment with ScalatraF
     }
 
     verify(feideApiClient, times(1)).getUser(eqTo(teacherToken))
+  }
+
+  test("That retrieving datetime strings from request works") {
+    val requestMock = mock[HttpServletRequest](withSettings.lenient())
+
+    val expectedDate = LocalDateTime.of(2025, Month.JANUARY, 2, 13, 39, 5)
+
+    when(requestMock.getQueryString).thenReturn(
+      "revision-date-from=2025-01-02T13:39:05Z&revision-date-to=2025-01-02T13:39:05Z"
+    )
+    val settings = controller.getDraftSearchSettingsFromRequest(requestMock)
+    settings.revisionDateFilterFrom should be(Some(expectedDate))
+    settings.revisionDateFilterTo should be(Some(expectedDate))
   }
 
 }

--- a/search-api/src/test/scala/no/ndla/searchapi/integration/DraftApiClientTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/integration/DraftApiClientTest.scala
@@ -12,7 +12,7 @@ import no.ndla.network.AuthUser
 import no.ndla.search.model.LanguageValue
 import no.ndla.searchapi.model.domain
 import no.ndla.searchapi.model.domain.DomainDumpResults
-import no.ndla.searchapi.model.domain.article.{Availability, LearningResourceType}
+import no.ndla.searchapi.model.domain.article.LearningResourceType
 import no.ndla.searchapi.model.domain.draft.{ArticleStatus, Copyright}
 import no.ndla.searchapi.model.domain.learningpath._
 import no.ndla.searchapi.{TestData, TestEnvironment, UnitSuite}

--- a/search-api/src/test/scala/no/ndla/searchapi/integration/DraftApiClientTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/integration/DraftApiClientTest.scala
@@ -12,7 +12,7 @@ import no.ndla.network.AuthUser
 import no.ndla.search.model.LanguageValue
 import no.ndla.searchapi.model.domain
 import no.ndla.searchapi.model.domain.DomainDumpResults
-import no.ndla.searchapi.model.domain.article.LearningResourceType
+import no.ndla.searchapi.model.domain.article.{Availability, LearningResourceType}
 import no.ndla.searchapi.model.domain.draft.{ArticleStatus, Copyright}
 import no.ndla.searchapi.model.domain.learningpath._
 import no.ndla.searchapi.{TestData, TestEnvironment, UnitSuite}
@@ -84,6 +84,7 @@ class DraftApiClientTest extends UnitSuite with TestEnvironment {
         domain.article.LearningResourceType.Article,
         List.empty,
         List.empty,
+        Seq.empty,
         Seq.empty
       )
 

--- a/search-api/src/test/scala/no/ndla/searchapi/model/search/SearchableDraftTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/model/search/SearchableDraftTest.scala
@@ -11,9 +11,11 @@ import no.ndla.search.model.{LanguageValue, SearchableLanguageFormats, Searchabl
 import no.ndla.searchapi.model.domain.article.{ArticleMetaImage, LearningResourceType}
 import no.ndla.searchapi.{TestData, TestEnvironment, UnitSuite}
 import no.ndla.searchapi.TestData._
-import no.ndla.searchapi.model.domain.draft.ArticleStatus
+import no.ndla.searchapi.model.domain.draft.{ArticleStatus, RevisionMeta}
 import org.json4s.Formats
 import org.json4s.native.Serialization.{read, write}
+
+import java.time.LocalDateTime
 
 class SearchableDraftTest extends UnitSuite with TestEnvironment {
 
@@ -63,6 +65,22 @@ class SearchableDraftTest extends UnitSuite with TestEnvironment {
     val embedResourcesAndIds =
       List(EmbedValues(resource = Some("test resource 1"), id = List("test id 1"), language = "nb"))
 
+    val today   = LocalDateTime.now().withNano(0)
+    val olddate = today.minusDays(5)
+
+    val revisionMeta = List(
+      RevisionMeta(
+        revisionDate = today,
+        note = "some note",
+        status = "needs-revision"
+      ),
+      RevisionMeta(
+        revisionDate = olddate,
+        note = "some other note",
+        status = "needs-revision"
+      )
+    )
+
     val original = SearchableDraft(
       id = 100,
       draftStatus = Status(ArticleStatus.DRAFT.toString, Seq(ArticleStatus.PROPOSAL.toString)),
@@ -87,8 +105,11 @@ class SearchableDraftTest extends UnitSuite with TestEnvironment {
         List(SearchableGrepContext("K123", Some("some title")), SearchableGrepContext("K456", Some("some title 2"))),
       traits = List.empty,
       embedAttributes = embedAttrs,
-      embedResourcesAndIds = embedResourcesAndIds
+      embedResourcesAndIds = embedResourcesAndIds,
+      revisionMeta = revisionMeta,
+      nextRevision = revisionMeta.lastOption
     )
+
     val json         = write(original)
     val deserialized = read[SearchableDraft](json)
 

--- a/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceAtomicTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceAtomicTest.scala
@@ -247,8 +247,86 @@ class MultiDraftSearchServiceAtomicTest
     search1.results.map(_.id) should be(List(3))
   }
 
-  // TODO: Implement these tests (and functionality)
   test("Test that filtering revision dates works as expected") {
-    ???
+    val today = LocalDateTime.now().withNano(0)
+
+    val draft1 = TestData.draft1.copy(
+      id = Some(1),
+      revisionMeta = Seq(
+        RevisionMeta(
+          today.plusDays(1),
+          note = "apekatt",
+          status = "needs-revision"
+        ),
+        RevisionMeta(
+          today.plusDays(10),
+          note = "note",
+          status = "revised"
+        )
+      )
+    )
+    val draft2 = TestData.draft1.copy(
+      id = Some(2),
+      revisionMeta = Seq(
+        RevisionMeta(
+          today.minusDays(10),
+          note = "kinakål",
+          status = "revised"
+        )
+      )
+    )
+    val draft3 = TestData.draft1.copy(
+      id = Some(3),
+      revisionMeta = Seq(
+        RevisionMeta(
+          today.minusDays(10),
+          note = "trylleformel",
+          status = "needs-revision"
+        )
+      )
+    )
+    val draft4 = TestData.draft1.copy(
+      id = Some(4),
+      revisionMeta = Seq()
+    )
+    draftIndexService.indexDocument(draft1, taxonomyTestBundle, Some(grepBundle)).get
+    draftIndexService.indexDocument(draft2, taxonomyTestBundle, Some(grepBundle)).get
+    draftIndexService.indexDocument(draft3, taxonomyTestBundle, Some(grepBundle)).get
+    draftIndexService.indexDocument(draft4, taxonomyTestBundle, Some(grepBundle)).get
+
+    blockUntil(() => draftIndexService.countDocuments == 4)
+
+    multiDraftSearchService
+      .matchingQuery(
+        multiDraftSearchSettings.copy(
+          revisionDateFilterFrom = Some(today),
+          revisionDateFilterTo = None
+        )
+      )
+      .get
+      .results
+      .map(_.id) should be(Seq(1))
+
+    multiDraftSearchService
+      .matchingQuery(
+        multiDraftSearchSettings.copy(
+          revisionDateFilterFrom = None,
+          revisionDateFilterTo = Some(today)
+        )
+      )
+      .get
+      .results
+      .map(_.id) should be(Seq(3))
+
+    multiDraftSearchService
+      .matchingQuery(
+        multiDraftSearchSettings.copy(
+          revisionDateFilterFrom = Some(today.minusDays(11)),
+          revisionDateFilterTo = Some(today.plusDays(1))
+        )
+      )
+      .get
+      .results
+      .map(_.id) should be(Seq(1, 3))
   }
 }

--- a/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceAtomicTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceAtomicTest.scala
@@ -181,4 +181,13 @@ class MultiDraftSearchServiceAtomicTest
     search2.totalCount should be(4)
     search2.results.map(_.id) should be(List(1, 3, 2, 4))
   }
+
+  // TODO: Implement these tests (and functionality)
+  test("Test that searching for note in revision meta works as expected") {
+    ???
+  }
+
+  test("Test that filtering revision dates works as expected") {
+    ???
+  }
 }

--- a/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceAtomicTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceAtomicTest.scala
@@ -10,10 +10,13 @@ package no.ndla.searchapi.service.search
 import no.ndla.scalatestsuite.IntegrationSuite
 import no.ndla.search.Elastic4sClientFactory
 import no.ndla.searchapi.TestData._
+import no.ndla.searchapi.model.domain.Sort
 import no.ndla.searchapi.model.domain.article._
+import no.ndla.searchapi.model.domain.draft.RevisionMeta
 import no.ndla.searchapi.{TestData, TestEnvironment}
 import org.scalatest.Outcome
 
+import java.time.LocalDateTime
 import scala.util.{Failure, Success}
 
 class MultiDraftSearchServiceAtomicTest
@@ -104,7 +107,78 @@ class MultiDraftSearchServiceAtomicTest
 
     search2.totalCount should be(2)
     search2.results.map(_.id) should be(List(1, 2))
-
   }
 
+  test("That sorting by revision date sorts by the earliest 'needs-revision'") {
+    val today     = LocalDateTime.now().withNano(0)
+    val yesterday = today.minusDays(1)
+    val tomorrow  = today.plusDays(1)
+
+    val draft1 = TestData.draft1.copy(
+      id = Some(1),
+      revisionMeta = Seq(
+        RevisionMeta(
+          today,
+          note = "note",
+          status = "needs-revision"
+        ),
+        RevisionMeta(
+          tomorrow,
+          note = "note",
+          status = "needs-revision"
+        ),
+        RevisionMeta(
+          yesterday,
+          note = "note",
+          status = "revised"
+        )
+      )
+    )
+    val draft2 = TestData.draft1.copy(
+      id = Some(2),
+      revisionMeta = Seq(
+        RevisionMeta(
+          yesterday.minusDays(10),
+          note = "note",
+          status = "revised"
+        )
+      )
+    )
+    val draft3 = TestData.draft1.copy(
+      id = Some(3),
+      revisionMeta = Seq(
+        RevisionMeta(
+          yesterday,
+          note = "note",
+          status = "needs-revision"
+        )
+      )
+    )
+    val draft4 = TestData.draft1.copy(
+      id = Some(4),
+      revisionMeta = Seq()
+    )
+    draftIndexService.indexDocument(draft1, taxonomyTestBundle, Some(grepBundle)).get
+    draftIndexService.indexDocument(draft2, taxonomyTestBundle, Some(grepBundle)).get
+    draftIndexService.indexDocument(draft3, taxonomyTestBundle, Some(grepBundle)).get
+    draftIndexService.indexDocument(draft4, taxonomyTestBundle, Some(grepBundle)).get
+
+    blockUntil(() => draftIndexService.countDocuments == 4)
+
+    val Success(search1) =
+      multiDraftSearchService.matchingQuery(
+        multiDraftSearchSettings.copy(sort = Sort.ByRevisionDateAsc)
+      )
+
+    search1.totalCount should be(4)
+    search1.results.map(_.id) should be(List(3, 1, 2, 4))
+
+    val Success(search2) =
+      multiDraftSearchService.matchingQuery(
+        multiDraftSearchSettings.copy(sort = Sort.ByRevisionDateDesc)
+      )
+
+    search2.totalCount should be(4)
+    search2.results.map(_.id) should be(List(1, 3, 2, 4))
+  }
 }

--- a/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceAtomicTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceAtomicTest.scala
@@ -182,11 +182,72 @@ class MultiDraftSearchServiceAtomicTest
     search2.results.map(_.id) should be(List(1, 3, 2, 4))
   }
 
-  // TODO: Implement these tests (and functionality)
   test("Test that searching for note in revision meta works as expected") {
-    ???
+    val today     = LocalDateTime.now().withNano(0)
+    val yesterday = today.minusDays(1)
+    val tomorrow  = today.plusDays(1)
+
+    val draft1 = TestData.draft1.copy(
+      id = Some(1),
+      revisionMeta = Seq(
+        RevisionMeta(
+          today,
+          note = "apekatt",
+          status = "needs-revision"
+        ),
+        RevisionMeta(
+          tomorrow,
+          note = "note",
+          status = "needs-revision"
+        ),
+        RevisionMeta(
+          yesterday,
+          note = "note",
+          status = "revised"
+        )
+      )
+    )
+    val draft2 = TestData.draft1.copy(
+      id = Some(2),
+      revisionMeta = Seq(
+        RevisionMeta(
+          yesterday.minusDays(10),
+          note = "kinakål",
+          status = "revised"
+        )
+      )
+    )
+    val draft3 = TestData.draft1.copy(
+      id = Some(3),
+      revisionMeta = Seq(
+        RevisionMeta(
+          yesterday,
+          note = "trylleformel",
+          status = "needs-revision"
+        )
+      )
+    )
+    val draft4 = TestData.draft1.copy(
+      id = Some(4),
+      revisionMeta = Seq()
+    )
+    draftIndexService.indexDocument(draft1, taxonomyTestBundle, Some(grepBundle)).get
+    draftIndexService.indexDocument(draft2, taxonomyTestBundle, Some(grepBundle)).get
+    draftIndexService.indexDocument(draft3, taxonomyTestBundle, Some(grepBundle)).get
+    draftIndexService.indexDocument(draft4, taxonomyTestBundle, Some(grepBundle)).get
+
+    blockUntil(() => draftIndexService.countDocuments == 4)
+
+    val Success(search1) =
+      multiDraftSearchService.matchingQuery(
+        multiDraftSearchSettings.copy(query = Some("trylleformel"))
+      )
+
+    search1.totalCount should be(1)
+    search1.results.map(_.id) should be(List(3))
   }
 
+  // TODO: Implement these tests (and functionality)
   test("Test that filtering revision dates works as expected") {
     ???
   }

--- a/search/src/main/scala/no/ndla/search/model/SearchableLanguageFormats.scala
+++ b/search/src/main/scala/no/ndla/search/model/SearchableLanguageFormats.scala
@@ -8,7 +8,9 @@
 package no.ndla.search.model
 
 import org.json4s.JsonAST.{JField, JObject, JString}
+import org.json4s.ext.JavaTimeSerializers
 import org.json4s.{CustomSerializer, DefaultFormats, Formats, JArray, JNothing, MappingException}
+
 import java.util.TimeZone
 
 class SearchableLanguageValuesSerializer
@@ -74,11 +76,13 @@ object SearchableLanguageFormats {
     defaultFormats(false) +
       new SearchableLanguageValuesSerializer +
       new SearchableLanguageListSerializer ++
-      org.json4s.ext.JodaTimeSerializers.all
+      org.json4s.ext.JodaTimeSerializers.all ++
+      JavaTimeSerializers.all
 
   val JSonFormatsWithMillis: Formats =
     defaultFormats(true) +
       new SearchableLanguageValuesSerializer +
       new SearchableLanguageListSerializer ++
-      org.json4s.ext.JodaTimeSerializers.all
+      org.json4s.ext.JodaTimeSerializers.all ++
+      JavaTimeSerializers.all
 }


### PR DESCRIPTION
Legger til støtte for å søke i revisjonsnotaer, samt filtrere på og sortere på revisjonsdatoer for drafts i search-api.

Kan testes ved å lagre diverse revisjoner i drafts for så å prøve `sort=revisionDate`, `revision-date-from`og `revision-date-to` query-parameterene. Gjerne i kombinasjon.