### PR TITLE
Add status field to ArticleSummary when searching for drafts

### DIFF
--- a/draft-api/src/main/scala/no/ndla/draftapi/model/api/ArticleSummary.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/model/api/ArticleSummary.scala
@@ -26,4 +26,6 @@ case class ArticleSummary(
     @(ApiModelProperty @field)(description = "Searchable tags for the article") tags: Option[ArticleTag],
     @(ApiModelProperty @field)(description = "The notes for this draft article") notes: Seq[String],
     @(ApiModelProperty @field)(description = "The users saved for this draft article") users: Seq[String],
-    @(ApiModelProperty @field)(description = "The codes from GREP API registered for this draft article") grepCodes: Seq[String])
+    @(ApiModelProperty @field)(description = "The codes from GREP API registered for this draft article") grepCodes: Seq[String],
+    @(ApiModelProperty @field)(description = "The status of this article", allowableValues = "CREATED,IMPORTED,DRAFT,SKETCH,USER_TEST,QUALITY_ASSURED,AWAITING_QUALITY_ASSURANCE") status: Status
+)

--- a/draft-api/src/main/scala/no/ndla/draftapi/model/search/SearchableArticle.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/model/search/SearchableArticle.scala
@@ -26,5 +26,5 @@ case class SearchableArticle(
     users: Seq[String],
     previousNotes: Seq[String],
     grepCodes: Seq[String],
-    status: SearchableStatus,
+    status: SearchableStatus
 )

--- a/draft-api/src/main/scala/no/ndla/draftapi/model/search/SearchableArticle.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/model/search/SearchableArticle.scala
@@ -25,5 +25,6 @@ case class SearchableArticle(
     defaultTitle: Option[String],
     users: Seq[String],
     previousNotes: Seq[String],
-    grepCodes: Seq[String]
+    grepCodes: Seq[String],
+    status: SearchableStatus,
 )

--- a/draft-api/src/main/scala/no/ndla/draftapi/model/search/SearchableGrepCode.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/model/search/SearchableGrepCode.scala
@@ -1,6 +1,6 @@
 /*
  * Part of NDLA draft-api.
- * Copyright (C) 221 NDLA
+ * Copyright (C) 2021 NDLA
  *
  * See LICENSE
  */

--- a/draft-api/src/main/scala/no/ndla/draftapi/model/search/SearchableGrepCode.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/model/search/SearchableGrepCode.scala
@@ -1,3 +1,10 @@
+/*
+ * Part of NDLA draft-api.
+ * Copyright (C) 221 NDLA
+ *
+ * See LICENSE
+ */
+
 package no.ndla.draftapi.model.search
 
 case class SearchableGrepCode(grepCode: String)

--- a/draft-api/src/main/scala/no/ndla/draftapi/model/search/SearchableStatus.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/model/search/SearchableStatus.scala
@@ -1,3 +1,10 @@
+/*
+ * Part of NDLA draft-api.
+ * Copyright (C) 2022 NDLA
+ *
+ * See LICENSE
+ */
+
 package no.ndla.draftapi.model.search
 
 import no.ndla.draftapi.model.domain.ArticleStatus

--- a/draft-api/src/main/scala/no/ndla/draftapi/model/search/SearchableStatus.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/model/search/SearchableStatus.scala
@@ -1,0 +1,5 @@
+package no.ndla.draftapi.model.search
+
+import no.ndla.draftapi.model.domain.ArticleStatus
+
+case class SearchableStatus(current: ArticleStatus.Value, other: Set[ArticleStatus.Value])

--- a/draft-api/src/main/scala/no/ndla/draftapi/service/search/ArticleIndexService.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/service/search/ArticleIndexService.scala
@@ -26,9 +26,9 @@ trait ArticleIndexService {
   val articleIndexService: ArticleIndexService
 
   class ArticleIndexService extends LazyLogging with IndexService[Article, SearchableArticle] {
-    implicit val formats: Formats                = SearchableLanguageFormats.JSonFormats + new EnumNameSerializer(ArticleStatus)
-    override val documentType: String            = DraftApiProperties.DraftSearchDocument
-    override val searchIndex: String             = DraftApiProperties.DraftSearchIndex
+    implicit val formats: Formats     = SearchableLanguageFormats.JSonFormats + new EnumNameSerializer(ArticleStatus)
+    override val documentType: String = DraftApiProperties.DraftSearchDocument
+    override val searchIndex: String  = DraftApiProperties.DraftSearchIndex
     override val repository: Repository[Article] = draftRepository
 
     override def createIndexRequests(domainModel: Article, indexName: String): Seq[IndexRequest] = {

--- a/draft-api/src/main/scala/no/ndla/draftapi/service/search/ArticleIndexService.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/service/search/ArticleIndexService.scala
@@ -8,15 +8,17 @@
 package no.ndla.draftapi.service.search
 
 import com.sksamuel.elastic4s.ElasticDsl._
+import com.sksamuel.elastic4s.fields.ObjectField
 import com.sksamuel.elastic4s.requests.indexes.IndexRequest
 import com.sksamuel.elastic4s.requests.mappings.MappingDefinition
 import com.typesafe.scalalogging.LazyLogging
 import no.ndla.draftapi.DraftApiProperties
-import no.ndla.draftapi.model.domain.Article
+import no.ndla.draftapi.model.domain.{Article, ArticleStatus}
 import no.ndla.draftapi.model.search.SearchableArticle
 import no.ndla.draftapi.repository.{DraftRepository, Repository}
 import no.ndla.search.model.SearchableLanguageFormats
 import org.json4s.Formats
+import org.json4s.ext.EnumNameSerializer
 import org.json4s.native.Serialization.write
 
 trait ArticleIndexService {
@@ -24,7 +26,7 @@ trait ArticleIndexService {
   val articleIndexService: ArticleIndexService
 
   class ArticleIndexService extends LazyLogging with IndexService[Article, SearchableArticle] {
-    implicit val formats: Formats                = SearchableLanguageFormats.JSonFormats
+    implicit val formats: Formats                = SearchableLanguageFormats.JSonFormats + new EnumNameSerializer(ArticleStatus)
     override val documentType: String            = DraftApiProperties.DraftSearchDocument
     override val searchIndex: String             = DraftApiProperties.DraftSearchIndex
     override val repository: Repository[Article] = draftRepository
@@ -45,7 +47,8 @@ trait ArticleIndexService {
         textField("notes"),
         textField("previousNotes"),
         keywordField("users"),
-        keywordField("grepCodes")
+        keywordField("grepCodes"),
+        ObjectField("status", properties = Seq(keywordField("current"), keywordField("other")))
       )
       val dynamics = generateLanguageSupportedDynamicTemplates("title", keepRaw = true) ++
         generateLanguageSupportedDynamicTemplates("content") ++

--- a/draft-api/src/main/scala/no/ndla/draftapi/service/search/SearchConverterService.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/service/search/SearchConverterService.scala
@@ -21,6 +21,7 @@ import no.ndla.search.SearchLanguage
 import no.ndla.search.model.{LanguageValue, SearchableLanguageFormats, SearchableLanguageList, SearchableLanguageValues}
 import org.joda.time.DateTime
 import org.json4s._
+import org.json4s.ext.EnumNameSerializer
 import org.json4s.native.JsonMethods._
 import org.json4s.native.Serialization.read
 import org.jsoup.Jsoup
@@ -30,7 +31,7 @@ trait SearchConverterService {
   val searchConverterService: SearchConverterService
 
   class SearchConverterService extends LazyLogging {
-    implicit val formats: Formats = SearchableLanguageFormats.JSonFormats
+    implicit val formats: Formats = SearchableLanguageFormats.JSonFormats + new EnumNameSerializer(ArticleStatus)
 
     def asSearchableArticle(ai: Article): SearchableArticle = {
 
@@ -64,7 +65,8 @@ trait SearchConverterService {
         defaultTitle = defaultTitle.map(_.title),
         users = ai.updatedBy +: ai.notes.map(_.user),
         previousNotes = ai.previousVersionsNotes.map(_.note),
-        grepCodes = ai.grepCodes
+        grepCodes = ai.grepCodes,
+        status = SearchableStatus(ai.status.current, ai.status.other)
       )
     }
 
@@ -89,6 +91,7 @@ trait SearchConverterService {
       val introduction =
         findByLanguageOrBestEffort(introductions, language).map(converterService.toApiArticleIntroduction)
       val tag = findByLanguageOrBestEffort(tags, language).map(converterService.toApiArticleTag)
+      val status = api.Status(searchableArticle.status.current.toString, searchableArticle.status.other.map(_.toString).toSeq)
 
       api.ArticleSummary(
         id = searchableArticle.id,
@@ -102,7 +105,8 @@ trait SearchConverterService {
         tags = tag,
         notes = notes,
         users = users,
-        grepCodes = searchableArticle.grepCodes
+        grepCodes = searchableArticle.grepCodes,
+        status = status
       )
     }
 

--- a/draft-api/src/main/scala/no/ndla/draftapi/service/search/SearchConverterService.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/service/search/SearchConverterService.scala
@@ -91,7 +91,8 @@ trait SearchConverterService {
       val introduction =
         findByLanguageOrBestEffort(introductions, language).map(converterService.toApiArticleIntroduction)
       val tag = findByLanguageOrBestEffort(tags, language).map(converterService.toApiArticleTag)
-      val status = api.Status(searchableArticle.status.current.toString, searchableArticle.status.other.map(_.toString).toSeq)
+      val status =
+        api.Status(searchableArticle.status.current.toString, searchableArticle.status.other.map(_.toString).toSeq)
 
       api.ArticleSummary(
         id = searchableArticle.id,

--- a/draft-api/src/test/scala/no/ndla/draftapi/model/search/SearchableArticleSerializerTest.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/model/search/SearchableArticleSerializerTest.scala
@@ -7,14 +7,16 @@
 
 package no.ndla.draftapi.model.search
 
+import no.ndla.draftapi.model.domain.ArticleStatus
 import no.ndla.draftapi.{TestEnvironment, UnitSuite}
 import no.ndla.search.model.{LanguageValue, SearchableLanguageFormats, SearchableLanguageList, SearchableLanguageValues}
 import org.joda.time.{DateTime, DateTimeZone}
 import org.json4s.Formats
+import org.json4s.ext.EnumNameSerializer
 import org.json4s.native.Serialization.{read, writePretty}
 
 class SearchableArticleSerializerTest extends UnitSuite with TestEnvironment {
-  implicit val formats: Formats = SearchableLanguageFormats.JSonFormats
+  implicit val formats: Formats = SearchableLanguageFormats.JSonFormats + new EnumNameSerializer(ArticleStatus)
 
   val searchableArticle1 = SearchableArticle(
     id = 10.toLong,
@@ -34,7 +36,8 @@ class SearchableArticleSerializerTest extends UnitSuite with TestEnvironment {
     defaultTitle = Some("tjuppidu"),
     users = Seq("ndalId54321"),
     previousNotes = Seq("Søte", "Jordbær"),
-    grepCodes = Seq("KM1337", "KM5432")
+    grepCodes = Seq("KM1337", "KM5432"),
+    status = SearchableStatus(ArticleStatus.PUBLISHED, Set.empty)
   )
 
   test("That deserialization and serialization of SearchableArticle works as expected") {


### PR DESCRIPTION
Legger inn `status` så vi slipper å kalle /draft/${id} for hver eneste status vi vil hente ut i strukturredigeringen på ED.