### PR TITLE
3146 add versionlog when updating revisionmeta

### DIFF
--- a/draft-api/src/main/scala/draftapi/db/migration/V37__AddIdToAllRevisionMeta.scala
+++ b/draft-api/src/main/scala/draftapi/db/migration/V37__AddIdToAllRevisionMeta.scala
@@ -1,0 +1,86 @@
+/*
+ * Part of NDLA draft-api
+ * Copyright (C) 2022 NDLA
+ *
+ * See LICENSE
+ */
+
+package draftapi.db.migration
+
+import enumeratum.Json4s
+import no.ndla.draftapi.model.domain.RevisionStatus
+import org.flywaydb.core.api.migration.{BaseJavaMigration, Context}
+import org.json4s.ext.{JavaTimeSerializers, JavaTypesSerializers}
+import org.json4s.native.JsonMethods.{compact, parse, render}
+import org.json4s.{Extraction, Formats}
+import org.postgresql.util.PGobject
+import scalikejdbc.{DB, DBSession, _}
+
+import java.time.LocalDateTime
+import java.util.UUID
+
+class V37__AddIdToAllRevisionMeta extends BaseJavaMigration {
+  implicit val formats: Formats = org.json4s.DefaultFormats ++ JavaTimeSerializers.all ++ JavaTypesSerializers.all + Json4s.serializer(RevisionStatus)
+
+  override def migrate(context: Context): Unit = {
+    val db = DB(context.getConnection)
+    db.autoClose(false)
+
+    db.withinTx { implicit session =>
+      migrateArticles
+    }
+  }
+
+  def migrateArticles(implicit session: DBSession): Unit = {
+    val count        = countAllArticles.get
+    var numPagesLeft = (count / 1000) + 1
+    var offset       = 0L
+
+    while (numPagesLeft > 0) {
+      allArticles(offset * 1000).map { case (id, document) =>
+        updateArticle(convertArticleUpdate(document), id)
+      }
+      numPagesLeft -= 1
+      offset += 1
+    }
+  }
+
+  def countAllArticles(implicit session: DBSession): Option[Long] = {
+    sql"select count(*) from articledata where document is not NULL"
+      .map(rs => rs.long("count"))
+      .single()
+  }
+
+  def allArticles(offset: Long)(implicit session: DBSession): Seq[(Long, String)] = {
+    sql"select id, document, article_id from articledata where document is not null order by id limit 1000 offset $offset"
+      .map(rs => {
+        (rs.long("id"), rs.string("document"))
+      })
+      .list()
+  }
+
+  def updateArticle(document: String, id: Long)(implicit session: DBSession): Int = {
+    val dataObject = new PGobject()
+    dataObject.setType("jsonb")
+    dataObject.setValue(document)
+
+    sql"update articledata set document = $dataObject where id = $id"
+      .update()
+  }
+
+  private[migration] def convertArticleUpdate(document: String): String = {
+    val oldArticle = parse(document)
+
+    val newArticle = oldArticle.mapField {
+      case ("revisionMeta", revisionMeta) =>
+        val oldMetas = revisionMeta.extract[Seq[V36__RevisionMeta]]
+        val newMetas = oldMetas.map(old => V37__RevisionMeta(UUID.randomUUID(), old.revisionDate, old.note, old.status))
+        ("revisionMeta", Extraction.decompose(newMetas))
+      case x => x
+    }
+    compact(render(newArticle))
+  }
+}
+
+case class V36__RevisionMeta(revisionDate: LocalDateTime, note: String, status: RevisionStatus)
+case class V37__RevisionMeta(id: UUID, revisionDate: LocalDateTime, note: String, status: RevisionStatus)

--- a/draft-api/src/main/scala/draftapi/db/migration/V37__AddIdToAllRevisionMeta.scala
+++ b/draft-api/src/main/scala/draftapi/db/migration/V37__AddIdToAllRevisionMeta.scala
@@ -20,7 +20,8 @@ import java.time.LocalDateTime
 import java.util.UUID
 
 class V37__AddIdToAllRevisionMeta extends BaseJavaMigration {
-  implicit val formats: Formats = org.json4s.DefaultFormats ++ JavaTimeSerializers.all ++ JavaTypesSerializers.all + Json4s.serializer(RevisionStatus)
+  implicit val formats: Formats =
+    org.json4s.DefaultFormats ++ JavaTimeSerializers.all ++ JavaTypesSerializers.all + Json4s.serializer(RevisionStatus)
 
   override def migrate(context: Context): Unit = {
     val db = DB(context.getConnection)

--- a/draft-api/src/main/scala/no/ndla/draftapi/model/api/RevisionMeta.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/model/api/RevisionMeta.scala
@@ -14,6 +14,7 @@ import java.time.LocalDateTime
 // format: off
 @ApiModel(description = "Information about the editorial notes")
 case class RevisionMeta(
+    @ApiModelProperty(description = "An unique uuid of the revision. If none supplied, one is generated.") id: Option[String],
     @ApiModelProperty(description = "A date on which the article would need to be revised") revisionDate: LocalDateTime,
     @ApiModelProperty(description = "Notes to keep track of what needs to happen before revision") note: String,
     @ApiModelProperty(description = "Status of a revision, either 'revised' or 'needs-revision'", allowableValues = "revised,needs-revision") status: String

--- a/draft-api/src/main/scala/no/ndla/draftapi/model/domain/Content.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/model/domain/Content.scala
@@ -12,7 +12,7 @@ import no.ndla.draftapi.{DraftApiProperties, Props}
 import no.ndla.language.Language.getSupportedLanguages
 import no.ndla.validation.{ValidationException, ValidationMessage}
 import org.json4s.FieldSerializer._
-import org.json4s.ext.{EnumNameSerializer, JavaTimeSerializers}
+import org.json4s.ext.{EnumNameSerializer, JavaTimeSerializers, JavaTypesSerializers}
 import org.json4s.native.Serialization._
 import org.json4s.{DefaultFormats, FieldSerializer, Formats}
 import scalikejdbc._
@@ -133,7 +133,8 @@ trait DBArticle {
       Json4s.serializer(ArticleType) +
       Json4s.serializer(RevisionStatus) +
       new EnumNameSerializer(Availability) ++
-      JavaTimeSerializers.all
+      JavaTimeSerializers.all ++
+      JavaTypesSerializers.all
 
     val repositorySerializer = jsonEncoder +
       FieldSerializer[Article](

--- a/draft-api/src/main/scala/no/ndla/draftapi/model/domain/RevisionMeta.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/model/domain/RevisionMeta.scala
@@ -10,8 +10,10 @@ package no.ndla.draftapi.model.domain
 import enumeratum._
 
 import java.time.LocalDateTime
+import java.util.UUID
 
 case class RevisionMeta(
+    id: UUID,
     revisionDate: LocalDateTime,
     note: String,
     status: RevisionStatus

--- a/draft-api/src/main/scala/no/ndla/draftapi/service/ConverterService.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/service/ConverterService.scala
@@ -25,7 +25,7 @@ import org.joda.time.DateTime
 import org.joda.time.format.ISODateTimeFormat
 import org.jsoup.nodes.Element
 
-import java.util.Date
+import java.util.{Date, UUID}
 import scala.jdk.CollectionConverters._
 import scala.util.control.Exception.allCatch
 import scala.util.{Failure, Success, Try}
@@ -103,6 +103,7 @@ trait ConverterService {
 
     private def toDomainRevisionMeta(revisionMeta: api.RevisionMeta): domain.RevisionMeta = {
       domain.RevisionMeta(
+        id = revisionMeta.id.map(UUID.fromString).getOrElse(UUID.randomUUID()),
         revisionDate = revisionMeta.revisionDate,
         note = revisionMeta.note,
         status = RevisionStatus.fromStringDefault(revisionMeta.status)
@@ -111,6 +112,7 @@ trait ConverterService {
 
     private def toApiRevisionMeta(revisionMeta: domain.RevisionMeta): api.RevisionMeta = {
       api.RevisionMeta(
+        id = Some(revisionMeta.id.toString),
         revisionDate = revisionMeta.revisionDate,
         note = revisionMeta.note,
         status = revisionMeta.status.entryName

--- a/draft-api/src/main/scala/no/ndla/draftapi/service/WriteService.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/service/WriteService.scala
@@ -326,19 +326,21 @@ trait WriteService {
       val newIds       = updatedArticle.revisionMeta.map(rm => rm.id).toSet
       val deleted = oldRevisions
         .filterNot(old => newIds.contains(old.id))
-        .map(del => EditorNote(f"Slettet revisjon ${del.note}.", user.id, updatedArticle.status, new Date()))
+        .map(del => domain.EditorNote(s"Slettet revisjon ${del.note}.", user.id, updatedArticle.status, new Date()))
 
       val notes = updatedArticle.revisionMeta.flatMap {
         case rm if !oldIds.contains(rm.id) && rm.status == RevisionStatus.Revised =>
-          EditorNote(f"Lagt til og fullført revisjon ${rm.note}.", user.id, updatedArticle.status, new Date()).some
+          domain
+            .EditorNote(s"Lagt til og fullført revisjon ${rm.note}.", user.id, updatedArticle.status, new Date())
+            .some
         case rm if !oldIds.contains(rm.id) =>
-          EditorNote(f"Lagt til revisjon ${rm.note}.", user.id, updatedArticle.status, new Date()).some
+          domain.EditorNote(s"Lagt til revisjon ${rm.note}.", user.id, updatedArticle.status, new Date()).some
         case rm =>
           oldRevisions.find(_.id == rm.id) match {
             case Some(old) if old.status != rm.status && rm.status == RevisionStatus.Revised =>
-              EditorNote(f"Fullført revisjon ${rm.note}.", user.id, updatedArticle.status, new Date()).some
+              domain.EditorNote(s"Fullført revisjon ${rm.note}.", user.id, updatedArticle.status, new Date()).some
             case Some(old) if old != rm =>
-              EditorNote(f"Endret revisjon ${rm.note}.", user.id, updatedArticle.status, new Date()).some
+              domain.EditorNote(s"Endret revisjon ${rm.note}.", user.id, updatedArticle.status, new Date()).some
             case _ => None
           }
       }

--- a/draft-api/src/test/scala/no/ndla/draftapi/service/WriteServiceTest.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/service/WriteServiceTest.scala
@@ -24,7 +24,7 @@ import scalikejdbc.DBSession
 
 import java.io.ByteArrayInputStream
 import java.time.LocalDateTime
-import java.util.Date
+import java.util.{Date, UUID}
 import scala.util.{Failure, Success, Try}
 
 class WriteServiceTest extends UnitSuite with TestEnvironment {
@@ -971,21 +971,25 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
       ),
       revisionMeta = Seq(
         RevisionMeta(
+          UUID.randomUUID(),
           yesterday,
           "Test1",
           RevisionStatus.Revised
         ),
         RevisionMeta(
+          UUID.randomUUID(),
           tomorrow,
           "Test2",
           RevisionStatus.Revised
         ),
         RevisionMeta(
+          UUID.randomUUID(),
           tomorrow,
           "Test3",
           RevisionStatus.NeedsRevision
         ),
         RevisionMeta(
+          UUID.randomUUID(),
           afterTomorrow,
           "Test4",
           RevisionStatus.NeedsRevision
@@ -1262,7 +1266,7 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
     val child    = Topic("urn:topic:2", "Topic", Some("urn:article:2"), List.empty)
     val resource = Resource("urn:resource:1", "Resource", Some("urn:article:3"), List.empty)
 
-    val revisionMeta = RevisionMeta(LocalDateTime.now(), "Test revision", RevisionStatus.NeedsRevision)
+    val revisionMeta = RevisionMeta(UUID.randomUUID(), LocalDateTime.now(), "Test revision", RevisionStatus.NeedsRevision)
     val article1 = TestData.sampleDomainArticle.copy(
       id = Some(1),
       revisionMeta = Seq(revisionMeta)
@@ -1306,7 +1310,7 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
     val child    = Topic("urn:topic:2", "Topic", None, List.empty)
     val resource = Resource("urn:resource:1", "Resource", Some("urn:article:2"), List.empty)
 
-    val revisionMeta = RevisionMeta(LocalDateTime.now(), "Test revision", RevisionStatus.NeedsRevision)
+    val revisionMeta = RevisionMeta(UUID.randomUUID(), LocalDateTime.now(), "Test revision", RevisionStatus.NeedsRevision)
     val article1 = TestData.sampleDomainArticle.copy(
       id = Some(1),
       revisionMeta = Seq(revisionMeta)


### PR DESCRIPTION
NDLANO/Issues#3146

Legger til innslag i endringslogg ved behandling av revisjonsdatoer. Måtte legge til en id til revisionMeta for å kunne spore endringer.

