### PR TITLE
Add support for subject filter in concept-list

### DIFF
--- a/validation/src/main/resources/embed-tag-rules.json
+++ b/validation/src/main/resources/embed-tag-rules.json
@@ -110,7 +110,7 @@
         "data-resource"
       ],
       "optional": [
-        [ "data-tag", "data-title" ],
+        [ "data-tag", "data-title", "data-subject" ],
         [ "data-resource_id", "data-recursive" ]
       ]
     },

--- a/validation/src/main/resources/embed-tag-rules.json
+++ b/validation/src/main/resources/embed-tag-rules.json
@@ -110,7 +110,7 @@
         "data-resource"
       ],
       "optional": [
-        [ "data-tag", "data-title", "data-subject" ],
+        [ "data-tag", "data-title", "data-subject-id" ],
         [ "data-resource_id", "data-recursive" ]
       ]
     },

--- a/validation/src/main/scala/no/ndla/validation/TagRules.scala
+++ b/validation/src/main/scala/no/ndla/validation/TagRules.scala
@@ -80,7 +80,7 @@ object TagAttributes extends Enumeration {
   val DataContent: TagAttributes.Value     = Value("data-code-content")
   val DataDisplay: TagAttributes.Value     = Value("data-display")
   val DataRecursive: TagAttributes.Value   = Value("data-recursive")
-  val DataSubject: TagAttributes.Value   = Value("data-subject")
+  val DataSubjectId: TagAttributes.Value   = Value("data-subject-id")
   val DataTag: TagAttributes.Value         = Value("data-tag")
 
   val DataUpperLeftY: TagAttributes.Value  = Value("data-upper-left-y")

--- a/validation/src/main/scala/no/ndla/validation/TagRules.scala
+++ b/validation/src/main/scala/no/ndla/validation/TagRules.scala
@@ -80,6 +80,7 @@ object TagAttributes extends Enumeration {
   val DataContent: TagAttributes.Value     = Value("data-code-content")
   val DataDisplay: TagAttributes.Value     = Value("data-display")
   val DataRecursive: TagAttributes.Value   = Value("data-recursive")
+  val DataSubject: TagAttributes.Value   = Value("data-subject")
   val DataTag: TagAttributes.Value         = Value("data-tag")
 
   val DataUpperLeftY: TagAttributes.Value  = Value("data-upper-left-y")

--- a/validation/src/test/scala/no/ndla/validation/EmbedTagValidatorTest.scala
+++ b/validation/src/test/scala/no/ndla/validation/EmbedTagValidatorTest.scala
@@ -297,7 +297,8 @@ class EmbedTagValidatorTest extends UnitSuite {
       Map(
         TagAttributes.DataResource -> ResourceType.ConceptList.toString,
         TagAttributes.DataTitle    -> "Liste",
-        TagAttributes.DataTag      -> "Liste:kategori:kategori2"
+        TagAttributes.DataTag      -> "Liste:kategori:kategori2",
+        TagAttributes.DataSubjectId      -> "urn:subject:123"
       )
     )
     embedTagValidator.validate("content", tag).size should be(0)


### PR DESCRIPTION
Relatert til NDLANO/Issues#3015

Legger til støtte for fag i concept-list embed for å kunne filtrere på det i tillegg til nøkkelord.