### PR TITLE
Delete learningpath from index before reindexing

### DIFF
--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/search/SearchIndexService.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/search/SearchIndexService.scala
@@ -75,6 +75,7 @@ trait SearchIndexService {
 
           e4sClient
             .execute {
+              deleteById(searchIndex, learningPath.id.get.toString)
               indexInto(searchIndex)
                 .doc(source)
                 .id(learningPath.id.get.toString)


### PR DESCRIPTION
This ensures nested learningsteps also are deleted so that deleted steps no longer prevents unpublishing of articles.

Om du sletter et steg, så oppdateres ikkje nested læringssteg slik at avpublisering av artikkelen fra steget blokkeres. Full reindeksering fikser problemet, men dette gjør at også inkrementell indeksering fungerer.

Test kjøres lokalt:
* Finn en læringssti og ta et vilkårlig steg. Finn artikkelen i ed og sjå at den er i bruk i stien.
* Rediger stien og slett steget.
* Sjekk i ed at stien ikkje lenger vises i lista over stier der artikkelen finnes.