### PR TITLE
Use `gen_random_uuid()` from postgres rather than `uuid-ossp` and bump to postgres 13.6

### DIFF
--- a/image-api/src/test/scala/no/ndla/imageapi/controller/HealthControllerTest.scala
+++ b/image-api/src/test/scala/no/ndla/imageapi/controller/HealthControllerTest.scala
@@ -10,7 +10,6 @@ package no.ndla.imageapi.controller
 
 import no.ndla.imageapi.{TestEnvironment, UnitSuite}
 import org.scalatra.test.scalatest.ScalatraFunSuite
-import scalaj.http.HttpResponse
 
 class HealthControllerTest extends UnitSuite with TestEnvironment with ScalatraFunSuite {
   lazy val controller = new HealthController

--- a/learningpath-api/src/main/resources/learningpathapi/db/migration/V16__CreateFolderTable.sql
+++ b/learningpath-api/src/main/resources/learningpathapi/db/migration/V16__CreateFolderTable.sql
@@ -1,8 +1,5 @@
-DROP EXTENSION IF EXISTS "uuid-ossp";
-CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
-
 CREATE TABLE folders (
-    id UUID DEFAULT uuid_generate_v4() PRIMARY KEY,
+    id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
     parent_id UUID NULL,
     feide_id TEXT,
     document JSONB,
@@ -12,7 +9,7 @@ CREATE TABLE folders (
 );
 
 CREATE TABLE resources (
-    id UUID DEFAULT uuid_generate_v4() PRIMARY KEY,
+    id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
     feide_id TEXT,
     path TEXT,
     resource_type TEXT,

--- a/scalatestsuite/src/main/scala/no/ndla/scalatestsuite/IntegrationSuite.scala
+++ b/scalatestsuite/src/main/scala/no/ndla/scalatestsuite/IntegrationSuite.scala
@@ -20,7 +20,7 @@ import scala.util.{Failure, Success, Try}
 abstract class IntegrationSuite(
     EnableElasticsearchContainer: Boolean = false,
     EnablePostgresContainer: Boolean = false,
-    PostgresqlVersion: String = "12.4",
+    PostgresqlVersion: String = "13.6",
     ElasticsearchImage: String = "9062bdb", // elasticsearch 7.16.2
     schemaName: String = "testschema"
 ) extends UnitTestSuite {


### PR DESCRIPTION
Depends on https://github.com/NDLANO/deploy/pull/410
Denne tar i bruk `gen_random_uuid()` fra postgres 13 istedetfor å bruke `uuid-ossp`.
Da slipper vi å gi superuser-tilganger til learningpath_api brukeren i miljøene (og vi burde jo oppgradere etterhvert uansett så why not now)