### PR TITLE
Instantiate `R__SetArticleTypeFromTaxonomy` migration

### DIFF
--- a/article-api/src/main/scala/no/ndla/articleapi/DBMigrator.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/DBMigrator.scala
@@ -11,7 +11,11 @@ package no.ndla.articleapi
 import articleapi.db.migrationwithdependencies.{
   R__SetArticleLanguageFromTaxonomy,
   R__SetArticleTypeFromTaxonomy,
-  V8__CopyrightFormatUpdated
+  V20__UpdateH5PDomainForFF,
+  V22__UpdateH5PDomainForFFVisualElement,
+  V33__ConvertLanguageUnknown,
+  V8__CopyrightFormatUpdated,
+  V9__TranslateUntranslatedAuthors
 }
 import no.ndla.articleapi.integration.DataSource
 import org.flywaydb.core.Flyway
@@ -29,7 +33,11 @@ trait DBMigrator {
         .javaMigrations(
           new R__SetArticleLanguageFromTaxonomy(props),
           new R__SetArticleTypeFromTaxonomy(props),
-          new V8__CopyrightFormatUpdated(props)
+          new V8__CopyrightFormatUpdated(props),
+          new V9__TranslateUntranslatedAuthors(props),
+          new V20__UpdateH5PDomainForFF(props),
+          new V22__UpdateH5PDomainForFFVisualElement(props),
+          new V33__ConvertLanguageUnknown(props)
         )
         .locations("articleapi/db/migration")
         .table("schema_version") // Flyway's default table name changed, so we specify the old one.

--- a/article-api/src/main/scala/no/ndla/articleapi/DBMigrator.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/DBMigrator.scala
@@ -8,7 +8,11 @@
 
 package no.ndla.articleapi
 
-import articleapi.db.migrationwithdependencies.{R__SetArticleLanguageFromTaxonomy, V8__CopyrightFormatUpdated}
+import articleapi.db.migrationwithdependencies.{
+  R__SetArticleLanguageFromTaxonomy,
+  R__SetArticleTypeFromTaxonomy,
+  V8__CopyrightFormatUpdated
+}
 import no.ndla.articleapi.integration.DataSource
 import org.flywaydb.core.Flyway
 import org.flywaydb.core.api.output.MigrateResult
@@ -24,7 +28,7 @@ trait DBMigrator {
         .configure()
         .javaMigrations(
           new R__SetArticleLanguageFromTaxonomy(props),
-          new R__SetArticleLanguageFromTaxonomy(props),
+          new R__SetArticleTypeFromTaxonomy(props),
           new V8__CopyrightFormatUpdated(props)
         )
         .locations("articleapi/db/migration")


### PR DESCRIPTION
Vi hadde en bug etter config-endringen hvor vi instansierte den samme migreringen to ganger istedetfor to forskjellige.
Ooog vi hadde glemt mange migreringer i article-api :^)