### PR TITLE
Adds sorting of resourcetypes to ensure same sorting in search as in …

### DIFF
--- a/project/Module.scala
+++ b/project/Module.scala
@@ -60,7 +60,7 @@ trait Module {
       "-deprecation",
       "-feature",
       "-Xfatal-warnings",
-      "-Xlint",
+      "-Xlint:-strict-unsealed-patmat",
       "-Wconf:src=src_managed/.*:silent",
       "-Wconf:cat=lint-byname-implicit:silent" // https://github.com/scala/bug/issues/12072
     ),

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
@@ -933,7 +933,7 @@ trait SearchConverterService {
         connectedResourceTypes
           .flatMap(rt => bundle.resourceTypeParentsByResourceTypeId.getOrElse(rt.id, List.empty))
           .filterNot(connectedResourceTypes.contains)
-      (connectedResourceTypes ++ subParents).distinct.sortWith((l,_) => l.subtypes.isDefined)
+      (connectedResourceTypes ++ subParents).distinct.sortWith((l, _) => l.subtypes.isDefined)
     }
 
     private def getTopicTaxonomyContexts(

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
@@ -933,7 +933,7 @@ trait SearchConverterService {
         connectedResourceTypes
           .flatMap(rt => bundle.resourceTypeParentsByResourceTypeId.getOrElse(rt.id, List.empty))
           .filterNot(connectedResourceTypes.contains)
-      (connectedResourceTypes ++ subParents).distinct
+      (connectedResourceTypes ++ subParents).distinct.sortWith((l,_) => l.subtypes.isDefined)
     }
 
     private def getTopicTaxonomyContexts(

--- a/search-api/src/test/scala/no/ndla/searchapi/service/search/ArticleIndexServiceTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/service/search/ArticleIndexServiceTest.scala
@@ -46,7 +46,7 @@ class ArticleIndexServiceTest
 
   override val converterService       = new ConverterService
   override val searchConverterService = new SearchConverterService
-  implicit val formats: Formats = SearchableLanguageFormats.JSonFormatsWithMillis
+  implicit val formats: Formats       = SearchableLanguageFormats.JSonFormatsWithMillis
 
   test("That articles are indexed correctly") {
     articleIndexService.cleanupIndexes()

--- a/search-api/src/test/scala/no/ndla/searchapi/service/search/ArticleIndexServiceTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/service/search/ArticleIndexServiceTest.scala
@@ -14,6 +14,7 @@ import no.ndla.search.model.SearchableLanguageFormats
 import no.ndla.searchapi.TestData._
 import no.ndla.searchapi.model.search.SearchableArticle
 import no.ndla.searchapi.{TestData, TestEnvironment, UnitSuite}
+import org.json4s.Formats
 import org.json4s.native.Serialization.read
 import org.scalatest.Outcome
 
@@ -45,7 +46,7 @@ class ArticleIndexServiceTest
 
   override val converterService       = new ConverterService
   override val searchConverterService = new SearchConverterService
-  implicit val formats                = SearchableLanguageFormats.JSonFormatsWithMillis
+  implicit val formats: Formats = SearchableLanguageFormats.JSonFormatsWithMillis
 
   test("That articles are indexed correctly") {
     articleIndexService.cleanupIndexes()


### PR DESCRIPTION
…taxonomy.

I taksonomi sorterer vi resourceType for ressurs for å få konsistent rekkefølge på disse. Det fungerer ikkje i søket fordi dette settes basert på liste av resourceResourceType. Denne endringa forsøker å gjenskape sorteringa fra taxonomy-api.