### PR TITLE
3087 add endpoint to update revisions

### DIFF
--- a/article-api/src/main/scala/no/ndla/articleapi/controller/ArticleControllerV2.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/controller/ArticleControllerV2.scala
@@ -17,6 +17,7 @@ import no.ndla.articleapi.model.domain.{ArticleIds, Sort}
 import no.ndla.articleapi.service.search.{ArticleSearchService, SearchConverterService}
 import no.ndla.articleapi.service.{ConverterService, ReadService, WriteService}
 import no.ndla.articleapi.validation.ContentValidator
+import no.ndla.common.ContentURIUtil.parseArticleIdAndRevision
 import no.ndla.language.Language.AllLanguages
 import org.json4s.ext.JavaTimeSerializers
 import org.json4s.{DefaultFormats, Formats}
@@ -330,18 +331,6 @@ trait ArticleControllerV2 {
           grepCodes,
           shouldScroll
         )
-      }
-    }
-
-    private val Pattern = """(urn:)?(article:)?(\d*)#?(\d*)""".r
-    private[controller] def parseArticleIdAndRevision(idString: String): (Try[Long], Option[Int]) = {
-      idString match {
-        case Pattern(_, _, id, rev) =>
-          (
-            stringParamToLong(this.articleId.paramName, id),
-            Try(rev.toInt).toOption
-          )
-        case _ => (stringParamToLong(this.articleId.paramName, ""), None)
       }
     }
 

--- a/common/src/main/scala/no/ndla/common/ContentURIUtil.scala
+++ b/common/src/main/scala/no/ndla/common/ContentURIUtil.scala
@@ -1,0 +1,17 @@
+package no.ndla.common
+
+import scala.util.Try
+
+object ContentURIUtil {
+
+  private val Pattern = """(urn:)?(article:)?(\d*)#?(\d*)""".r
+  def parseArticleIdAndRevision(idString: String): (Try[Long], Option[Int]) = {
+    idString match {
+      case Pattern(_, _, id, rev) =>
+        (
+          Try(id.toLong),
+          Try(rev.toInt).toOption
+        )
+    }
+  }
+}

--- a/draft-api/src/main/scala/no/ndla/draftapi/controller/DraftController.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/controller/DraftController.scala
@@ -7,6 +7,7 @@
 
 package no.ndla.draftapi.controller
 
+import enumeratum.Json4s
 import no.ndla.draftapi.DraftApiProperties
 import no.ndla.draftapi.DraftApiProperties.InitialScrollContextKeywords
 import no.ndla.draftapi.auth.User
@@ -20,13 +21,12 @@ import no.ndla.language.Language
 import no.ndla.mapping
 import no.ndla.mapping.LicenseDefinition
 import org.joda.time.DateTime
+import org.json4s.ext.JavaTimeSerializers
 import org.json4s.{DefaultFormats, Formats}
 import org.scalatra.swagger.{ResponseMessage, Swagger}
 import org.scalatra.{Created, NotFound, Ok}
 
 import scala.util.{Failure, Success, Try}
-import enumeratum.Json4s
-import org.json4s.ext.JavaTimeSerializers
 
 trait DraftController {
   this: ReadService
@@ -57,6 +57,7 @@ trait DraftController {
     private val optionalArticleId =
       Param[Option[Long]]("articleId", description = "The ID of the article to generate a status state machine for")
     private val articleId = Param[Long]("article_id", "Id of the article that is to be fetched")
+    private val nodeId    = Param[String]("node_id", "Id of the taxonomy node to process")
     private val size      = Param[Option[Int]]("size", "Limit the number of results to this many elements")
     private val articleTypes = Param[Option[String]](
       "articleTypes",
@@ -769,6 +770,34 @@ trait DraftController {
       }
     }
 
-  }
+    post(
+      "/copyRevisionDates/:node_id",
+      operation(
+        apiOperation[Boolean]("copyRevisionDates")
+          .summary("Copy revision dates from the node with this id to _all_ children in taxonomy")
+          .description("Copy revision dates from the node with this id to _all_ children in taxonomy")
+          .parameters(
+            asHeaderParam(correlationId),
+            asPathParam(nodeId)
+          )
+          .authorizations("oauth2")
+          .responseMessages(response404, response500)
+      )
+    ) {
+      val userInfo = user.getUser
+      val nodeId   = paramOrNone(this.nodeId.paramName)
 
+      doOrAccessDenied(userInfo.canWrite) {
+        nodeId match {
+          case None => NotFound(body = Error(Error.NOT_FOUND, s"No nodeid supplied"))
+          case Some(publicId) =>
+            writeService.copyRevisionDates(publicId) match {
+              case Success(bool) => bool
+              case Failure(ex)   => errorHandler(ex)
+            }
+        }
+      }
+    }
+
+  }
 }

--- a/draft-api/src/main/scala/no/ndla/draftapi/controller/DraftController.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/controller/DraftController.scala
@@ -773,7 +773,7 @@ trait DraftController {
     post(
       "/copyRevisionDates/:node_id",
       operation(
-        apiOperation[Boolean]("copyRevisionDates")
+        apiOperation[Unit]("copyRevisionDates")
           .summary("Copy revision dates from the node with this id to _all_ children in taxonomy")
           .description("Copy revision dates from the node with this id to _all_ children in taxonomy")
           .parameters(
@@ -792,7 +792,7 @@ trait DraftController {
           case None => NotFound(body = Error(Error.NOT_FOUND, s"No nodeid supplied"))
           case Some(publicId) =>
             writeService.copyRevisionDates(publicId) match {
-              case Success(bool) => bool
+              case Success(_) => Ok()
               case Failure(ex)   => errorHandler(ex)
             }
         }

--- a/draft-api/src/main/scala/no/ndla/draftapi/controller/DraftController.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/controller/DraftController.scala
@@ -792,8 +792,8 @@ trait DraftController {
           case None => NotFound(body = Error(Error.NOT_FOUND, s"No nodeid supplied"))
           case Some(publicId) =>
             writeService.copyRevisionDates(publicId) match {
-              case Success(_) => Ok()
-              case Failure(ex)   => errorHandler(ex)
+              case Success(_)  => Ok()
+              case Failure(ex) => errorHandler(ex)
             }
         }
       }

--- a/draft-api/src/main/scala/no/ndla/draftapi/integration/TaxonomyApiClient.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/integration/TaxonomyApiClient.scala
@@ -216,6 +216,14 @@ trait TaxonomyApiClient {
     def queryTopic(articleId: Long): Try[List[Topic]] =
       get[List[Topic]](s"$TaxonomyApiEndpoint/queries/topics", "contentURI" -> s"urn:article:$articleId")
 
+    def getNode(uri: String): Try[Topic] = get[Topic](s"$TaxonomyApiEndpoint/nodes/${uri}")
+
+    def getChildNodes(uri: String): Try[List[Topic]] =
+      get[List[Topic]](s"$TaxonomyApiEndpoint/nodes/${uri}/nodes", "recursive" -> "true")
+
+    def getChildResources(uri: String): Try[List[Resource]] =
+      get[List[Resource]](s"$TaxonomyApiEndpoint/nodes/${uri}/resources")
+
     private[integration] def delete(url: String, params: (String, String)*): Try[Unit] =
       ndlaClient.fetchRawWithForwardedAuth(
         Http(url).method("DELETE").timeout(taxonomyTimeout, taxonomyTimeout).params(params)

--- a/draft-api/src/main/scala/no/ndla/draftapi/integration/TaxonomyApiClient.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/integration/TaxonomyApiClient.scala
@@ -253,6 +253,7 @@ trait TaxonomyApiClient {
 trait Taxonomy[E <: Taxonomy[E]] {
   val id: String
   def name: String
+  def contentUri: Option[String]
   def withName(name: String): E
 }
 case class Resource(id: String, name: String, contentUri: Option[String], paths: List[String])

--- a/draft-api/src/main/scala/no/ndla/draftapi/service/WriteService.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/service/WriteService.scala
@@ -869,7 +869,7 @@ trait WriteService {
       }
     }
 
-    private def getRevisionMetaForUrn(topic: Topic): Seq[RevisionMeta] = {
+    private def getRevisionMetaForUrn(topic: Topic): Seq[domain.RevisionMeta] = {
       topic.contentUri match {
         case Some(contentUri) =>
           parseArticleIdAndRevision(contentUri) match {
@@ -906,9 +906,9 @@ trait WriteService {
         case Some(contentUri) =>
           parseArticleIdAndRevision(contentUri) match {
             case (Success(articleId), _) => updateArticleWithRevisions(articleId, revisions)
-            case _                       => Success()
+            case _                       => Success(())
           }
-        case _ => Success()
+        case _ => Success(())
       }
 
       updateResult.map(_ => {

--- a/draft-api/src/main/scala/no/ndla/draftapi/service/WriteService.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/service/WriteService.scala
@@ -912,12 +912,9 @@ trait WriteService {
       updateResult.map(_ => {
         entity match {
           case Topic(id, _, _, _) =>
-            for {
-              topics    <- taxonomyApiClient.getChildNodes(id)
-              resources <- taxonomyApiClient.getChildResources(id)
-              _         <- topics.traverse(setRevisions(_, revisions))
-              _         <- resources.traverse(setRevisions(_, revisions))
-            } yield ()
+            taxonomyApiClient
+              .getChildResources(id)
+              .flatMap(resources => resources.traverse(setRevisions(_, revisions)))
           case _ => Success(())
         }
       })

--- a/draft-api/src/test/scala/no/ndla/draftapi/service/WriteServiceTest.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/service/WriteServiceTest.scala
@@ -1273,10 +1273,12 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
     when(taxonomyApiClient.getNode(nodeId)).thenReturn(Success(node))
     when(taxonomyApiClient.getChildNodes(nodeId)).thenReturn(Success(List(child)))
     when(taxonomyApiClient.getChildResources(nodeId)).thenReturn(Success(List(resource)))
+    when(taxonomyApiClient.getChildNodes(child.id)).thenReturn(Success(List.empty))
+    when(taxonomyApiClient.getChildResources(child.id)).thenReturn(Success(List.empty))
     when(draftRepository.withId(1)).thenReturn(Some(article1))
     when(draftRepository.withId(2)).thenReturn(Some(article2))
     when(draftRepository.withId(3)).thenReturn(Some(article3))
-    service.copyRevisionDates(nodeId) should be(Success(true))
+    service.copyRevisionDates(nodeId) should be(Success(()))
     verify(draftRepository, times(2)).updateArticle(any[Article], any[Boolean])(any[DBSession])
   }
 
@@ -1293,10 +1295,12 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
     when(taxonomyApiClient.getNode(nodeId)).thenReturn(Success(node))
     when(taxonomyApiClient.getChildNodes(nodeId)).thenReturn(Success(List(child)))
     when(taxonomyApiClient.getChildResources(nodeId)).thenReturn(Success(List(resource)))
+    when(taxonomyApiClient.getChildNodes(child.id)).thenReturn(Success(List.empty))
+    when(taxonomyApiClient.getChildResources(child.id)).thenReturn(Success(List.empty))
     when(draftRepository.withId(1)).thenReturn(Some(article1))
     when(draftRepository.withId(2)).thenReturn(Some(article2))
     when(draftRepository.withId(3)).thenReturn(Some(article3))
-    service.copyRevisionDates(nodeId) should be(Success(true))
+    service.copyRevisionDates(nodeId) should be(Success(()))
     verify(draftRepository, times(0)).updateArticle(any[Article], any[Boolean])(any[DBSession])
   }
 
@@ -1316,9 +1320,11 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
     when(taxonomyApiClient.getNode(nodeId)).thenReturn(Success(node))
     when(taxonomyApiClient.getChildNodes(nodeId)).thenReturn(Success(List(child)))
     when(taxonomyApiClient.getChildResources(nodeId)).thenReturn(Success(List(resource)))
+    when(taxonomyApiClient.getChildNodes(child.id)).thenReturn(Success(List.empty))
+    when(taxonomyApiClient.getChildResources(child.id)).thenReturn(Success(List.empty))
     when(draftRepository.withId(1)).thenReturn(Some(article1))
     when(draftRepository.withId(2)).thenReturn(Some(article2))
-    service.copyRevisionDates(nodeId) should be(Success(true))
+    service.copyRevisionDates(nodeId) should be(Success(()))
     verify(draftRepository, times(1)).updateArticle(any[Article], any[Boolean])(any[DBSession])
   }
 }

--- a/draft-api/src/test/scala/no/ndla/draftapi/service/WriteServiceTest.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/service/WriteServiceTest.scala
@@ -8,6 +8,7 @@
 package no.ndla.draftapi.service
 
 import no.ndla.draftapi.auth.{Role, UserInfo}
+import no.ndla.draftapi.integration.{Resource, Topic}
 import no.ndla.draftapi.model.api.{ArticleApiArticle, PartialArticleFields}
 import no.ndla.draftapi.model.domain.ArticleStatus.{DRAFT, PUBLISHED}
 import no.ndla.draftapi.model.domain._
@@ -17,7 +18,7 @@ import no.ndla.validation.{HtmlTagRules, ValidationMessage}
 import org.joda.time.DateTime
 import org.mockito.ArgumentMatchers._
 import org.mockito.invocation.InvocationOnMock
-import org.mockito.{ArgumentCaptor, Mockito}
+import org.mockito.{ArgumentCaptor, ArgumentMatchers, Mockito}
 import org.scalatra.servlet.FileItem
 import scalikejdbc.DBSession
 
@@ -1255,4 +1256,69 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
     )
   }
 
+  test("copyRevisionDates updates articles") {
+    val nodeId   = "urn:topic:1"
+    val node     = Topic(nodeId, "Topic", Some("urn:article:1"), List.empty)
+    val child    = Topic("urn:topic:2", "Topic", Some("urn:article:2"), List.empty)
+    val resource = Resource("urn:resource:1", "Resource", Some("urn:article:3"), List.empty)
+
+    val revisionMeta = RevisionMeta(LocalDateTime.now(), "Test revision", RevisionStatus.NeedsRevision)
+    val article1 = TestData.sampleDomainArticle.copy(
+      id = Some(1),
+      revisionMeta = Seq(revisionMeta)
+    )
+    val article2 = TestData.sampleDomainArticle.copy(id = Some(2))
+    val article3 = TestData.sampleDomainArticle.copy(id = Some(3))
+
+    when(taxonomyApiClient.getNode(nodeId)).thenReturn(Success(node))
+    when(taxonomyApiClient.getChildNodes(nodeId)).thenReturn(Success(List(child)))
+    when(taxonomyApiClient.getChildResources(nodeId)).thenReturn(Success(List(resource)))
+    when(draftRepository.withId(1)).thenReturn(Some(article1))
+    when(draftRepository.withId(2)).thenReturn(Some(article2))
+    when(draftRepository.withId(3)).thenReturn(Some(article3))
+    service.copyRevisionDates(nodeId) should be(Success(true))
+    verify(draftRepository, times(2)).updateArticle(any[Article], any[Boolean])(any[DBSession])
+  }
+
+  test("copyRevisionDates does nothing if revisionMeta is empty") {
+    val nodeId   = "urn:topic:1"
+    val node     = Topic(nodeId, "Topic", Some("urn:article:1"), List.empty)
+    val child    = Topic("urn:topic:2", "Topic", Some("urn:article:2"), List.empty)
+    val resource = Resource("urn:resource:1", "Resource", Some("urn:article:3"), List.empty)
+
+    val article1 = TestData.sampleDomainArticle.copy(id = Some(1))
+    val article2 = TestData.sampleDomainArticle.copy(id = Some(2))
+    val article3 = TestData.sampleDomainArticle.copy(id = Some(3))
+
+    when(taxonomyApiClient.getNode(nodeId)).thenReturn(Success(node))
+    when(taxonomyApiClient.getChildNodes(nodeId)).thenReturn(Success(List(child)))
+    when(taxonomyApiClient.getChildResources(nodeId)).thenReturn(Success(List(resource)))
+    when(draftRepository.withId(1)).thenReturn(Some(article1))
+    when(draftRepository.withId(2)).thenReturn(Some(article2))
+    when(draftRepository.withId(3)).thenReturn(Some(article3))
+    service.copyRevisionDates(nodeId) should be(Success(true))
+    verify(draftRepository, times(0)).updateArticle(any[Article], any[Boolean])(any[DBSession])
+  }
+
+  test("copyRevisionDates skips empty contentUris") {
+    val nodeId   = "urn:topic:1"
+    val node     = Topic(nodeId, "Topic", Some("urn:article:1"), List.empty)
+    val child    = Topic("urn:topic:2", "Topic", None, List.empty)
+    val resource = Resource("urn:resource:1", "Resource", Some("urn:article:2"), List.empty)
+
+    val revisionMeta = RevisionMeta(LocalDateTime.now(), "Test revision", RevisionStatus.NeedsRevision)
+    val article1 = TestData.sampleDomainArticle.copy(
+      id = Some(1),
+      revisionMeta = Seq(revisionMeta)
+    )
+    val article2 = TestData.sampleDomainArticle.copy(id = Some(2))
+
+    when(taxonomyApiClient.getNode(nodeId)).thenReturn(Success(node))
+    when(taxonomyApiClient.getChildNodes(nodeId)).thenReturn(Success(List(child)))
+    when(taxonomyApiClient.getChildResources(nodeId)).thenReturn(Success(List(resource)))
+    when(draftRepository.withId(1)).thenReturn(Some(article1))
+    when(draftRepository.withId(2)).thenReturn(Some(article2))
+    service.copyRevisionDates(nodeId) should be(Success(true))
+    verify(draftRepository, times(1)).updateArticle(any[Article], any[Boolean])(any[DBSession])
+  }
 }

--- a/draft-api/src/test/scala/no/ndla/draftapi/service/WriteServiceTest.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/service/WriteServiceTest.scala
@@ -1272,14 +1272,12 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
 
     when(taxonomyApiClient.getNode(nodeId)).thenReturn(Success(node))
     when(taxonomyApiClient.getChildNodes(nodeId)).thenReturn(Success(List(child)))
-    when(taxonomyApiClient.getChildResources(nodeId)).thenReturn(Success(List(resource)))
-    when(taxonomyApiClient.getChildNodes(child.id)).thenReturn(Success(List.empty))
-    when(taxonomyApiClient.getChildResources(child.id)).thenReturn(Success(List.empty))
+    when(taxonomyApiClient.getChildResources(anyString())).thenReturn(Success(List(resource)))
     when(draftRepository.withId(1)).thenReturn(Some(article1))
     when(draftRepository.withId(2)).thenReturn(Some(article2))
     when(draftRepository.withId(3)).thenReturn(Some(article3))
     service.copyRevisionDates(nodeId) should be(Success(()))
-    verify(draftRepository, times(2)).updateArticle(any[Article], any[Boolean])(any[DBSession])
+    verify(draftRepository, times(3)).updateArticle(any[Article], any[Boolean])(any[DBSession])
   }
 
   test("copyRevisionDates does nothing if revisionMeta is empty") {
@@ -1294,9 +1292,7 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
 
     when(taxonomyApiClient.getNode(nodeId)).thenReturn(Success(node))
     when(taxonomyApiClient.getChildNodes(nodeId)).thenReturn(Success(List(child)))
-    when(taxonomyApiClient.getChildResources(nodeId)).thenReturn(Success(List(resource)))
-    when(taxonomyApiClient.getChildNodes(child.id)).thenReturn(Success(List.empty))
-    when(taxonomyApiClient.getChildResources(child.id)).thenReturn(Success(List.empty))
+    when(taxonomyApiClient.getChildResources(anyString())).thenReturn(Success(List(resource)))
     when(draftRepository.withId(1)).thenReturn(Some(article1))
     when(draftRepository.withId(2)).thenReturn(Some(article2))
     when(draftRepository.withId(3)).thenReturn(Some(article3))
@@ -1319,12 +1315,10 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
 
     when(taxonomyApiClient.getNode(nodeId)).thenReturn(Success(node))
     when(taxonomyApiClient.getChildNodes(nodeId)).thenReturn(Success(List(child)))
-    when(taxonomyApiClient.getChildResources(nodeId)).thenReturn(Success(List(resource)))
-    when(taxonomyApiClient.getChildNodes(child.id)).thenReturn(Success(List.empty))
-    when(taxonomyApiClient.getChildResources(child.id)).thenReturn(Success(List.empty))
+    when(taxonomyApiClient.getChildResources(anyString())).thenReturn(Success(List(resource)))
     when(draftRepository.withId(1)).thenReturn(Some(article1))
     when(draftRepository.withId(2)).thenReturn(Some(article2))
     service.copyRevisionDates(nodeId) should be(Success(()))
-    verify(draftRepository, times(1)).updateArticle(any[Article], any[Boolean])(any[DBSession])
+    verify(draftRepository, times(2)).updateArticle(any[Article], any[Boolean])(any[DBSession])
   }
 }

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/model/api/SearchParams.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/model/api/SearchParams.scala
@@ -11,32 +11,17 @@ package no.ndla.learningpathapi.model.api
 import org.scalatra.swagger.annotations.{ApiModel, ApiModelProperty}
 import scala.annotation.meta.field
 
+// format: off
 @ApiModel(description = "The search parameters")
 case class SearchParams(
     @(ApiModelProperty @field)(description = "The search query") query: Option[String],
-    @(ApiModelProperty @field)(
-      description = "The ISO 639-1 language code describing language used in query-params"
-    ) language: Option[String],
+    @(ApiModelProperty @field)(description = "The ISO 639-1 language code describing language used in query-params") language: Option[String],
     @(ApiModelProperty @field)(description = "The page number of the search hits to display.") page: Option[Int],
-    @(ApiModelProperty @field)(description = "The number of search hits to display for each page.") pageSize: Option[
-      Int
-    ],
-    @(ApiModelProperty @field)(description = "Return only learning paths that have one of the provided ids") ids: List[
-      Long
-    ],
-    @(ApiModelProperty @field)(
-      description = "Return only learning paths that are tagged with this exact tag."
-    ) tag: Option[String],
-    @(ApiModelProperty @field)(description = "The sorting used on results. Default is by -relevance.") sort: Option[
-      String
-    ],
-    @(ApiModelProperty @field)(
-      description = "Return all matched learning paths whether they exist on selected language or not."
-    ) fallback: Option[Boolean],
-    @(ApiModelProperty @field)(
-      description = "Return only learning paths that have the provided verification status."
-    ) verificationStatus: Option[String],
-    @(ApiModelProperty @field)(
-      description = "A search context retrieved from the response header of a previous search."
-    ) scrollId: Option[String]
+    @(ApiModelProperty @field)(description = "The number of search hits to display for each page.") pageSize: Option[Int],
+    @(ApiModelProperty @field)(description = "Return only learning paths that have one of the provided ids") ids: List[Long],
+    @(ApiModelProperty @field)(description = "Return only learning paths that are tagged with this exact tag.") tag: Option[String],
+    @(ApiModelProperty @field)(description = "The sorting used on results. Default is by -relevance.") sort: Option[String],
+    @(ApiModelProperty @field)(description = "Return all matched learning paths whether they exist on selected language or not.") fallback: Option[Boolean],
+    @(ApiModelProperty @field)(description = "Return only learning paths that have the provided verification status.") verificationStatus: Option[String],
+    @(ApiModelProperty @field)(description = "A search context retrieved from the response header of a previous search.") scrollId: Option[String]
 )


### PR DESCRIPTION
Fixes NDLANO/Issues#3087

Legger til endepunkt som tar inn en node-id og henter ut revisionMeta for tilhørende artikkel. Oppdaterer rekursivt alle underliggende artikler.