### PR TITLE
Handle non-matching cases in `parseArticleIdAndRevision`

### DIFF
--- a/.github/workflows/common_ci.yml
+++ b/.github/workflows/common_ci.yml
@@ -1,0 +1,51 @@
+name: 'CI: common'
+on:
+  workflow_dispatch:
+    inputs: {}
+  push:
+    paths:
+      - common/**
+      - project/commonlib.scala
+      - project/Dependencies.scala
+      - project/Module.scala
+  pull_request:
+    paths:
+      - common/**
+      - project/commonlib.scala
+      - project/Dependencies.scala
+      - project/Module.scala
+env:
+  AWS_ACCESS_KEY_ID: ${{ secrets.CI_AWS_CLIENT_ID }}
+  AWS_DEFAULT_REGION: eu-west-1
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.CI_AWS_CLIENT_SECRET }}
+  NDLA_AWS_ECR_REPO: ${{ secrets.NDLA_AWS_ECR_REPO }}
+  CI_RELEASE_ROLE: ${{ secrets.CI_RELEASE_ROLE }}
+  CI_GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
+  DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
+  DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+  NDLA_RELEASES: ${{ secrets.NDLA_RELEASES }}
+  PACT_BROKER_PASSWORD: ${{ secrets.PACT_BROKER_PASSWORD }}
+  PACT_BROKER_URL: ${{ secrets.PACT_BROKER_URL }}
+  PACT_BROKER_USERNAME: ${{ secrets.PACT_BROKER_USERNAME }}
+  COMPONENT: common
+jobs:
+  unit_tests:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: coursier/cache-action@v6
+      - uses: olafurpg/setup-scala@v10
+        with:
+          java-version: adopt@1.11
+      - name: Login to ECR repo
+        run: RES=$(aws sts assume-role --role-arn $CI_RELEASE_ROLE --role-session-name
+          github-actions-ecr-login) AWS_ACCESS_KEY_ID=$(echo $RES | jq -r .Credentials.AccessKeyId)
+          AWS_SECRET_ACCESS_KEY=$(echo $RES | jq -r .Credentials.SecretAccessKey) AWS_SESSION_TOKEN=$(echo
+          $RES | jq -r .Credentials.SessionToken) aws ecr get-login-password --region
+          eu-central-1 | docker login --username AWS --password-stdin $NDLA_AWS_ECR_REPO
+      - name: Login to dockerhub
+        run: echo $DOCKER_HUB_PASSWORD | docker login --username $DOCKER_HUB_USERNAME
+          --password-stdin
+      - name: Unit tests
+        run: sbt common/test

--- a/article-api/src/main/scala/no/ndla/articleapi/controller/ArticleControllerV2.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/controller/ArticleControllerV2.scala
@@ -16,7 +16,7 @@ import no.ndla.articleapi.model.domain.{ArticleIds, Sort}
 import no.ndla.articleapi.service.search.{ArticleSearchService, SearchConverterService}
 import no.ndla.articleapi.service.{ConverterService, ReadService, WriteService}
 import no.ndla.articleapi.validation.ContentValidator
-import no.ndla.common.ContentURIUtil.parseArticleIdAndRevision
+import no.ndla.common.ContentURIUtil.{NotUrnPatternException, parseArticleIdAndRevision}
 import no.ndla.language.Language.AllLanguages
 import org.json4s.ext.JavaTimeSerializers
 import org.json4s.{DefaultFormats, Formats}
@@ -356,7 +356,9 @@ trait ArticleControllerV2 {
       )
     ) {
       parseArticleIdAndRevision(params(this.articleId.paramName)) match {
-        case (Failure(ex), _) => errorHandler(ex)
+        case (Failure(_), _) =>
+          val ex = digitsOnlyError(articleId.paramName).exception
+          errorHandler(ex)
         case (Success(articleId), inlineRevision) =>
           val language = paramOrDefault(this.language.paramName, AllLanguages)
           val fallback = booleanOrDefault(this.fallback.paramName, default = false)

--- a/article-api/src/test/scala/no/ndla/articleapi/controller/ArticleControllerV2Test.scala
+++ b/article-api/src/test/scala/no/ndla/articleapi/controller/ArticleControllerV2Test.scala
@@ -65,7 +65,7 @@ class ArticleControllerV2Test extends UnitSuite with TestEnvironment with Scalat
     }
   }
 
-  test("/<article_id> should return 400 if the article was not found withIdV2") {
+  test("/<article_id> should return 400 if the id is not valid") {
     get(s"/test/one") {
       status should equal(400)
     }
@@ -146,18 +146,6 @@ class ArticleControllerV2Test extends UnitSuite with TestEnvironment with Scalat
     get("/test/tag-search/") {
       status should equal(200)
     }
-  }
-
-  test("That parsing articleId with and without revision works as expected") {
-    controller.parseArticleIdAndRevision("urn:article:15") should be((Success(15), None))
-    controller.parseArticleIdAndRevision("urn:article:15#10") should be((Success(15), Some(10)))
-    controller.parseArticleIdAndRevision("15") should be((Success(15), None))
-    controller.parseArticleIdAndRevision("15#100") should be((Success(15), Some(100)))
-
-    val (failed, Some(100)) = controller.parseArticleIdAndRevision("#100")
-    failed.isFailure should be(true)
-    val (failed2, None) = controller.parseArticleIdAndRevision("")
-    failed2.isFailure should be(true)
   }
 
   test("That initial search-context doesn't scroll") {

--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ lazy val `learningpath-api` = Module.setup(project in file("./learningpath-api/"
 lazy val `oembed-proxy`     = Module.setup(project in file("./oembed-proxy/"),     oembedproxy,       deps = Seq(network,                                                         common))
 lazy val `search-api`       = Module.setup(project in file("./search-api/"),       searchapi,         deps = Seq(network, mapping, language,             scalatestsuite % "test", common, search))
 
-lazy val common             = Module.setup(project in file("./common/"),           commonlib)
+lazy val common             = Module.setup(project in file("./common/"),           commonlib,         deps = Seq(                                        scalatestsuite % "test"))
 lazy val scalatestsuite     = Module.setup(project in file("./scalatestsuite/"),   scalatestsuitelib, deps = Seq(network))
 lazy val network            = Module.setup(project in file("./network/"),          networklib)
 lazy val language           = Module.setup(project in file("./language/"),         languagelib)

--- a/common/src/main/scala/no/ndla/common/ContentURIUtil.scala
+++ b/common/src/main/scala/no/ndla/common/ContentURIUtil.scala
@@ -1,17 +1,23 @@
 package no.ndla.common
 
-import scala.util.Try
+import scala.util.{Failure, Try}
 
 object ContentURIUtil {
+  case class NotUrnPatternException(message: String) extends RuntimeException(message)
 
   private val Pattern = """(urn:)?(article:)?(\d*)#?(\d*)""".r
-  def parseArticleIdAndRevision(idString: String): (Try[Long], Option[Int]) = {
+  type Result = (Try[Long], Option[Int])
+  def parseArticleIdAndRevision(idString: String): Result = {
     idString match {
       case Pattern(_, _, id, rev) =>
         (
           Try(id.toLong),
           Try(rev.toInt).toOption
         )
+      case _ =>
+        Failure(
+          NotUrnPatternException("Pattern passed to `parseArticleIdAndRevision` did not match urn pattern.")
+        ) -> None
     }
   }
 }

--- a/common/src/test/scala/no/ndla/common/ContentURIUtilTest.scala
+++ b/common/src/test/scala/no/ndla/common/ContentURIUtilTest.scala
@@ -1,0 +1,32 @@
+package no.ndla.common
+
+import no.ndla.common.ContentURIUtil.NotUrnPatternException
+import no.ndla.scalatestsuite.UnitTestSuite
+
+import scala.util.{Failure, Success}
+
+class ContentURIUtilTest extends UnitTestSuite {
+
+  test("That parsing articleId with and without revision works as expected") {
+    ContentURIUtil.parseArticleIdAndRevision("urn:article:15") should be((Success(15), None))
+    ContentURIUtil.parseArticleIdAndRevision("urn:article:15#10") should be((Success(15), Some(10)))
+    ContentURIUtil.parseArticleIdAndRevision("15") should be((Success(15), None))
+    ContentURIUtil.parseArticleIdAndRevision("15#100") should be((Success(15), Some(100)))
+
+    val (failed, Some(100)) = ContentURIUtil.parseArticleIdAndRevision("#100")
+    failed.isFailure should be(true)
+    val (failed2, None) = ContentURIUtil.parseArticleIdAndRevision("")
+    failed2.isFailure should be(true)
+  }
+
+  test("That non-matching idString will fail and not throw exception") {
+    val result = ContentURIUtil.parseArticleIdAndRevision("one")
+    result should be(
+      (
+        Failure(NotUrnPatternException("Pattern passed to `parseArticleIdAndRevision` did not match urn pattern.")),
+        None
+      )
+    )
+  }
+
+}


### PR DESCRIPTION
Oppdaget ikke vi fjernet en case her, og siden CI er litt på kjøret frem til vi får ryddet opp i pact så var det litt vanskelig å se i testene også. Denne fikser at `parseArticleIdAndRevision` kunne (og gjorde i article-api testene) kaste en exception istedet for å returnere `Failure`.