### PR TITLE
Sjekker at minst en revision er uferdig.

### DIFF
--- a/article-api/src/main/scala/no/ndla/articleapi/ArticleSwagger.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/ArticleSwagger.scala
@@ -47,8 +47,7 @@ trait ArticleApiInfo {
   class ArticleSwagger extends Swagger("2.0", "1.0", ArticleApiInfo.apiInfo) {
 
     private def writeRolesInTest: List[String] = {
-      val writeRoles = List(props.DraftRoleWithWriteAccess, props.RoleWithWriteAccess)
-      writeRoles.map(_.replace(":", "-test:"))
+      List(props.DraftRoleWithWriteAccess, props.RoleWithWriteAccess)
     }
 
     addAuthorization(

--- a/article-api/src/main/scala/no/ndla/articleapi/validation/ContentValidator.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/validation/ContentValidator.scala
@@ -8,7 +8,7 @@
 
 package no.ndla.articleapi.validation
 
-import no.ndla.articleapi.{ArticleApiProperties, Props}
+import no.ndla.articleapi.Props
 import no.ndla.articleapi.integration.DraftApiClient
 import no.ndla.articleapi.model.domain._
 import no.ndla.language.model.{Iso639, LanguageField}
@@ -16,6 +16,7 @@ import no.ndla.mapping.License.getLicense
 import no.ndla.validation.HtmlTagRules.stringToJsoupDocument
 import no.ndla.validation.{TextValidator, ValidationException, ValidationMessage}
 
+import java.time.LocalDateTime
 import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Success, Try}
 
@@ -53,12 +54,19 @@ trait ContentValidator {
         article.requiredLibraries.flatMap(validateRequiredLibrary) ++
         article.metaImage.flatMap(validateMetaImage) ++
         article.visualElement.flatMap(v => validateVisualElement(v)) ++
-        validateArticleType(article.articleType)
-
+        validateArticleType(article.articleType) ++
+        validateRevisionDate(article.revisionDate)
       if (validationErrors.isEmpty) {
         Success(article)
       } else {
         Failure(new ValidationException(errors = validationErrors))
+      }
+    }
+
+    def validateRevisionDate(revisionDate: Option[LocalDateTime]): Seq[ValidationMessage] = {
+      revisionDate match {
+        case None => Seq(ValidationMessage("revisionDate", "Article must have at least one unfinished revision"))
+        case _    => Seq.empty
       }
     }
 

--- a/article-api/src/test/scala/no/ndla/articleapi/TestData.scala
+++ b/article-api/src/test/scala/no/ndla/articleapi/TestData.scala
@@ -14,6 +14,8 @@ import no.ndla.mapping.License
 import no.ndla.validation.EmbedTagRules.ResourceHtmlEmbedTag
 import org.joda.time.{DateTime, DateTimeZone}
 
+import java.time.LocalDateTime
+
 trait TestData {
   this: Props =>
 
@@ -141,7 +143,7 @@ trait TestData {
       Seq(1),
       availability = Availability.everyone,
       relatedContent = Seq.empty,
-      revisionDate = None
+      revisionDate = Some(LocalDateTime.now().withNano(0))
     )
 
     val sampleDomainArticle = Article(

--- a/article-api/src/test/scala/no/ndla/articleapi/validation/ContentValidatorTest.scala
+++ b/article-api/src/test/scala/no/ndla/articleapi/validation/ContentValidatorTest.scala
@@ -391,4 +391,9 @@ class ContentValidatorTest extends UnitSuite with TestEnvironment {
 
     softRes.isSuccess should be(true)
   }
+
+  test("validateArticle throws an exception on an article with a missing revisionDate") {
+    val article = TestData.sampleArticleWithByNcSa.copy(revisionDate = None)
+    contentValidator.validateArticle(article).isFailure should be(true)
+  }
 }

--- a/draft-api/src/main/scala/no/ndla/draftapi/DraftSwagger.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/DraftSwagger.scala
@@ -42,12 +42,11 @@ trait DraftApiInfo {
   class DraftSwagger extends Swagger("2.0", "1.0", DraftApiInfo.apiInfo) {
 
     private def writeRolesInTest: List[String] = {
-      val writeRoles = List(
+      List(
         props.DraftRoleWithWriteAccess,
         props.DraftRoleWithPublishAccess,
         props.ArticleRoleWithPublishAccess
       )
-      writeRoles.map(_.replace(":", "-test:"))
     }
 
     addAuthorization(

--- a/draft-api/src/main/scala/no/ndla/draftapi/integration/ArticleApiClient.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/integration/ArticleApiClient.scala
@@ -135,7 +135,6 @@ trait ArticleApiClient {
     }
   }
 
-  case class ArticleApiId(id: Long)
   case class PartialPublishArticle(
       availability: Option[api.Availability.Value],
       grepCodes: Option[Seq[String]],
@@ -186,3 +185,4 @@ trait ArticleApiClient {
     def empty(): PartialPublishArticle = PartialPublishArticle(None, None, None, None, None, None, Right(None))
   }
 }
+case class ArticleApiId(id: Long)

--- a/draft-api/src/main/scala/no/ndla/draftapi/integration/SearchApiClient.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/integration/SearchApiClient.scala
@@ -14,7 +14,7 @@ import no.ndla.draftapi.model.domain._
 import no.ndla.draftapi.service.ConverterService
 import no.ndla.network.NdlaClient
 import org.json4s.Formats
-import org.json4s.ext.{EnumNameSerializer, JavaTimeSerializers}
+import org.json4s.ext.{EnumNameSerializer, JavaTimeSerializers, JavaTypesSerializers}
 import org.json4s.native.Serialization.write
 import scalaj.http.Http
 
@@ -38,7 +38,8 @@ trait SearchApiClient {
           new EnumNameSerializer(Availability) +
           Json4s.serializer(ArticleType) +
           Json4s.serializer(RevisionStatus) ++
-          JavaTimeSerializers.all
+          JavaTimeSerializers.all ++
+          JavaTypesSerializers.all
 
       implicit val executionContext: ExecutionContextExecutorService =
         ExecutionContext.fromExecutorService(Executors.newSingleThreadExecutor)

--- a/integration-tests/src/test/scala/no/ndla/integrationtests/draftapi/articleapi/ArticleApiClientTest.scala
+++ b/integration-tests/src/test/scala/no/ndla/integrationtests/draftapi/articleapi/ArticleApiClientTest.scala
@@ -11,7 +11,7 @@ import no.ndla.{articleapi, draftapi}
 import no.ndla.articleapi.ArticleApiProperties
 import no.ndla.draftapi.model.api.ContentId
 import no.ndla.draftapi.model.domain
-import no.ndla.draftapi.model.domain.{Article, Availability, Copyright, RevisionMeta}
+import no.ndla.draftapi.model.domain.{Article, Availability, Copyright, RevisionMeta, RevisionStatus}
 import no.ndla.integrationtests.UnitSuite
 import no.ndla.network.AuthUser
 import no.ndla.scalatestsuite.IntegrationSuite
@@ -20,7 +20,8 @@ import org.joda.time.DateTime
 import org.json4s.Formats
 import org.testcontainers.containers.PostgreSQLContainer
 
-import java.util.Date
+import java.time.LocalDateTime
+import java.util.{Date, UUID}
 import scala.util.{Failure, Success, Try}
 
 class ArticleApiClientTest
@@ -91,7 +92,14 @@ class ArticleApiClientTest
     conceptIds = Seq.empty,
     availability = Availability.everyone,
     relatedContent = Seq.empty,
-    revisionMeta = RevisionMeta.default
+    revisionMeta = Seq(
+      RevisionMeta(
+        id = UUID.randomUUID(),
+        note = "Revision",
+        revisionDate = LocalDateTime.now(),
+        status = RevisionStatus.NeedsRevision
+      )
+    )
   )
 
   val exampleToken =


### PR DESCRIPTION
revisionDate i article-api settes til første uferdige revisjonsdato fra draft-api. Dersom den er None så betyr det at det ikkje finnes uferdige revisjondatoer, og dermed vil ikkje artikkelen validere.