### PR TITLE
Remove elasticsearch cluster status check

### DIFF
--- a/search-api/src/main/scala/no/ndla/searchapi/controller/HealthController.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/controller/HealthController.scala
@@ -8,12 +8,9 @@
 
 package no.ndla.searchapi.controller
 
-import com.sksamuel.elastic4s.ElasticDsl._
 import com.typesafe.scalalogging.LazyLogging
 import no.ndla.search.Elastic4sClient
-import org.scalatra.{InternalServerError, Ok, ScalatraServlet}
-
-import scala.util.{Failure, Success}
+import org.scalatra.{Ok, ScalatraServlet}
 
 trait HealthController {
   this: Elastic4sClient =>
@@ -21,27 +18,7 @@ trait HealthController {
 
   class HealthController extends ScalatraServlet with LazyLogging {
     get("/") {
-      e4sClient.execute(clusterHealth()) match {
-        case Failure(exception) =>
-          logger.error(
-            "Something went wrong when contacting elasticsearch instance when performing health check",
-            exception
-          )
-          InternalServerError()
-        case Success(successfulResponse) if successfulResponse.status == 200 && successfulResponse.isSuccess =>
-          Ok()
-        case Success(notReallySuccessfulResponse) =>
-          logger.error(
-            s"""Health check against elasticsearch failed --->
-                 |Status: $status
-                 |Body: ${notReallySuccessfulResponse.body.getOrElse("<missing>")}
-                 |headers:   ${notReallySuccessfulResponse.headers.mkString("\n\t")}
-                 |Result: ${notReallySuccessfulResponse.result.toString}
-                 |""".stripMargin
-          )
-          InternalServerError()
-      }
+      Ok()
     }
-
   }
 }

--- a/search-api/src/test/scala/no/ndla/searchapi/controller/HealthControllerTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/controller/HealthControllerTest.scala
@@ -8,12 +8,8 @@
 
 package no.ndla.searchapi.controller
 
-import com.sksamuel.elastic4s.requests.cluster.ClusterHealthRequest
-import com.sksamuel.elastic4s.{Handler, RequestSuccess}
 import no.ndla.searchapi.{TestEnvironment, UnitSuite}
 import org.scalatra.test.scalatest.ScalatraFunSuite
-
-import scala.util.{Failure, Try}
 
 class HealthControllerTest extends UnitSuite with TestEnvironment with ScalatraFunSuite {
 
@@ -21,21 +17,8 @@ class HealthControllerTest extends UnitSuite with TestEnvironment with ScalatraF
   addServlet(controller, "/")
 
   test("That /health returns 200 ok") {
-    val x = Try(RequestSuccess(200, None, Map.empty, ""))
-    when(
-      e4sClient.execute(any[ClusterHealthRequest])(any[Handler[ClusterHealthRequest, String]], any[Manifest[String]])
-    )
-      .thenReturn(x)
     get("/") {
       status should equal(200)
-    }
-  }
-
-  test("That /health returns 500 when elasticsearch not reachable") {
-    when(e4sClient.execute(any[Any])(any[Handler[Any, Any]], any[Manifest[Any]]))
-      .thenReturn(Failure(new java.net.ConnectException("Is no work")))
-    get("/") {
-      status should equal(500)
     }
   }
 


### PR DESCRIPTION
Det gir egentlig ikke meningen å drepe search-api pods dersom elasticsearch clusteret ikke er grønt, så fjerner denne delen av helsesjekken.