### PR TITLE
Make sure article has at least one planned revisions. Create one with…

### DIFF
--- a/draft-api/src/main/scala/no/ndla/draftapi/model/domain/RevisionMeta.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/model/domain/RevisionMeta.scala
@@ -22,12 +22,11 @@ case class RevisionMeta(
 }
 
 object RevisionMeta {
-  def default: Seq[RevisionMeta] = Seq.empty
   def planned: Seq[RevisionMeta] = Seq(
     RevisionMeta(
       UUID.randomUUID(),
       LocalDateTime.now().plusYears(5).withNano(0),
-      "Automatisk revisjonsdato satt av systemet.",
+      "Automatisk revisjonsdato satt av systemet",
       RevisionStatus.NeedsRevision
     )
   )

--- a/draft-api/src/main/scala/no/ndla/draftapi/model/domain/RevisionMeta.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/model/domain/RevisionMeta.scala
@@ -22,7 +22,7 @@ case class RevisionMeta(
 }
 
 object RevisionMeta {
-  def planned: Seq[RevisionMeta] = Seq(
+  def default: Seq[RevisionMeta] = Seq(
     RevisionMeta(
       UUID.randomUUID(),
       LocalDateTime.now().plusYears(5).withNano(0),

--- a/draft-api/src/main/scala/no/ndla/draftapi/model/domain/RevisionMeta.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/model/domain/RevisionMeta.scala
@@ -23,6 +23,14 @@ case class RevisionMeta(
 
 object RevisionMeta {
   def default: Seq[RevisionMeta] = Seq.empty
+  def planned: Seq[RevisionMeta] = Seq(
+    RevisionMeta(
+      UUID.randomUUID(),
+      LocalDateTime.now().plusYears(5).withNano(0),
+      "Automatisk revisjonsdato satt av systemet.",
+      RevisionStatus.NeedsRevision
+    )
+  )
 }
 
 sealed abstract class RevisionStatus(override val entryName: String) extends EnumEntry

--- a/draft-api/src/main/scala/no/ndla/draftapi/service/ConverterService.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/service/ConverterService.scala
@@ -60,8 +60,8 @@ trait ConverterService {
       val newAvailability = Availability.valueOf(newArticle.availability).getOrElse(Availability.everyone)
       val revisionMeta = newArticle.revisionMeta match {
         case Some(revs) if revs.nonEmpty =>
-          newArticle.revisionMeta.map(_.map(toDomainRevisionMeta)).getOrElse(RevisionMeta.planned)
-        case _ => RevisionMeta.planned
+          newArticle.revisionMeta.map(_.map(toDomainRevisionMeta)).getOrElse(RevisionMeta.default)
+        case _ => RevisionMeta.default
       }
 
       newNotes(newArticle.notes, user, status).map(notes =>

--- a/draft-api/src/main/scala/no/ndla/draftapi/service/ConverterService.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/service/ConverterService.scala
@@ -58,7 +58,11 @@ trait ConverterService {
       val oldCreatedDate  = oldNdlaCreatedDate.map(date => new DateTime(date).toDate)
       val oldUpdatedDate  = oldNdlaUpdatedDate.map(date => new DateTime(date).toDate)
       val newAvailability = Availability.valueOf(newArticle.availability).getOrElse(Availability.everyone)
-      val revisionMeta    = newArticle.revisionMeta.map(_.map(toDomainRevisionMeta)).getOrElse(RevisionMeta.default)
+      val revisionMeta = newArticle.revisionMeta match {
+        case Some(revs) if revs.nonEmpty =>
+          newArticle.revisionMeta.map(_.map(toDomainRevisionMeta)).getOrElse(RevisionMeta.planned)
+        case _ => RevisionMeta.planned
+      }
 
       newNotes(newArticle.notes, user, status).map(notes =>
         domain.Article(

--- a/draft-api/src/main/scala/no/ndla/draftapi/validation/ContentValidator.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/validation/ContentValidator.scala
@@ -19,6 +19,7 @@ import no.ndla.mapping.License.getLicense
 import no.ndla.validation._
 import org.joda.time.format.ISODateTimeFormat
 
+import java.time.LocalDateTime
 import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Success, Try}
 
@@ -150,7 +151,9 @@ trait ContentValidator {
     }
 
     private def validateRevisionMeta(revisionMeta: Seq[RevisionMeta]): Seq[ValidationMessage] = {
-      revisionMeta.find(rm => rm.status == RevisionStatus.NeedsRevision) match {
+      revisionMeta.find(rm =>
+        rm.status == RevisionStatus.NeedsRevision && rm.revisionDate.isAfter(LocalDateTime.now())
+      ) match {
         case Some(_) => Seq.empty
         case None =>
           Seq(

--- a/draft-api/src/main/scala/no/ndla/draftapi/validation/ContentValidator.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/validation/ContentValidator.scala
@@ -78,7 +78,8 @@ trait ContentValidator {
         validateTags(article.tags) ++
         article.requiredLibraries.flatMap(validateRequiredLibrary) ++
         article.metaImage.flatMap(validateMetaImage) ++
-        article.visualElement.flatMap(v => validateVisualElement(v))
+        article.visualElement.flatMap(v => validateVisualElement(v)) ++
+        validateRevisionMeta(article.revisionMeta)
 
       if (validationErrors.isEmpty) {
         Success(article)
@@ -146,6 +147,19 @@ trait ContentValidator {
           requiredToOptional = Map("image" -> Seq("data-caption"))
         )
         .toList ++ validateLanguage("language", content.language)
+    }
+
+    private def validateRevisionMeta(revisionMeta: Seq[RevisionMeta]): Seq[ValidationMessage] = {
+      revisionMeta.find(rm => rm.status == RevisionStatus.NeedsRevision) match {
+        case Some(_) => Seq.empty
+        case None =>
+          Seq(
+            ValidationMessage(
+              "revisionMeta",
+              "An article must contain at least one planned revisiondate"
+            )
+          )
+      }
     }
 
     private def validateIntroduction(content: ArticleIntroduction): List[ValidationMessage] = {

--- a/draft-api/src/test/scala/no/ndla/draftapi/TestData.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/TestData.scala
@@ -7,14 +7,14 @@
 
 package no.ndla.draftapi
 
-import no.ndla.draftapi.model.{api, domain}
-import no.ndla.draftapi.model.domain._
-import ArticleStatus._
 import no.ndla.draftapi.auth.{Role, UserInfo}
 import no.ndla.draftapi.integration.{LearningPath, Title}
 import no.ndla.draftapi.model.api.{GrepCodesSearchResult, NewAgreement, NewArticle, TagsSearchResult, UpdatedArticle}
-import org.joda.time.{DateTime, DateTimeZone}
+import no.ndla.draftapi.model.domain.ArticleStatus._
+import no.ndla.draftapi.model.domain._
+import no.ndla.draftapi.model.{api, domain}
 import no.ndla.mapping.License.{CC_BY, CC_BY_NC_SA, CC_BY_SA}
+import org.joda.time.{DateTime, DateTimeZone}
 
 import java.util.Date
 
@@ -308,7 +308,7 @@ object TestData {
     Seq.empty,
     Availability.everyone,
     Seq.empty,
-    RevisionMeta.default
+    RevisionMeta.planned
   )
 
   val sampleDomainArticle: Article = Article(

--- a/draft-api/src/test/scala/no/ndla/draftapi/TestData.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/TestData.scala
@@ -308,7 +308,7 @@ object TestData {
     Seq.empty,
     Availability.everyone,
     Seq.empty,
-    RevisionMeta.planned
+    RevisionMeta.default
   )
 
   val sampleDomainArticle: Article = Article(

--- a/draft-api/src/test/scala/no/ndla/draftapi/TestData.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/TestData.scala
@@ -280,7 +280,7 @@ object TestData {
     Seq.empty,
     Availability.everyone,
     Seq.empty,
-    RevisionMeta.default
+    Seq.empty
   )
 
   val sampleArticleWithPublicDomain: Article = Article(
@@ -336,7 +336,7 @@ object TestData {
     Seq.empty,
     Availability.everyone,
     Seq.empty,
-    RevisionMeta.default
+    Seq.empty
   )
 
   val sampleDomainArticle2: Article = Article(
@@ -364,7 +364,7 @@ object TestData {
     Seq.empty,
     Availability.everyone,
     Seq.empty,
-    RevisionMeta.default
+    Seq.empty
   )
 
   val newArticle: NewArticle = api.NewArticle(
@@ -437,7 +437,7 @@ object TestData {
     Seq.empty,
     Availability.everyone,
     Seq.empty,
-    RevisionMeta.default
+    Seq.empty
   )
 
   val apiArticleWithHtmlFaultV2: api.Article = api.Article(

--- a/draft-api/src/test/scala/no/ndla/draftapi/service/ConverterServiceTest.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/service/ConverterServiceTest.scala
@@ -300,7 +300,7 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
       conceptIds = Seq.empty,
       availability = Availability.everyone,
       relatedContent = Seq.empty,
-      revisionMeta = RevisionMeta.default
+      revisionMeta = Seq.empty
     )
 
     val updatedNothing = TestData.blankUpdatedArticle.copy(
@@ -338,7 +338,7 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
       conceptIds = Seq.empty,
       availability = Availability.everyone,
       relatedContent = Seq.empty,
-      revisionMeta = RevisionMeta.default
+      revisionMeta = Seq.empty
     )
 
     val expectedArticle = Article(
@@ -366,7 +366,7 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
       conceptIds = Seq.empty,
       availability = Availability.everyone,
       relatedContent = Seq.empty,
-      revisionMeta = RevisionMeta.default
+      revisionMeta = Seq.empty
     )
 
     val updatedEverything = TestData.blankUpdatedArticle.copy(
@@ -422,7 +422,7 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
       conceptIds = Seq.empty,
       availability = Availability.everyone,
       relatedContent = Seq.empty,
-      revisionMeta = RevisionMeta.default
+      revisionMeta = Seq.empty
     )
 
     val expectedArticle = Article(
@@ -450,7 +450,7 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
       conceptIds = Seq.empty,
       availability = Availability.everyone,
       relatedContent = Seq.empty,
-      revisionMeta = RevisionMeta.default
+      revisionMeta = Seq.empty
     )
 
     val updatedEverything = TestData.blankUpdatedArticle.copy(

--- a/draft-api/src/test/scala/no/ndla/draftapi/service/WriteServiceTest.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/service/WriteServiceTest.scala
@@ -1104,7 +1104,7 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
       None,
       None
     )
-    saved.get.notes.size should be(1)
+    saved.get.notes.size should be(2)
     saved.get.notes.head.note should be("Lagt til revisjon Ny revision.")
     val savedRevision = saved.get.revisions.head
 

--- a/draft-api/src/test/scala/no/ndla/draftapi/service/WriteServiceTest.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/service/WriteServiceTest.scala
@@ -1105,7 +1105,9 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
       None
     )
     saved.get.notes.size should be(2)
-    saved.get.notes.head.note should be("Lagt til revisjon Ny revision.")
+    saved.get.notes.map(n => n.note) should be(
+      Seq("Lagt til revisjon Ny revision.", "Slettet revisjon Automatisk revisjonsdato satt av systemet.")
+    )
     val savedRevision = saved.get.revisions.head
 
     val revised = revision.copy(id = savedRevision.id, status = RevisionStatus.Revised.entryName)

--- a/draft-api/src/test/scala/no/ndla/draftapi/validation/ContentValidatorTest.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/validation/ContentValidatorTest.scala
@@ -277,4 +277,17 @@ class ContentValidatorTest extends UnitSuite with TestEnvironment {
     res.errors.head.message should be("Meta image ID must be a number")
   }
 
+  test("validation should fail if revisionMeta does not have unplanned revisions") {
+    val Failure(res: ValidationException) =
+      contentValidator.validateArticle(
+        TestData.sampleArticleWithByNcSa.copy(
+          revisionMeta = RevisionMeta.default
+        )
+      )
+
+    res.errors.length should be(1)
+    res.errors.head.field should be("revisionMeta")
+    res.errors.head.message should be("An article must contain at least one planned revisiondate")
+  }
+
 }

--- a/draft-api/src/test/scala/no/ndla/draftapi/validation/ContentValidatorTest.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/validation/ContentValidatorTest.scala
@@ -281,7 +281,7 @@ class ContentValidatorTest extends UnitSuite with TestEnvironment {
     val Failure(res: ValidationException) =
       contentValidator.validateArticle(
         TestData.sampleArticleWithByNcSa.copy(
-          revisionMeta = RevisionMeta.default
+          revisionMeta = Seq.empty
         )
       )
 


### PR DESCRIPTION
… new article.

For å kunne forhindre lagring av artikkel uten planlagt revisjonsdato, så legges det til en første gong en artikkel lagres.