### PR TITLE
#2846: Adds more image-api fields

### DIFF
--- a/image-api/src/main/scala/db/migration/V12__AddSizeMetaData.scala
+++ b/image-api/src/main/scala/db/migration/V12__AddSizeMetaData.scala
@@ -1,0 +1,123 @@
+/*
+ * Part of NDLA image-api.
+ * Copyright (C) 2022 NDLA
+ *
+ * See LICENSE
+ */
+
+package db.migration
+
+import com.amazonaws.regions.Regions
+import com.amazonaws.services.s3.model.{GetObjectRequest, S3Object}
+import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
+import com.typesafe.scalalogging.LazyLogging
+import io.lemonlabs.uri.Uri
+import no.ndla.imageapi.ImageApiProperties.StorageName
+import org.apache.commons.io.IOUtils
+import org.flywaydb.core.api.migration.{BaseJavaMigration, Context}
+import org.json4s.JsonAST.{JField, JInt}
+import org.json4s.native.JsonMethods.{compact, parse, render}
+import org.json4s.{DefaultFormats, JObject}
+import org.postgresql.util.PGobject
+import scalikejdbc.{DB, DBSession, _}
+
+import java.io.ByteArrayInputStream
+import javax.imageio.ImageIO
+import scala.util.{Failure, Success, Try}
+
+class V12__AddSizeMetaData extends BaseJavaMigration with LazyLogging {
+
+  implicit val formats: DefaultFormats.type = org.json4s.DefaultFormats
+
+  override def migrate(context: Context): Unit = {
+    val db = DB(context.getConnection)
+    db.autoClose(false)
+
+    db.withinTx { implicit session =>
+      imagesToUpdate.map { case (id, document) =>
+        update(convertImageUpdate(document), id)
+      }
+    }
+  }
+
+  def imagesToUpdate(implicit session: DBSession): List[(Long, String)] = {
+    sql"select id, metadata from imagemetadata"
+      .map(rs => {
+        (rs.long("id"), rs.string("metadata"))
+      })
+      .list()
+  }
+
+  val currentRegion: Option[Regions] = Option(Regions.getCurrentRegion).map(region => Regions.fromName(region.getName))
+
+  val amazonClient: AmazonS3 =
+    AmazonS3ClientBuilder
+      .standard()
+      .withRegion(currentRegion.getOrElse(Regions.EU_CENTRAL_1))
+      .build()
+
+  def getS3Object(imageKey: String): Try[S3Object] = {
+    Try(amazonClient.getObject(new GetObjectRequest(StorageName, imageKey)))
+  }
+
+  def get(imageKey: String): Try[Option[(Int, Int)]] = {
+    getS3Object(imageKey).flatMap(s3Object => {
+      val s3Is         = s3Object.getObjectContent
+      val imageContent = IOUtils.toByteArray(s3Is)
+      val stream       = new ByteArrayInputStream(imageContent)
+      val image        = Try(Option(ImageIO.read(stream)))
+
+      image match {
+        case Success(Some(image)) => Success(Some(image.getWidth -> image.getHeight))
+        case Success(None) =>
+          val isSVG = new String(imageContent).toLowerCase.contains("<svg")
+          if (isSVG) {
+            // Since SVG are vector-images size doesn't make sense
+            Success(None)
+          } else {
+            Failure(new RuntimeException("Broken image"))
+          }
+        case Failure(ex) => Failure(ex)
+      }
+    })
+  }
+
+  def convertImageUpdate(imageMeta: String): String = {
+    val oldDocument = parse(imageMeta)
+
+    val imageUrl = (oldDocument \ "imageUrl").extract[String]
+    val imageKey = Uri
+      .parse(imageUrl)
+      .toStringRaw
+      .dropWhile(_ == '/') // Strip heading '/'
+    val newDocument = get(imageKey) match {
+      case Success(Some((width, height))) =>
+        val toMerge = JObject(
+          JField(
+            "imageDimensions",
+            JObject(
+              JField("width", JInt(width)),
+              JField("height", JInt(height))
+            )
+          )
+        )
+        oldDocument.merge(toMerge)
+      case Success(None) =>
+        oldDocument
+      case Failure(ex) =>
+        logger.warn(s"Something went wrong when fetching $imageKey", ex)
+        val toMerge = JObject(JField("imageDimensions", JObject(JField("width", JInt(0)), JField("height", JInt(0)))))
+        oldDocument.merge(toMerge)
+    }
+
+    compact(render(newDocument))
+  }
+
+  def update(imagemetadata: String, id: Long)(implicit session: DBSession) = {
+    val dataObject = new PGobject()
+    dataObject.setType("jsonb")
+    dataObject.setValue(imagemetadata)
+
+    sql"update imagemetadata set metadata = ${dataObject} where id = $id".update()
+  }
+}

--- a/image-api/src/main/scala/no/ndla/imageapi/model/api/ImageDimensions.scala
+++ b/image-api/src/main/scala/no/ndla/imageapi/model/api/ImageDimensions.scala
@@ -1,0 +1,18 @@
+/*
+ * Part of NDLA image-api.
+ * Copyright (C) 2022 NDLA
+ *
+ * See LICENSE
+ *
+ */
+
+package no.ndla.imageapi.model.api
+
+import org.scalatra.swagger.annotations.{ApiModel, ApiModelProperty}
+import scala.annotation.meta.field
+
+@ApiModel(description = "Dimensions of an image")
+case class ImageDimensions(
+    @(ApiModelProperty @field)(description = "The width of the image in pixels") width: Int,
+    @(ApiModelProperty @field)(description = "The height of the image in pixels") height: Int
+)

--- a/image-api/src/main/scala/no/ndla/imageapi/model/api/ImageMetaInformationV2.scala
+++ b/image-api/src/main/scala/no/ndla/imageapi/model/api/ImageMetaInformationV2.scala
@@ -31,5 +31,6 @@ case class ImageMetaInformationV2(
     @(ApiModelProperty @field)(description = "Describes when the image was created") created: Date,
     @(ApiModelProperty @field)(description = "Describes who created the image") createdBy: String,
     @(ApiModelProperty @field)(description = "Describes if the model has released use of the image", allowableValues = "not-set,yes,no,not-applicable") modelRelease: String,
-    @(ApiModelProperty @field)(description = "Describes the changes made to the image, only visible to editors") editorNotes: Option[Seq[EditorNote]]
+    @(ApiModelProperty @field)(description = "Describes the changes made to the image, only visible to editors") editorNotes: Option[Seq[EditorNote]],
+    @(ApiModelProperty @field)(description = "Dimensions of the image") imageDimensions: Option[ImageDimensions]
 )

--- a/image-api/src/main/scala/no/ndla/imageapi/model/api/ImageMetaSummary.scala
+++ b/image-api/src/main/scala/no/ndla/imageapi/model/api/ImageMetaSummary.scala
@@ -26,5 +26,8 @@ case class ImageMetaSummary(
     @(ApiModelProperty @field)(description = "List of supported languages in priority") supportedLanguages: Seq[String],
     @(ApiModelProperty @field)(description = "Describes if the model has released use of the image", allowableValues = "not-set,yes,no,not-applicable") modelRelease: Option[String],
     @(ApiModelProperty @field)(description = "Describes the changes made to the image, only visible to editors") editorNotes: Option[Seq[String]],
-    @(ApiModelProperty @field)(description = "The time and date of last update") lastUpdated: Date
+    @(ApiModelProperty @field)(description = "The time and date of last update") lastUpdated: Date,
+    @(ApiModelProperty @field)(description = "The size of the image in bytes") fileSize: Long,
+    @(ApiModelProperty @field)(description = "The mimetype of the image") contentType: String,
+    @(ApiModelProperty @field)(description = "Dimensions of the image") imageDimensions: Option[ImageDimensions]
 )

--- a/image-api/src/main/scala/no/ndla/imageapi/model/domain/ImageApiModels.scala
+++ b/image-api/src/main/scala/no/ndla/imageapi/model/domain/ImageApiModels.scala
@@ -36,7 +36,7 @@ case class ImageTag(tags: Seq[String], language: String) extends LanguageField[S
   override def value: Seq[String] = tags
   override def isEmpty: Boolean   = tags.isEmpty
 }
-case class Image(fileName: String, size: Long, contentType: String)
+case class Image(fileName: String, size: Long, contentType: String, dimensions: Option[ImageDimensions])
 case class Copyright(
     license: String,
     origin: String,
@@ -50,6 +50,7 @@ case class Copyright(
 case class License(license: String, description: String, url: Option[String])
 case class Author(`type`: String, name: String)
 case class EditorNote(timeStamp: Date, updatedBy: String, note: String)
+case class ImageDimensions(width: Int, height: Int)
 
 object ModelReleasedStatus extends Enumeration {
   val YES            = Value("yes")
@@ -92,7 +93,8 @@ case class ImageMetaInformation(
     created: Date,
     createdBy: String,
     modelReleased: ModelReleasedStatus.Value,
-    editorNotes: Seq[EditorNote]
+    editorNotes: Seq[EditorNote],
+    imageDimensions: Option[ImageDimensions]
 )
 
 object ImageMetaInformation extends SQLSyntaxSupport[ImageMetaInformation] {
@@ -124,7 +126,8 @@ object ImageMetaInformation extends SQLSyntaxSupport[ImageMetaInformation] {
       meta.created,
       meta.createdBy,
       meta.modelReleased,
-      meta.editorNotes
+      meta.editorNotes,
+      meta.imageDimensions
     )
   }
 }

--- a/image-api/src/main/scala/no/ndla/imageapi/model/search/SearchableImage.scala
+++ b/image-api/src/main/scala/no/ndla/imageapi/model/search/SearchableImage.scala
@@ -24,5 +24,8 @@ case class SearchableImage(
     lastUpdated: Date,
     defaultTitle: Option[String],
     modelReleased: Option[String],
-    editorNotes: Seq[String]
+    editorNotes: Seq[String],
+    fileSize: Long,
+    contentType: String,
+    imageDimensions: Option[(Int, Int)]
 )

--- a/image-api/src/main/scala/no/ndla/imageapi/model/search/SearchableImage.scala
+++ b/image-api/src/main/scala/no/ndla/imageapi/model/search/SearchableImage.scala
@@ -7,6 +7,7 @@
 
 package no.ndla.imageapi.model.search
 
+import no.ndla.imageapi.model.domain.ImageDimensions
 import no.ndla.search.model.{SearchableLanguageList, SearchableLanguageValues}
 
 import java.util.Date
@@ -27,5 +28,5 @@ case class SearchableImage(
     editorNotes: Seq[String],
     fileSize: Long,
     contentType: String,
-    imageDimensions: Option[(Int, Int)]
+    imageDimensions: Option[ImageDimensions]
 )

--- a/image-api/src/main/scala/no/ndla/imageapi/service/ConverterService.scala
+++ b/image-api/src/main/scala/no/ndla/imageapi/service/ConverterService.scala
@@ -101,24 +101,26 @@ trait ConverterService {
 
       val apiUrl = asApiUrl(imageMeta.imageUrl, rawBaseUrl)
 
-      val editorNotes = Option.when(authRole.userHasWriteRole())(asApiEditorNotes(imageMeta.editorNotes))
+      val editorNotes     = Option.when(authRole.userHasWriteRole())(asApiEditorNotes(imageMeta.editorNotes))
+      val imageDimensions = imageMeta.imageDimensions.map(d => api.ImageDimensions(d.width, d.height))
 
       api.ImageMetaInformationV2(
-        imageMeta.id.get.toString,
-        baseUrl + imageMeta.id.get,
-        title,
-        alttext,
-        apiUrl,
-        imageMeta.size,
-        imageMeta.contentType,
-        withAgreementCopyright(asApiCopyright(imageMeta.copyright)),
-        tags,
-        caption,
-        getSupportedLanguages(imageMeta),
-        imageMeta.created,
-        imageMeta.createdBy,
-        imageMeta.modelReleased.toString,
-        editorNotes
+        id = imageMeta.id.get.toString,
+        metaUrl = baseUrl + imageMeta.id.get,
+        title = title,
+        alttext = alttext,
+        imageUrl = apiUrl,
+        size = imageMeta.size,
+        contentType = imageMeta.contentType,
+        copyright = withAgreementCopyright(asApiCopyright(imageMeta.copyright)),
+        tags = tags,
+        caption = caption,
+        supportedLanguages = getSupportedLanguages(imageMeta),
+        created = imageMeta.created,
+        createdBy = imageMeta.createdBy,
+        modelRelease = imageMeta.modelReleased.toString,
+        editorNotes = editorNotes,
+        imageDimensions = imageDimensions
       )
     }
 
@@ -214,7 +216,8 @@ trait ConverterService {
           created = now,
           updated = now,
           modelReleased = modelStatus,
-          editorNotes = Seq(domain.EditorNote(now, user, "Image created."))
+          editorNotes = Seq(domain.EditorNote(now, user, "Image created.")),
+          imageDimensions = image.dimensions
         )
       })
     }

--- a/image-api/src/main/scala/no/ndla/imageapi/service/search/ImageIndexService.scala
+++ b/image-api/src/main/scala/no/ndla/imageapi/service/search/ImageIndexService.scala
@@ -8,7 +8,7 @@
 package no.ndla.imageapi.service.search
 
 import com.sksamuel.elastic4s.ElasticDsl._
-import com.sksamuel.elastic4s.fields.ElasticField
+import com.sksamuel.elastic4s.fields.{ElasticField, ObjectField}
 import com.sksamuel.elastic4s.requests.indexes.IndexRequest
 import com.sksamuel.elastic4s.requests.mappings.MappingDefinition
 import com.sksamuel.elastic4s.requests.mappings.dynamictemplate.DynamicTemplateRequest
@@ -44,7 +44,14 @@ trait ImageIndexService {
         dateField("lastUpdated"),
         keywordField("defaultTitle"),
         keywordField("modelReleased"),
-        textField("editorNotes")
+        textField("editorNotes"),
+        ObjectField(
+          "imageDimensions",
+          properties = Seq(
+            intField("width"),
+            intField("height")
+          )
+        )
       )
 
       val dynamics: Seq[DynamicTemplateRequest] = generateLanguageSupportedDynamicTemplates("titles", keepRaw = true) ++

--- a/image-api/src/main/scala/no/ndla/imageapi/service/search/SearchConverterService.scala
+++ b/image-api/src/main/scala/no/ndla/imageapi/service/search/SearchConverterService.scala
@@ -50,8 +50,6 @@ trait SearchConverterService {
         })
         .lastOption
 
-      val dimensions = image.imageDimensions.map(d => (d.width, d.height))
-
       SearchableImage(
         id = imageWithAgreement.id.get,
         titles =
@@ -74,7 +72,7 @@ trait SearchConverterService {
         editorNotes = image.editorNotes.map(_.note),
         fileSize = image.size,
         contentType = image.contentType,
-        imageDimensions = dimensions
+        imageDimensions = image.imageDimensions
       )
     }
 
@@ -112,7 +110,7 @@ trait SearchConverterService {
         lastUpdated = searchableImage.lastUpdated,
         fileSize = searchableImage.fileSize,
         contentType = searchableImage.contentType,
-        imageDimensions = searchableImage.imageDimensions.map { case (width, height) =>
+        imageDimensions = searchableImage.imageDimensions.map { case domain.ImageDimensions(width, height) =>
           api.ImageDimensions(width, height)
         }
       )

--- a/image-api/src/main/scala/no/ndla/imageapi/service/search/SearchConverterService.scala
+++ b/image-api/src/main/scala/no/ndla/imageapi/service/search/SearchConverterService.scala
@@ -50,6 +50,8 @@ trait SearchConverterService {
         })
         .lastOption
 
+      val dimensions = image.imageDimensions.map(d => (d.width, d.height))
+
       SearchableImage(
         id = imageWithAgreement.id.get,
         titles =
@@ -69,7 +71,10 @@ trait SearchConverterService {
         lastUpdated = imageWithAgreement.updated,
         defaultTitle = defaultTitle.map(t => t.title),
         modelReleased = Some(image.modelReleased.toString),
-        editorNotes = image.editorNotes.map(_.note)
+        editorNotes = image.editorNotes.map(_.note),
+        fileSize = image.size,
+        contentType = image.contentType,
+        imageDimensions = dimensions
       )
     }
 
@@ -104,7 +109,12 @@ trait SearchConverterService {
         supportedLanguages = supportedLanguages,
         modelRelease = searchableImage.modelReleased,
         editorNotes = editorNotes,
-        lastUpdated = searchableImage.lastUpdated
+        lastUpdated = searchableImage.lastUpdated,
+        fileSize = searchableImage.fileSize,
+        contentType = searchableImage.contentType,
+        imageDimensions = searchableImage.imageDimensions.map { case (width, height) =>
+          api.ImageDimensions(width, height)
+        }
       )
     }
 

--- a/image-api/src/test/scala/db/migration/V12__AddSizeMetaDataTest.scala
+++ b/image-api/src/test/scala/db/migration/V12__AddSizeMetaDataTest.scala
@@ -19,12 +19,12 @@ import scala.util.{Failure, Success}
 class V12__AddSizeMetaDataTest extends UnitSuite with TestEnvironment {
   val migration = spy(new V12__AddSizeMetaData)
 
-  val testUrl = "http://test.test/1"
-  val imageStreamMock = mock[ImageStream]
+  val testUrl           = "http://test.test/1"
+  val imageStreamMock   = mock[ImageStream]
   val bufferedImageMock = mock[BufferedImage]
 
   test("migration not do anything if the document already has new status format") {
-    when(migration.get(testUrl)).thenReturn(Success(Some(100, 200)))
+    when(migration.get(testUrl)).thenReturn(Success(Some((100, 200))))
     val original =
       s"""{"id":"1","metaUrl":"$testUrl","title":{"title":"Elg i busk","language":"nb"},"created":"2017-04-01T12:15:32Z","createdBy":"ndla124","modelRelease":"yes","alttext":{"alttext":"Elg i busk","language":"nb"},"imageUrl":"$testUrl","size":2865539,"contentType":"image/jpeg","copyright":{"license":{"license":"gnu","description":"gnuggert","url":"https://gnuli/"},"agreementId":1,"origin":"http://www.scanpix.no","creators":[{"type":"Forfatter","name":"Knutulf Knagsen"}],"processors":[{"type":"Redaksjonelt","name":"Kåre Knegg"}],"rightsholders":[]},"tags":{"tags":["rovdyr","elg"],"language":"nb"},"caption":{"caption":"Elg i busk","language":"nb"},"supportedLanguages":["nb"],"imageDimensions":{"width":100,"height":200}}"""
 
@@ -44,7 +44,7 @@ class V12__AddSizeMetaDataTest extends UnitSuite with TestEnvironment {
   }
 
   test("That svg's doesn't get a size") {
-    val s3Mock = mock[S3Object]
+    val s3Mock      = mock[S3Object]
     val requestMock = mock[HttpRequestBase]
 
     val svgImage = new S3ObjectInputStream(CCLogoSvgImage.stream, requestMock)
@@ -59,9 +59,9 @@ class V12__AddSizeMetaDataTest extends UnitSuite with TestEnvironment {
   }
 
   test("That real image gets its size") {
-    val s3Mock = mock[S3Object]
+    val s3Mock      = mock[S3Object]
     val requestMock = mock[HttpRequestBase]
-    val image = new S3ObjectInputStream(NdlaLogoImage.stream, requestMock)
+    val image       = new S3ObjectInputStream(NdlaLogoImage.stream, requestMock)
     when(s3Mock.getObjectContent).thenReturn(image)
     when(migration.getS3Object("some.jpg")).thenReturn(Success(s3Mock))
 

--- a/image-api/src/test/scala/db/migration/V12__AddSizeMetaDataTest.scala
+++ b/image-api/src/test/scala/db/migration/V12__AddSizeMetaDataTest.scala
@@ -1,0 +1,75 @@
+/*
+ * Part of NDLA image-api.
+ * Copyright (C) 2018 NDLA
+ *
+ * See LICENSE
+ */
+
+package db.migration
+
+import com.amazonaws.services.s3.model.{S3Object, S3ObjectInputStream}
+import no.ndla.imageapi.TestData.{CCLogoSvgImage, NdlaLogoImage}
+import no.ndla.imageapi.model.domain.ImageStream
+import no.ndla.imageapi.{TestEnvironment, UnitSuite}
+import org.apache.http.client.methods.HttpRequestBase
+
+import java.awt.image.BufferedImage
+import scala.util.{Failure, Success}
+
+class V12__AddSizeMetaDataTest extends UnitSuite with TestEnvironment {
+  val migration = spy(new V12__AddSizeMetaData)
+
+  val testUrl = "http://test.test/1"
+  val imageStreamMock = mock[ImageStream]
+  val bufferedImageMock = mock[BufferedImage]
+
+  test("migration not do anything if the document already has new status format") {
+    when(migration.get(testUrl)).thenReturn(Success(Some(100, 200)))
+    val original =
+      s"""{"id":"1","metaUrl":"$testUrl","title":{"title":"Elg i busk","language":"nb"},"created":"2017-04-01T12:15:32Z","createdBy":"ndla124","modelRelease":"yes","alttext":{"alttext":"Elg i busk","language":"nb"},"imageUrl":"$testUrl","size":2865539,"contentType":"image/jpeg","copyright":{"license":{"license":"gnu","description":"gnuggert","url":"https://gnuli/"},"agreementId":1,"origin":"http://www.scanpix.no","creators":[{"type":"Forfatter","name":"Knutulf Knagsen"}],"processors":[{"type":"Redaksjonelt","name":"Kåre Knegg"}],"rightsholders":[]},"tags":{"tags":["rovdyr","elg"],"language":"nb"},"caption":{"caption":"Elg i busk","language":"nb"},"supportedLanguages":["nb"],"imageDimensions":{"width":100,"height":200}}"""
+
+    migration.convertImageUpdate(original) should equal(original)
+  }
+
+  test("migration sets width and height to 0 if image does not exist in s3") {
+
+    doReturn(Success(imageStreamMock)).when(imageStorage).get(any[String])
+    when(migration.get(testUrl)).thenReturn(Failure(new Exception("no such key")))
+
+    val old =
+      s"""{"id":"1","metaUrl":"$testUrl","title":{"title":"Elg i busk","language":"nb"},"created":"2017-04-01T12:15:32Z","createdBy":"ndla124","modelRelease":"yes","alttext":{"alttext":"Elg i busk","language":"nb"},"imageUrl":"$testUrl","size":2865539,"contentType":"image/jpeg","copyright":{"license":{"license":"gnu","description":"gnuggert","url":"https://gnuli/"},"agreementId":1,"origin":"http://www.scanpix.no","creators":[{"type":"Forfatter","name":"Knutulf Knagsen"}],"processors":[{"type":"Redaksjonelt","name":"Kåre Knegg"}],"rightsholders":[]},"tags":{"tags":["rovdyr","elg"],"language":"nb"},"caption":{"caption":"Elg i busk","language":"nb"},"supportedLanguages":["nb"]}"""
+    val expected =
+      s"""{"id":"1","metaUrl":"$testUrl","title":{"title":"Elg i busk","language":"nb"},"created":"2017-04-01T12:15:32Z","createdBy":"ndla124","modelRelease":"yes","alttext":{"alttext":"Elg i busk","language":"nb"},"imageUrl":"$testUrl","size":2865539,"contentType":"image/jpeg","copyright":{"license":{"license":"gnu","description":"gnuggert","url":"https://gnuli/"},"agreementId":1,"origin":"http://www.scanpix.no","creators":[{"type":"Forfatter","name":"Knutulf Knagsen"}],"processors":[{"type":"Redaksjonelt","name":"Kåre Knegg"}],"rightsholders":[]},"tags":{"tags":["rovdyr","elg"],"language":"nb"},"caption":{"caption":"Elg i busk","language":"nb"},"supportedLanguages":["nb"],"imageDimensions":{"width":0,"height":0}}"""
+    migration.convertImageUpdate(old) should equal(expected)
+  }
+
+  test("That svg's doesn't get a size") {
+    val s3Mock = mock[S3Object]
+    val requestMock = mock[HttpRequestBase]
+
+    val svgImage = new S3ObjectInputStream(CCLogoSvgImage.stream, requestMock)
+
+    when(s3Mock.getObjectContent).thenReturn(svgImage)
+    when(migration.getS3Object("some.svg")).thenReturn(Success(s3Mock))
+
+    val old =
+      s"""{"id":"1","metaUrl":"$testUrl","title":{"title":"Elg i busk","language":"nb"},"created":"2017-04-01T12:15:32Z","createdBy":"ndla124","modelRelease":"yes","alttext":{"alttext":"Elg i busk","language":"nb"},"imageUrl":"some.svg","size":2865539,"contentType":"image/jpeg","copyright":{"license":{"license":"gnu","description":"gnuggert","url":"https://gnuli/"},"agreementId":1,"origin":"http://www.scanpix.no","creators":[{"type":"Forfatter","name":"Knutulf Knagsen"}],"processors":[{"type":"Redaksjonelt","name":"Kåre Knegg"}],"rightsholders":[]},"tags":{"tags":["rovdyr","elg"],"language":"nb"},"caption":{"caption":"Elg i busk","language":"nb"},"supportedLanguages":["nb"]}"""
+
+    migration.convertImageUpdate(old) should be(old)
+  }
+
+  test("That real image gets its size") {
+    val s3Mock = mock[S3Object]
+    val requestMock = mock[HttpRequestBase]
+    val image = new S3ObjectInputStream(NdlaLogoImage.stream, requestMock)
+    when(s3Mock.getObjectContent).thenReturn(image)
+    when(migration.getS3Object("some.jpg")).thenReturn(Success(s3Mock))
+
+    val old =
+      s"""{"id":"1","metaUrl":"$testUrl","title":{"title":"Elg i busk","language":"nb"},"created":"2017-04-01T12:15:32Z","createdBy":"ndla124","modelRelease":"yes","alttext":{"alttext":"Elg i busk","language":"nb"},"imageUrl":"some.jpg","size":2865539,"contentType":"image/jpeg","copyright":{"license":{"license":"gnu","description":"gnuggert","url":"https://gnuli/"},"agreementId":1,"origin":"http://www.scanpix.no","creators":[{"type":"Forfatter","name":"Knutulf Knagsen"}],"processors":[{"type":"Redaksjonelt","name":"Kåre Knegg"}],"rightsholders":[]},"tags":{"tags":["rovdyr","elg"],"language":"nb"},"caption":{"caption":"Elg i busk","language":"nb"},"supportedLanguages":["nb"]}"""
+    val expected =
+      s"""{"id":"1","metaUrl":"$testUrl","title":{"title":"Elg i busk","language":"nb"},"created":"2017-04-01T12:15:32Z","createdBy":"ndla124","modelRelease":"yes","alttext":{"alttext":"Elg i busk","language":"nb"},"imageUrl":"some.jpg","size":2865539,"contentType":"image/jpeg","copyright":{"license":{"license":"gnu","description":"gnuggert","url":"https://gnuli/"},"agreementId":1,"origin":"http://www.scanpix.no","creators":[{"type":"Forfatter","name":"Knutulf Knagsen"}],"processors":[{"type":"Redaksjonelt","name":"Kåre Knegg"}],"rightsholders":[]},"tags":{"tags":["rovdyr","elg"],"language":"nb"},"caption":{"caption":"Elg i busk","language":"nb"},"supportedLanguages":["nb"],"imageDimensions":{"width":189,"height":60}}"""
+
+    migration.convertImageUpdate(old) should be(expected)
+  }
+}

--- a/image-api/src/test/scala/no/ndla/imageapi/TestData.scala
+++ b/image-api/src/test/scala/no/ndla/imageapi/TestData.scala
@@ -50,7 +50,8 @@ object TestData {
     updated(),
     "ndla124",
     ModelReleasedStatus.YES,
-    Seq.empty
+    Seq.empty,
+    None
   )
 
   val apiElg = api.ImageMetaInformationV2(
@@ -81,6 +82,7 @@ object TestData {
     updated(),
     "ndla123",
     ModelReleasedStatus.YES.toString,
+    None,
     None
   )
 
@@ -108,7 +110,8 @@ object TestData {
     updated(),
     "ndla124",
     ModelReleasedStatus.YES,
-    Seq.empty
+    Seq.empty,
+    None
   )
 
   val jerv = ImageMetaInformation(
@@ -135,7 +138,8 @@ object TestData {
     updated(),
     "ndla124",
     ModelReleasedStatus.YES,
-    Seq.empty
+    Seq.empty,
+    None
   )
 
   val mink = ImageMetaInformation(
@@ -162,7 +166,8 @@ object TestData {
     updated(),
     "ndla124",
     ModelReleasedStatus.YES,
-    Seq.empty
+    Seq.empty,
+    None
   )
 
   val rein = ImageMetaInformation(
@@ -189,7 +194,8 @@ object TestData {
     updated(),
     "ndla124",
     ModelReleasedStatus.YES,
-    Seq.empty
+    Seq.empty,
+    None
   )
 
   val nonexisting = ImageMetaInformation(
@@ -216,7 +222,8 @@ object TestData {
     updated(),
     "ndla124",
     ModelReleasedStatus.YES,
-    Seq.empty
+    Seq.empty,
+    None
   )
 
   val nonexistingWithoutThumb = ImageMetaInformation(
@@ -243,7 +250,8 @@ object TestData {
     updated(),
     "ndla124",
     ModelReleasedStatus.YES,
-    Seq.empty
+    Seq.empty,
+    None
   )
 
   val testdata = List(elg, bjorn, jerv, mink, rein)

--- a/image-api/src/test/scala/no/ndla/imageapi/controller/ImageControllerV2Test.scala
+++ b/image-api/src/test/scala/no/ndla/imageapi/controller/ImageControllerV2Test.scala
@@ -121,10 +121,13 @@ class ImageControllerV2Test extends UnitSuite with ScalatraSuite with TestEnviro
       Seq("nb"),
       Some("yes"),
       None,
-      date.toDate
+      date.toDate,
+      123,
+      "image/jpg",
+      None
     )
     val expectedBody =
-      """{"totalCount":1,"page":1,"pageSize":10,"language":"nb","results":[{"id":"4","title":{"title":"Tittel","language":"nb"},"contributors":["Jason Bourne","Ben Affleck"],"altText":{"alttext":"AltText","language":"nb"},"previewUrl":"http://image-api.ndla-local/image-api/raw/4","metaUrl":"http://image-api.ndla-local/image-api/v2/images/4","license":"by-sa","supportedLanguages":["nb"],"modelRelease":"yes","lastUpdated":"2021-04-01T12:34:56Z"}]}"""
+      """{"totalCount":1,"page":1,"pageSize":10,"language":"nb","results":[{"id":"4","title":{"title":"Tittel","language":"nb"},"contributors":["Jason Bourne","Ben Affleck"],"altText":{"alttext":"AltText","language":"nb"},"previewUrl":"http://image-api.ndla-local/image-api/raw/4","metaUrl":"http://image-api.ndla-local/image-api/v2/images/4","license":"by-sa","supportedLanguages":["nb"],"modelRelease":"yes","lastUpdated":"2021-04-01T12:34:56Z","fileSize":123,"contentType":"image/jpg"}]}"""
     val domainSearchResult = domain.SearchResult(1, Some(1), 10, "nb", List(imageSummary), None)
     val apiSearchResult    = api.SearchResult(1, Some(1), 10, "nb", List(imageSummary))
     when(imageSearchService.matchingQuery(any[SearchSettings])).thenReturn(Success(domainSearchResult))
@@ -223,7 +226,8 @@ class ImageControllerV2Test extends UnitSuite with ScalatraSuite with TestEnviro
       new Date(),
       "createdBy",
       ModelReleasedStatus.YES,
-      Seq.empty
+      Seq.empty,
+      None
     )
 
     when(writeService.storeNewImage(any[NewImageMetaInformationV2], any[FileItem])).thenReturn(Success(sampleImageMeta))

--- a/image-api/src/test/scala/no/ndla/imageapi/controller/InternControllerTest.scala
+++ b/image-api/src/test/scala/no/ndla/imageapi/controller/InternControllerTest.scala
@@ -52,6 +52,7 @@ class InternControllerTest extends UnitSuite with ScalatraSuite with TestEnviron
     updated,
     "ndla124",
     ModelReleasedStatus.YES.toString,
+    None,
     None
   )
 
@@ -70,7 +71,8 @@ class InternControllerTest extends UnitSuite with ScalatraSuite with TestEnviron
     updated,
     "ndla124",
     ModelReleasedStatus.YES,
-    Seq.empty
+    Seq.empty,
+    None
   )
 
   override def beforeEach() = {

--- a/image-api/src/test/scala/no/ndla/imageapi/service/ConverterServiceTest.scala
+++ b/image-api/src/test/scala/no/ndla/imageapi/service/ConverterServiceTest.scala
@@ -23,8 +23,9 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
 
   val updated: Date = new DateTime(2017, 4, 1, 12, 15, 32, DateTimeZone.UTC).toDate
 
-  val full    = Image("/123.png", 200, "image/png")
-  val wanting = Image("123.png", 200, "image/png")
+  val someDims = Some(ImageDimensions(100, 100))
+  val full     = Image("/123.png", 200, "image/png", someDims)
+  val wanting  = Image("123.png", 200, "image/png", someDims)
 
   val DefaultImageMetaInformation = ImageMetaInformation(
     Some(1),
@@ -41,7 +42,8 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
     updated,
     "ndla124",
     ModelReleasedStatus.YES,
-    Seq.empty
+    Seq.empty,
+    someDims
   )
 
   val WantingImageMetaInformation = ImageMetaInformation(
@@ -59,7 +61,8 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
     updated,
     "ndla124",
     ModelReleasedStatus.YES,
-    Seq.empty
+    Seq.empty,
+    someDims
   )
 
   val MultiLangImage = ImageMetaInformation(
@@ -77,7 +80,8 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
     updated,
     "ndla124",
     ModelReleasedStatus.YES,
-    Seq.empty
+    Seq.empty,
+    someDims
   )
 
   override def beforeEach(): Unit = {

--- a/image-api/src/test/scala/no/ndla/imageapi/service/ReadServiceTest.scala
+++ b/image-api/src/test/scala/no/ndla/imageapi/service/ReadServiceTest.scala
@@ -97,7 +97,8 @@ class ReadServiceTest extends UnitSuite with TestEnvironment {
       TestData.updated(),
       "ndla124",
       ModelReleasedStatus.YES,
-      Seq.empty
+      Seq.empty,
+      None
     )
 
     when(imageRepository.withId(1)).thenReturn(Some(agreementElg))
@@ -137,7 +138,8 @@ class ReadServiceTest extends UnitSuite with TestEnvironment {
       TestData.updated(),
       "ndla124",
       ModelReleasedStatus.YES,
-      Seq.empty
+      Seq.empty,
+      None
     )
 
     when(imageRepository.withId(1)).thenReturn(Some(agreementElg))

--- a/image-api/src/test/scala/no/ndla/imageapi/service/ValidationServiceTest.scala
+++ b/image-api/src/test/scala/no/ndla/imageapi/service/ValidationServiceTest.scala
@@ -35,7 +35,8 @@ class ValidationServiceTest extends UnitSuite with TestEnvironment {
     updated(),
     "ndla124",
     ModelReleasedStatus.YES,
-    Seq.empty
+    Seq.empty,
+    None
   )
 
   override def beforeEach() = {

--- a/image-api/src/test/scala/no/ndla/imageapi/service/search/ImageSearchServiceTest.scala
+++ b/image-api/src/test/scala/no/ndla/imageapi/service/search/ImageSearchServiceTest.scala
@@ -46,8 +46,8 @@ class ImageSearchServiceTest
 
   val getStartAtAndNumResults: PrivateMethod[(Int, Int)] = PrivateMethod[(Int, Int)](Symbol("getStartAtAndNumResults"))
 
-  val largeImage = Image("large-full-url", 10000, "jpg")
-  val smallImage = Image("small-full-url", 100, "jpg")
+  val largeImage = Image("large-full-url", 10000, "jpg", None)
+  val smallImage = Image("small-full-url", 100, "jpg", None)
 
   val byNcSa = Copyright(
     CC_BY_NC_SA.toString,
@@ -98,7 +98,8 @@ class ImageSearchServiceTest
     updated,
     "ndla124",
     ModelReleasedStatus.NO,
-    Seq.empty
+    Seq.empty,
+    None
   )
 
   val image2 = ImageMetaInformation(
@@ -116,7 +117,8 @@ class ImageSearchServiceTest
     updated,
     "ndla124",
     ModelReleasedStatus.NOT_APPLICABLE,
-    Seq(EditorNote(new Date(), "someone", "Lillehjelper"))
+    Seq(EditorNote(new Date(), "someone", "Lillehjelper")),
+    None
   )
 
   val image3 = ImageMetaInformation(
@@ -134,7 +136,8 @@ class ImageSearchServiceTest
     updated,
     "ndla124",
     ModelReleasedStatus.YES,
-    Seq.empty
+    Seq.empty,
+    None
   )
 
   val image4 = ImageMetaInformation(
@@ -152,7 +155,8 @@ class ImageSearchServiceTest
     updated,
     "ndla124",
     ModelReleasedStatus.YES,
-    Seq.empty
+    Seq.empty,
+    None
   )
 
   val image5 = ImageMetaInformation(
@@ -174,7 +178,8 @@ class ImageSearchServiceTest
     updated,
     "ndla124",
     ModelReleasedStatus.YES,
-    Seq.empty
+    Seq.empty,
+    None
   )
 
   override def beforeAll(): Unit = {

--- a/project/Module.scala
+++ b/project/Module.scala
@@ -74,12 +74,14 @@ trait Module {
   ) ++ loadEnvFile() ++ fmtSettings
 
   private def loadEnvFile(): Seq[Def.Setting[_]] = {
-    Seq(
-      fork := true,
-      envVars ++= {
-        parseFile(baseDirectory.value / ".env").getOrElse(Map.empty)
-      }
-    )
+    if (sys.env.get("DISABLE_SUB_DOTENV").contains("true")) Seq.empty
+    else
+      Seq(
+        fork := true,
+        envVars ++= {
+          parseFile(baseDirectory.value / ".env").getOrElse(Map.empty)
+        }
+      )
   }
 
   def withLogging(libs: Seq[ModuleID]): Seq[ModuleID] = {


### PR DESCRIPTION
Relates to NDLANO/Issues#2846

Legger til `ImageDimensions` i databasen, samt eksponerer `imageDimensions`, `fileSize` og `contentType` i søkeresultater.