### PR TITLE
Add extra formats for correct serializing

### DIFF
--- a/article-api/src/main/scala/no/ndla/articleapi/integration/SearchApiClient.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/integration/SearchApiClient.scala
@@ -9,11 +9,11 @@ package no.ndla.articleapi.integration
 
 import com.typesafe.scalalogging.LazyLogging
 import no.ndla.articleapi.ArticleApiProperties.SearchHost
-import no.ndla.articleapi.model.domain.{Article, ArticleType}
+import no.ndla.articleapi.model.domain.{Article, ArticleType, Availability}
 import no.ndla.articleapi.service.ConverterService
 import no.ndla.network.NdlaClient
 import org.json4s.Formats
-import org.json4s.ext.EnumNameSerializer
+import org.json4s.ext.{EnumNameSerializer, JavaTimeSerializers}
 import org.json4s.native.Serialization.write
 import scalaj.http.Http
 
@@ -33,7 +33,9 @@ trait SearchApiClient {
     def indexArticle(article: Article): Article = {
       implicit val formats: Formats =
         org.json4s.DefaultFormats +
-          new EnumNameSerializer(ArticleType)
+          new EnumNameSerializer(ArticleType) +
+          new EnumNameSerializer(Availability) ++
+          JavaTimeSerializers.all
 
       implicit val executionContext: ExecutionContextExecutorService =
         ExecutionContext.fromExecutorService(Executors.newSingleThreadExecutor)

--- a/draft-api/src/main/scala/no/ndla/draftapi/integration/SearchApiClient.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/integration/SearchApiClient.scala
@@ -7,18 +7,18 @@
 
 package no.ndla.draftapi.integration
 
-import java.util.concurrent.Executors
 import com.typesafe.scalalogging.LazyLogging
 import enumeratum.Json4s
 import no.ndla.draftapi.DraftApiProperties.SearchApiHost
-import no.ndla.draftapi.model.domain.{Article, ArticleStatus, ArticleType}
+import no.ndla.draftapi.model.domain._
 import no.ndla.draftapi.service.ConverterService
 import no.ndla.network.NdlaClient
 import org.json4s.Formats
-import org.json4s.ext.EnumNameSerializer
+import org.json4s.ext.{EnumNameSerializer, JavaTimeSerializers}
 import org.json4s.native.Serialization.write
 import scalaj.http.Http
 
+import java.util.concurrent.Executors
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutorService, Future}
 import scala.util.{Failure, Success, Try}
 
@@ -35,7 +35,10 @@ trait SearchApiClient {
       implicit val formats: Formats =
         org.json4s.DefaultFormats +
           new EnumNameSerializer(ArticleStatus) +
-          Json4s.serializer(ArticleType)
+          new EnumNameSerializer(Availability) +
+          Json4s.serializer(ArticleType) +
+          Json4s.serializer(RevisionStatus) ++
+          JavaTimeSerializers.all
 
       implicit val executionContext: ExecutionContextExecutorService =
         ExecutionContext.fromExecutorService(Executors.newSingleThreadExecutor)

--- a/search-api/src/main/scala/no/ndla/searchapi/controller/NdlaController.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/controller/NdlaController.scala
@@ -21,7 +21,7 @@ import no.ndla.searchapi.model.api.{
   ValidationException,
   ValidationMessage
 }
-import no.ndla.searchapi.model.domain.article.LearningResourceType
+import no.ndla.searchapi.model.domain.article.{Availability, LearningResourceType}
 import no.ndla.searchapi.model.domain.draft.ArticleStatus
 import no.ndla.searchapi.model.domain.learningpath._
 import org.apache.logging.log4j.ThreadContext
@@ -45,7 +45,8 @@ abstract class NdlaController extends ScalatraServlet with NativeJsonSupport wit
       new EnumNameSerializer(StepType) +
       new EnumNameSerializer(StepStatus) +
       new EnumNameSerializer(EmbedType) +
-      new EnumNameSerializer(LearningResourceType) ++
+      new EnumNameSerializer(LearningResourceType) +
+      new EnumNameSerializer(Availability) ++
       org.json4s.ext.JodaTimeSerializers.all ++
       JavaTimeSerializers.all
 


### PR DESCRIPTION
Sort of fixes NDLANO/Issues#3081

Inkrementell indeksering feiler fordi dei forskjellige apiene ikkje klarer å serialisere korrekt i kommunikasjonen mellom dei. Legger derfor på ekstra serialiseringsinfo i formats.

Må testes lokalt ved å ha ganske fullt oppsett i lokal docker.
* Sjekk ut pr og kjør `ndla deploy local draft-api` og tilsvarende for article-api og search-api.
* Kjør også ed lokalt slik at du kan åpne den på http://localhost:30019
* Finn en artikkel som er publisert, og gjør en endring i feks nøkkelord
* Artikkelen skal lagres i draft-api, draft-api sender indeksering til search-api og det skal gå bra. (ingen feilmelding i search-api)
* Fordi du har endra nøkkelord i en publisert artikkel vil draft-api gjøre en delpublisering til article-api og det skal gå bra. (ingen feilmelding i article-api). Merk at draft-api ikkje klarer å lese returen fra delpubliseringa endå slik at det logges som en feil i draft, men det har ingen praktisk betydning.
* Fordi delpublisering oppdaterer en artikkel så sender article-api en indeksering til search-api og det skal gå bra. (ingen feilmelding i search-api)