### PR TITLE
#3054: Ignore unpublished articles when dumping :^)

### DIFF
--- a/article-api/src/main/scala/no/ndla/articleapi/repository/ArticleRepository.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/repository/ArticleRepository.scala
@@ -214,8 +214,7 @@ trait ArticleRepository {
                    ${ar.result.*},
                    ${ar.revision} as revision,
                    max(revision) over (partition by article_id) as max_revision
-                 from ${Article.as(ar)}
-                 where document is not NULL) _
+                 from ${Article.as(ar)}) _
            where revision = max_revision
            offset $offset
            limit $pageSize


### PR DESCRIPTION
Fixes NDLANO/Issues#3054

Viser seg at vi skipper over artikler med tomt document når vi dumper de i article-api. Dette gjør at avpubliserte artikler blir indeksert og dukker opp i det vanlige søket.

Kan testes ved å sjekke at en avpublisert artikkel ikke dukker opp i `/intern/dump/article` i article-api, evt at den ikke dukker opp i søket i search-api :smile: 