### PR TITLE
Split resources/subfolders into multiple fields

### DIFF
--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/controller/FolderController.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/controller/FolderController.scala
@@ -188,7 +188,7 @@ trait FolderController {
     }
 
     get(
-      "/resources/",
+      "/resources/?",
       operation(
         apiOperation[List[Resource]]("fetchAllResources")
           .summary("Fetch all resources that belongs to a user")
@@ -213,7 +213,7 @@ trait FolderController {
     }
 
     post(
-      "/:folder_id/resources/",
+      "/:folder_id/resources/?",
       operation(
         apiOperation[Unit]("createFolderResource")
           .summary("Creates new folder resource")

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/model/api/Breadcrumb.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/model/api/Breadcrumb.scala
@@ -1,0 +1,17 @@
+/*
+ * Part of NDLA learningpath-api.
+ * Copyright (C) 2022 NDLA
+ *
+ * See LICENSE
+ *
+ */
+
+package no.ndla.learningpathapi.model.api
+
+import scala.annotation.meta.field
+import org.scalatra.swagger.runtime.annotations.ApiModelProperty
+
+case class Breadcrumb(
+    @(ApiModelProperty @field)(description = "UUID of the folder") id: String,
+    @(ApiModelProperty @field)(description = "Folder name") name: String
+)

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/model/api/Folder.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/model/api/Folder.scala
@@ -61,15 +61,24 @@ case class Resource(
     @(ApiModelProperty @field)(description = "Type of the resource. (Article, Learningpath)") resourceType: String,
     @(ApiModelProperty @field)(description = "Relative path of this resource") path: String,
     @(ApiModelProperty @field)(description = "When the resource was created") created: LocalDateTime,
-    @(ApiModelProperty @field)(description = "List of tags") tags: List[String]
+    @(ApiModelProperty @field)(description = "List of tags") tags: List[String],
+    @(ApiModelProperty @field)(
+      description = "The id of the resource, useful for fetching metadata for the resource"
+    ) resourceId: Option[Long]
 )
 
 case class NewResource(
     @(ApiModelProperty @field)(description = "Type of the resource. (Article, Learningpath)") resourceType: String,
     @(ApiModelProperty @field)(description = "Relative path of this resource") path: String,
-    @(ApiModelProperty @field)(description = "List of tags") tags: Option[List[String]]
+    @(ApiModelProperty @field)(description = "List of tags") tags: Option[List[String]],
+    @(ApiModelProperty @field)(
+      description = "The id of the resource, useful for fetching metadata for the resource"
+    ) resourceId: Option[Long]
 )
 
 case class UpdatedResource(
-    @(ApiModelProperty @field)(description = "List of tags") tags: Option[List[String]]
+    @(ApiModelProperty @field)(description = "List of tags") tags: Option[List[String]],
+    @(ApiModelProperty @field)(
+      description = "The id of the resource, useful for fetching metadata for the resource"
+    ) resourceId: Option[Long]
 )

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/model/api/Folder.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/model/api/Folder.scala
@@ -21,7 +21,7 @@ case class Folder(
     @(ApiModelProperty @field)(description = "Folder status") status: String,
     @(ApiModelProperty @field)(description = "Folder favorite flag") isFavorite: Boolean,
     @(ApiModelProperty @field)(description = "UUID of parent folder") parentId: Option[String],
-    @(ApiModelProperty @field)(description = "List of parent folders to resource") breadcrumbs: List[String],
+    @(ApiModelProperty @field)(description = "List of parent folders to resource") breadcrumbs: List[Breadcrumb],
     @(ApiModelProperty @field)(description = "List of subfolders") subfolders: List[FolderData],
     @(ApiModelProperty @field)(description = "List of resources") resources: List[Resource]
 ) extends FolderData

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/model/api/Folder.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/model/api/Folder.scala
@@ -22,6 +22,7 @@ case class Folder(
     @(ApiModelProperty @field)(description = "Folder name") name: String,
     @(ApiModelProperty @field)(description = "Folder status") status: String,
     @(ApiModelProperty @field)(description = "Folder favorite flag") isFavorite: Boolean,
+    @(ApiModelProperty @field)(description = "UUID of parent folder") parentId: Option[String],
     @(ApiModelProperty @field)(description = "List of parent folders to resource") breadcrumbs: List[String],
     @(ApiModelProperty @field)(description = "List of other folders and resources") data: List[FolderData]
 ) extends FolderData

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/model/api/Folder.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/model/api/Folder.scala
@@ -8,13 +8,11 @@
 
 package no.ndla.learningpathapi.model.api
 
-import com.scalatsi.TypescriptType.TSUnion
+import com.scalatsi.{TSIType, TSNamedType, TSType}
 import org.scalatra.swagger.runtime.annotations.ApiModelProperty
 
 import java.time.LocalDateTime
 import scala.annotation.meta.field
-import com.scalatsi._
-
 import scala.annotation.unused
 
 case class Folder(
@@ -24,7 +22,8 @@ case class Folder(
     @(ApiModelProperty @field)(description = "Folder favorite flag") isFavorite: Boolean,
     @(ApiModelProperty @field)(description = "UUID of parent folder") parentId: Option[String],
     @(ApiModelProperty @field)(description = "List of parent folders to resource") breadcrumbs: List[String],
-    @(ApiModelProperty @field)(description = "List of other folders and resources") data: List[FolderData]
+    @(ApiModelProperty @field)(description = "List of subfolders") subfolders: List[FolderData],
+    @(ApiModelProperty @field)(description = "List of resources") resources: List[Resource]
 ) extends FolderData
 
 // 1: This object is needed for generating recursive Folder typescript type.
@@ -42,9 +41,8 @@ object Folder {
 sealed trait FolderData {}
 object FolderData       {
   // 3: After being redirected here from TSType.external we are manually making the union of FolderData,
-  // with Resource and Folder. After that we alias it as IFolderData so that scala-tsi can incorporate it.
-  implicit val folderDataUnion: TSUnion                 = TSUnion.of(Folder.resource.get, Folder.folderTSI.get)
-  implicit val folderDataAlias: TSNamedType[FolderData] = TSType.alias[FolderData]("IFolderData", folderDataUnion)
+  // with Folder. After that we alias it as IFolderData so that scala-tsi can incorporate it.
+  implicit val folderDataAlias: TSNamedType[FolderData] = TSType.alias[FolderData]("IFolderData", Folder.folderTSI.get)
 }
 
 case class NewFolder(
@@ -64,7 +62,7 @@ case class Resource(
     @(ApiModelProperty @field)(description = "Relative path of this resource") path: String,
     @(ApiModelProperty @field)(description = "When the resource was created") created: LocalDateTime,
     @(ApiModelProperty @field)(description = "List of tags") tags: List[String]
-) extends FolderData
+)
 
 case class NewResource(
     @(ApiModelProperty @field)(description = "Type of the resource. (Article, Learningpath)") resourceType: String,

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/model/api/Folder.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/model/api/Folder.scala
@@ -64,7 +64,7 @@ case class Resource(
     @(ApiModelProperty @field)(description = "List of tags") tags: List[String],
     @(ApiModelProperty @field)(
       description = "The id of the resource, useful for fetching metadata for the resource"
-    ) resourceId: Option[Long]
+    ) resourceId: Long
 )
 
 case class NewResource(
@@ -73,7 +73,7 @@ case class NewResource(
     @(ApiModelProperty @field)(description = "List of tags") tags: Option[List[String]],
     @(ApiModelProperty @field)(
       description = "The id of the resource, useful for fetching metadata for the resource"
-    ) resourceId: Option[Long]
+    ) resourceId: Long
 )
 
 case class UpdatedResource(

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/model/domain/Folder.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/model/domain/Folder.scala
@@ -150,11 +150,11 @@ trait DBFolder {
       val parentId = rs.get[Option[UUID]](colNameWrapper("parent_id"))
       id.map(id =>
         metaData.toFullFolder(
-          id,
-          feideId,
-          parentId,
-          List.empty,
-          List.empty
+          id = id,
+          feideId = feideId,
+          parentId = parentId,
+          resources = List.empty,
+          subfolders = List.empty
         )
       )
     }

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/model/domain/Folder.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/model/domain/Folder.scala
@@ -84,8 +84,14 @@ trait DBResource {
   }
 }
 
-case class FolderDocument(isFavorite: Boolean, name: String, status: FolderStatus.Value, data: List[FolderData]) {
-  def toFullFolder(id: UUID, feideId: FeideID, parentId: Option[UUID]): Folder = {
+case class FolderDocument(isFavorite: Boolean, name: String, status: FolderStatus.Value) {
+  def toFullFolder(
+      id: UUID,
+      feideId: FeideID,
+      parentId: Option[UUID],
+      resources: List[Resource],
+      subfolders: List[Folder]
+  ): Folder = {
     Folder(
       id = id,
       feideId = feideId,
@@ -93,7 +99,8 @@ case class FolderDocument(isFavorite: Boolean, name: String, status: FolderStatu
       name = name,
       status = status,
       isFavorite = isFavorite,
-      data = data
+      resources = resources,
+      subfolders = subfolders
     )
   }
 }
@@ -105,16 +112,14 @@ case class Folder(
     name: String,
     status: FolderStatus.Value,
     isFavorite: Boolean,
-    data: List[FolderData]
+    subfolders: List[Folder],
+    resources: List[Resource]
 ) extends FolderContent {
-  def toDocument(): FolderDocument = {
-    FolderDocument(
-      isFavorite = isFavorite,
-      name = name,
-      status = status,
-      data = data
-    )
-  }
+  def toDocument(): FolderDocument = FolderDocument(
+    isFavorite = isFavorite,
+    name = name,
+    status = status
+  )
 }
 
 trait DBFolder {
@@ -145,11 +150,12 @@ trait DBFolder {
         metaData.toFullFolder(
           id,
           feideId,
-          parentId
+          parentId,
+          List.empty,
+          List.empty
         )
       )
     }
-
   }
 }
 

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/model/domain/Folder.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/model/domain/Folder.scala
@@ -20,7 +20,7 @@ import java.time.LocalDateTime
 import scala.util.Try
 import cats.implicits._
 
-case class ResourceDocument(tags: List[String]) {
+case class ResourceDocument(tags: List[String], resourceId: Option[Long]) {
   def toFullResource(
       id: UUID,
       path: String,
@@ -34,7 +34,8 @@ case class ResourceDocument(tags: List[String]) {
       path = path,
       resourceType = resourceType,
       tags = tags,
-      created = created
+      created = created,
+      resourceId = resourceId
     )
 }
 
@@ -44,7 +45,8 @@ case class Resource(
     created: LocalDateTime,
     path: String,
     resourceType: String,
-    tags: List[String]
+    tags: List[String],
+    resourceId: Option[Long]
 ) extends FeideContent
 
 trait DBResource {

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/model/domain/Folder.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/model/domain/Folder.scala
@@ -20,7 +20,7 @@ import java.time.LocalDateTime
 import scala.util.Try
 import cats.implicits._
 
-case class ResourceDocument(tags: List[String], resourceId: Option[Long]) {
+case class ResourceDocument(tags: List[String], resourceId: Long) {
   def toFullResource(
       id: UUID,
       path: String,
@@ -46,7 +46,7 @@ case class Resource(
     path: String,
     resourceType: String,
     tags: List[String],
-    resourceId: Option[Long]
+    resourceId: Long
 ) extends FeideContent
 
 trait DBResource {

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/repository/FolderRepository.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/repository/FolderRepository.scala
@@ -48,7 +48,13 @@ trait FolderRepository {
         """.update()
 
         logger.info(s"Inserted new folder with id: $newId")
-        document.toFullFolder(newId, feideId, parentId, List.empty, List.empty)
+        document.toFullFolder(
+          id = newId,
+          feideId = feideId,
+          parentId = parentId,
+          resources = List.empty,
+          subfolders = List.empty
+        )
       }
 
     def insertResource(

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/repository/FolderRepository.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/repository/FolderRepository.scala
@@ -227,7 +227,8 @@ trait FolderRepository {
           val byPid = rest.groupBy(_.parentId)
           def injectChildrenRecursively(current: Folder): Folder = byPid.get(current.id.some) match {
             case Some(children) =>
-              val childrenWithTheirChildrenFolders = children.map(child => Left(injectChildrenRecursively(child)))
+              val childrenWithTheirChildrenFolders =
+                children.sortBy(_.id.toString).map(child => Left(injectChildrenRecursively(child)))
               current.copy(data = childrenWithTheirChildrenFolders ++ current.data)
             case None => current
           }

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/ConverterService.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/ConverterService.scala
@@ -699,15 +699,15 @@ trait ConverterService {
       )
     }
 
-    private def toApiFolderData(domainData: domain.Folder, crumbs: List[api.Breadcrumb]): Try[api.Folder] = {
+    def toApiFolder(domainFolder: domain.Folder, breadcrumbs: List[api.Breadcrumb]): Try[api.Folder] = {
       def loop(folder: domain.Folder, crumbs: List[api.Breadcrumb]): Try[api.Folder] = folder.subfolders
-        .traverse(d => {
+        .traverse(folder => {
           val newCrumb = api.Breadcrumb(
-            id = d.id.toString,
-            name = d.name
+            id = folder.id.toString,
+            name = folder.name
           )
           val newCrumbs = crumbs :+ newCrumb
-          loop(d, newCrumbs)
+          loop(folder, newCrumbs)
         })
         .flatMap(subFolders =>
           folder.resources
@@ -726,35 +726,7 @@ trait ConverterService {
             })
         )
 
-      loop(domainData, crumbs)
-    }
-
-    def toApiFolder(domainFolder: domain.Folder, breadcrumbs: List[api.Breadcrumb]): Try[api.Folder] = {
-      domainFolder.subfolders
-        .traverse(folder => {
-          val newCrumb = api.Breadcrumb(
-            id = folder.id.toString,
-            name = folder.name
-          )
-          val newCrumbs = breadcrumbs :+ newCrumb
-          toApiFolderData(folder, newCrumbs)
-        })
-        .flatMap(subfolders => {
-          domainFolder.resources
-            .traverse(toApiResource)
-            .map(resources => {
-              api.Folder(
-                id = domainFolder.id.toString,
-                name = domainFolder.name,
-                status = domainFolder.status.toString,
-                isFavorite = domainFolder.isFavorite,
-                subfolders = subfolders,
-                resources = resources,
-                breadcrumbs = breadcrumbs,
-                parentId = domainFolder.parentId.map(_.toString)
-              )
-            })
-        })
+      loop(domainFolder, breadcrumbs)
     }
 
     def mergeFolder(existing: domain.Folder, updated: api.UpdatedFolder): domain.Folder = {

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/ConverterService.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/ConverterService.scala
@@ -774,7 +774,8 @@ trait ConverterService {
     }
 
     def mergeResource(existing: domain.Resource, updated: api.UpdatedResource): domain.Resource = {
-      val tags = updated.tags.getOrElse(existing.tags)
+      val tags       = updated.tags.getOrElse(existing.tags)
+      val resourceId = updated.resourceId.orElse(existing.resourceId)
 
       domain.Resource(
         id = existing.id,
@@ -782,12 +783,14 @@ trait ConverterService {
         resourceType = existing.resourceType,
         path = existing.path,
         created = existing.created,
-        tags = tags
+        tags = tags,
+        resourceId = resourceId
       )
     }
 
     def mergeResource(existing: domain.Resource, newResource: api.NewResource): domain.Resource = {
-      val tags = newResource.tags.getOrElse(existing.tags)
+      val tags       = newResource.tags.getOrElse(existing.tags)
+      val resourceId = newResource.resourceId.orElse(existing.resourceId)
 
       domain.Resource(
         id = existing.id,
@@ -795,7 +798,8 @@ trait ConverterService {
         resourceType = existing.resourceType,
         path = existing.path,
         created = existing.created,
-        tags = tags
+        tags = tags,
+        resourceId = resourceId
       )
     }
 
@@ -804,6 +808,7 @@ trait ConverterService {
       val path         = domainResource.path
       val created      = domainResource.created
       val tags         = domainResource.tags
+      val resourceId   = domainResource.resourceId
 
       Success(
         api.Resource(
@@ -811,14 +816,18 @@ trait ConverterService {
           resourceType = resourceType,
           path = path,
           created = created,
-          tags = tags
+          tags = tags,
+          resourceId = resourceId
         )
       )
     }
 
     def toDomainResource(newResource: api.NewResource): ResourceDocument = {
       val tags = newResource.tags.getOrElse(List.empty)
-      ResourceDocument(tags = tags)
+      ResourceDocument(
+        tags = tags,
+        resourceId = newResource.resourceId
+      )
     }
 
     def domainToApiModel[Domain, Api](

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/ConverterService.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/ConverterService.scala
@@ -726,7 +726,8 @@ trait ConverterService {
                   status = folder.status.toString,
                   isFavorite = folder.isFavorite,
                   data = subFolders,
-                  breadcrumbs = crumbs
+                  breadcrumbs = crumbs,
+                  parentId = folder.parentId.map(_.toString)
                 )
               )
         }
@@ -747,7 +748,8 @@ trait ConverterService {
             status = domainFolder.status.toString,
             isFavorite = domainFolder.isFavorite,
             data = folderData,
-            breadcrumbs = breadcrumbs
+            breadcrumbs = breadcrumbs,
+            parentId = domainFolder.parentId.map(_.toString)
           )
         )
     }

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/ConverterService.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/ConverterService.scala
@@ -747,7 +747,7 @@ trait ConverterService {
 
     def mergeResource(existing: domain.Resource, updated: api.UpdatedResource): domain.Resource = {
       val tags       = updated.tags.getOrElse(existing.tags)
-      val resourceId = updated.resourceId.orElse(existing.resourceId)
+      val resourceId = updated.resourceId.getOrElse(existing.resourceId)
 
       domain.Resource(
         id = existing.id,
@@ -761,8 +761,7 @@ trait ConverterService {
     }
 
     def mergeResource(existing: domain.Resource, newResource: api.NewResource): domain.Resource = {
-      val tags       = newResource.tags.getOrElse(existing.tags)
-      val resourceId = newResource.resourceId.orElse(existing.resourceId)
+      val tags = newResource.tags.getOrElse(existing.tags)
 
       domain.Resource(
         id = existing.id,
@@ -771,7 +770,7 @@ trait ConverterService {
         path = existing.path,
         created = existing.created,
         tags = tags,
-        resourceId = resourceId
+        resourceId = newResource.resourceId
       )
     }
 

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/ReadService.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/ReadService.scala
@@ -181,8 +181,7 @@ trait ReadService {
       val favoriteFolder = domain.FolderDocument(
         name = FavoriteFolderDefaultName,
         status = domain.FolderStatus.PRIVATE,
-        isFavorite = true,
-        data = List.empty
+        isFavorite = true
       )
       folderRepository.insertFolder(feideId, None, favoriteFolder)
     }
@@ -236,10 +235,10 @@ trait ReadService {
       .folderWithId(folderId)
       .flatMap(folder => {
         val folderResources =
-          if (shouldIncludeResources) folderRepository.getFolderResources(folderId).map(_.map(_.asRight))
+          if (shouldIncludeResources) folderRepository.getFolderResources(folderId)
           else Success(List.empty)
 
-        folderResources.map(res => folder.copy(data = res))
+        folderResources.map(res => folder.copy(resources = res))
       })
 
     def getSingleFolderWithContent(

--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/TestData.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/TestData.scala
@@ -128,14 +128,14 @@ object TestData {
     name = "",
     status = domain.FolderStatus.PRIVATE,
     isFavorite = false,
-    data = List.empty
+    subfolders = List.empty,
+    resources = List.empty
   )
 
   val baseFolderDocument: FolderDocument = FolderDocument(
     isFavorite = false,
     name = "some-name",
-    status = FolderStatus.PUBLIC,
-    data = List.empty
+    status = FolderStatus.PUBLIC
   )
 
   val baseResourceDocument: ResourceDocument = ResourceDocument(
@@ -147,7 +147,8 @@ object TestData {
     name = "",
     status = "",
     isFavorite = false,
-    data = List.empty,
+    subfolders = List.empty,
+    resources = List.empty,
     breadcrumbs = List.empty,
     parentId = None
   )

--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/TestData.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/TestData.scala
@@ -119,7 +119,7 @@ object TestData {
     path = "",
     created = LocalDateTime.now(),
     tags = List.empty,
-    resourceId = None
+    resourceId = 1
   )
 
   val emptyDomainFolder: domain.Folder = domain.Folder(
@@ -141,7 +141,7 @@ object TestData {
 
   val baseResourceDocument: ResourceDocument = ResourceDocument(
     tags = List.empty,
-    resourceId = None
+    resourceId = 1
   )
 
   val emptyApiFolder: api.Folder = api.Folder(

--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/TestData.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/TestData.scala
@@ -148,7 +148,8 @@ object TestData {
     status = "",
     isFavorite = false,
     data = List.empty,
-    breadcrumbs = List.empty
+    breadcrumbs = List.empty,
+    parentId = None
   )
 
 }

--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/TestData.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/TestData.scala
@@ -118,7 +118,8 @@ object TestData {
     resourceType = "",
     path = "",
     created = LocalDateTime.now(),
-    tags = List.empty
+    tags = List.empty,
+    resourceId = None
   )
 
   val emptyDomainFolder: domain.Folder = domain.Folder(
@@ -139,7 +140,8 @@ object TestData {
   )
 
   val baseResourceDocument: ResourceDocument = ResourceDocument(
-    tags = List.empty
+    tags = List.empty,
+    resourceId = None
   )
 
   val emptyApiFolder: api.Folder = api.Folder(

--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/repository/FolderRepositoryTest.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/repository/FolderRepositoryTest.scala
@@ -173,7 +173,7 @@ class FolderRepositoryTest
       resource1.path,
       resource1.resourceType,
       resource1.created,
-      ResourceDocument(resource1.tags)
+      ResourceDocument(resource1.tags, resource1.resourceId)
     )
     val correct =
       repository.resourceWithPathAndTypeAndFeideId(path = "pathernity test", resourceType = "type", feideId = "feide-1")
@@ -330,7 +330,7 @@ class FolderRepositoryTest
       "/testPath",
       "resourceType",
       LocalDateTime.now(),
-      ResourceDocument(List())
+      ResourceDocument(List(), None)
     )
     repository.createFolderResourceConnection(insertedMain.get.id, insertedResource.get.id).get
 

--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/repository/FolderRepositoryTest.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/repository/FolderRepositoryTest.scala
@@ -332,7 +332,7 @@ class FolderRepositoryTest
         "/testPath",
         "resourceType",
         LocalDateTime.now(),
-        ResourceDocument(List(), None)
+        ResourceDocument(List(), 1)
       )
       .failIfFailure
     repository.createFolderResourceConnection(insertedMain.id, insertedResource.id).failIfFailure

--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/repository/FolderRepositoryTest.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/repository/FolderRepositoryTest.scala
@@ -333,16 +333,19 @@ class FolderRepositoryTest
     )
     repository.createFolderResourceConnection(insertedMain.get.id, insertedResource.get.id).get
 
-    val expectedResult = insertedMain.get.copy(
-      data = List(
-        Left(
-          insertedChild1.get.copy(
-            data = List(
-              Left(insertedChild3.get)
-            )
+    val expectedFolders = List(
+      Left(insertedChild2.get),
+      Left(
+        insertedChild1.get.copy(
+          data = List(
+            Left(insertedChild3.get)
           )
-        ),
-        Left(insertedChild2.get),
+        )
+      )
+    ).sortBy { case Left(ch) => ch.id.toString }
+
+    val expectedResult = insertedMain.get.copy(
+      data = expectedFolders ++ List(
         Right(insertedResource.get)
       )
     )

--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/repository/FolderRepositoryTest.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/repository/FolderRepositoryTest.scala
@@ -280,7 +280,10 @@ class FolderRepositoryTest
       ).sortBy(_.id.toString)
     )
 
-    repository.buildTreeStructureFromListOfChildren(List(mainParent, child1, child2, nestedChild1)) should be(
+    repository.buildTreeStructureFromListOfChildren(
+      mainParent.id,
+      List(mainParent, child1, child2, nestedChild1)
+    ) should be(
       Some(expectedResult)
     )
   }

--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/ConverterServiceTest.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/ConverterServiceTest.scala
@@ -522,7 +522,7 @@ class ConverterServiceTest extends UnitSuite with UnitTestEnvironment {
         path = "/subject/1/topic/1/resource/4",
         created = created,
         tags = List("a", "b", "c"),
-        resourceId = None
+        resourceId = 1
       )
     val folderData1 = domain.Folder(
       id = subFolder1UUID,
@@ -570,7 +570,7 @@ class ConverterServiceTest extends UnitSuite with UnitTestEnvironment {
       tags = List("a", "b", "c"),
       created = created,
       path = "/subject/1/topic/1/resource/4",
-      resourceId = None
+      resourceId = 1
     )
     val apiData1 = api.Folder(
       id = subFolder1UUID.toString,
@@ -675,7 +675,7 @@ class ConverterServiceTest extends UnitSuite with UnitTestEnvironment {
         path = "/subject/1/topic/1/resource/4",
         created = created,
         tags = List("a", "b", "c"),
-        resourceId = None
+        resourceId = 1
       )
     val expected =
       api.Resource(
@@ -684,7 +684,7 @@ class ConverterServiceTest extends UnitSuite with UnitTestEnvironment {
         path = "/subject/1/topic/1/resource/4",
         created = created,
         tags = List("a", "b", "c"),
-        resourceId = None
+        resourceId = 1
       )
 
     service.toApiResource(existing) should be(Success(expected))
@@ -698,16 +698,16 @@ class ConverterServiceTest extends UnitSuite with UnitTestEnvironment {
         resourceType = "audio",
         path = "/subject/1/topic/1/resource/4",
         tags = Some(List("a", "b")),
-        resourceId = None
+        resourceId = 1
       )
     val newResource2 =
-      api.NewResource(resourceType = "audio", path = "/subject/1/topic/1/resource/4", tags = None, resourceId = None)
+      api.NewResource(resourceType = "audio", path = "/subject/1/topic/1/resource/4", tags = None, resourceId = 2)
     val expected1 =
       domain.ResourceDocument(
         tags = List("a", "b"),
-        resourceId = None
+        resourceId = 1
       )
-    val expected2 = expected1.copy(tags = List.empty)
+    val expected2 = expected1.copy(tags = List.empty, resourceId = 2)
 
     service.toDomainResource(newResource1) should be(expected1)
     service.toDomainResource(newResource2) should be(expected2)

--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/ConverterServiceTest.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/ConverterServiceTest.scala
@@ -573,7 +573,8 @@ class ConverterServiceTest extends UnitSuite with UnitTestEnvironment {
       status = "private",
       isFavorite = false,
       data = List(apiResource),
-      breadcrumbs = List("mainFolder", "folderData3", "folderData1")
+      breadcrumbs = List("mainFolder", "folderData3", "folderData1"),
+      parentId = Some(subFolder3UUID.toString)
     )
     val apiData2 = api.Folder(
       id = subFolder2UUID.toString,
@@ -581,7 +582,8 @@ class ConverterServiceTest extends UnitSuite with UnitTestEnvironment {
       status = "public",
       isFavorite = false,
       data = List.empty,
-      breadcrumbs = List("mainFolder", "folderData2")
+      breadcrumbs = List("mainFolder", "folderData2"),
+      parentId = Some(mainFolderUUID.toString)
     )
     val apiData3 = api.Folder(
       id = subFolder3UUID.toString,
@@ -589,7 +591,8 @@ class ConverterServiceTest extends UnitSuite with UnitTestEnvironment {
       status = "private",
       isFavorite = false,
       data = List(apiData1),
-      breadcrumbs = List("mainFolder", "folderData3")
+      breadcrumbs = List("mainFolder", "folderData3"),
+      parentId = Some(mainFolderUUID.toString)
     )
     val expected = api.Folder(
       id = mainFolderUUID.toString,
@@ -597,7 +600,8 @@ class ConverterServiceTest extends UnitSuite with UnitTestEnvironment {
       status = "public",
       isFavorite = false,
       data = List(apiData2, apiData3, apiResource),
-      breadcrumbs = List("mainFolder")
+      breadcrumbs = List("mainFolder"),
+      parentId = None
     )
 
     val Success(result) = service.toApiFolder(mainFolder, List("mainFolder"))

--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/ConverterServiceTest.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/ConverterServiceTest.scala
@@ -493,8 +493,7 @@ class ConverterServiceTest extends UnitSuite with UnitTestEnvironment {
     val expected1 = domain.FolderDocument(
       name = "kenkaku",
       status = domain.FolderStatus.PRIVATE,
-      isFavorite = false,
-      data = List.empty
+      isFavorite = false
     )
 
     service.toDomainFolderDocument(newFolder1).get should be(expected1)
@@ -531,7 +530,8 @@ class ConverterServiceTest extends UnitSuite with UnitTestEnvironment {
       name = "folderData1",
       status = domain.FolderStatus.PRIVATE,
       isFavorite = false,
-      data = List(Right(resource))
+      resources = List(resource),
+      subfolders = List.empty
     )
     val folderData2 = domain.Folder(
       id = subFolder2UUID,
@@ -540,7 +540,8 @@ class ConverterServiceTest extends UnitSuite with UnitTestEnvironment {
       name = "folderData2",
       status = domain.FolderStatus.PUBLIC,
       isFavorite = false,
-      data = List.empty
+      subfolders = List.empty,
+      resources = List.empty
     )
     val folderData3 = domain.Folder(
       id = subFolder3UUID,
@@ -549,7 +550,8 @@ class ConverterServiceTest extends UnitSuite with UnitTestEnvironment {
       name = "folderData3",
       status = domain.FolderStatus.PRIVATE,
       isFavorite = false,
-      data = List(Left(folderData1))
+      subfolders = List(folderData1),
+      resources = List.empty
     )
     val mainFolder = domain.Folder(
       id = mainFolderUUID,
@@ -558,7 +560,8 @@ class ConverterServiceTest extends UnitSuite with UnitTestEnvironment {
       name = "mainFolder",
       status = domain.FolderStatus.PUBLIC,
       isFavorite = false,
-      data = List(Left(folderData2), Left(folderData3), Right(resource))
+      subfolders = List(folderData2, folderData3),
+      resources = List(resource)
     )
     val apiResource = api.Resource(
       id = resourceUUID.toString,
@@ -572,7 +575,8 @@ class ConverterServiceTest extends UnitSuite with UnitTestEnvironment {
       name = "folderData1",
       status = "private",
       isFavorite = false,
-      data = List(apiResource),
+      resources = List(apiResource),
+      subfolders = List(),
       breadcrumbs = List("mainFolder", "folderData3", "folderData1"),
       parentId = Some(subFolder3UUID.toString)
     )
@@ -581,7 +585,8 @@ class ConverterServiceTest extends UnitSuite with UnitTestEnvironment {
       name = "folderData2",
       status = "public",
       isFavorite = false,
-      data = List.empty,
+      resources = List.empty,
+      subfolders = List.empty,
       breadcrumbs = List("mainFolder", "folderData2"),
       parentId = Some(mainFolderUUID.toString)
     )
@@ -590,7 +595,8 @@ class ConverterServiceTest extends UnitSuite with UnitTestEnvironment {
       name = "folderData3",
       status = "private",
       isFavorite = false,
-      data = List(apiData1),
+      subfolders = List(apiData1),
+      resources = List(),
       breadcrumbs = List("mainFolder", "folderData3"),
       parentId = Some(mainFolderUUID.toString)
     )
@@ -599,7 +605,8 @@ class ConverterServiceTest extends UnitSuite with UnitTestEnvironment {
       name = "mainFolder",
       status = "public",
       isFavorite = false,
-      data = List(apiData2, apiData3, apiResource),
+      subfolders = List(apiData2, apiData3),
+      resources = List(apiResource),
       breadcrumbs = List("mainFolder"),
       parentId = None
     )
@@ -619,7 +626,8 @@ class ConverterServiceTest extends UnitSuite with UnitTestEnvironment {
       name = "folderData1",
       status = domain.FolderStatus.PRIVATE,
       isFavorite = false,
-      data = List.empty
+      subfolders = List.empty,
+      resources = List.empty
     )
     val updatedWithData    = api.UpdatedFolder(name = Some("newNamae"), status = Some("public"))
     val updatedWithoutData = api.UpdatedFolder(name = None, status = None)

--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/ConverterServiceTest.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/ConverterServiceTest.scala
@@ -521,7 +521,8 @@ class ConverterServiceTest extends UnitSuite with UnitTestEnvironment {
         resourceType = "concept",
         path = "/subject/1/topic/1/resource/4",
         created = created,
-        tags = List("a", "b", "c")
+        tags = List("a", "b", "c"),
+        resourceId = None
       )
     val folderData1 = domain.Folder(
       id = subFolder1UUID,
@@ -568,7 +569,8 @@ class ConverterServiceTest extends UnitSuite with UnitTestEnvironment {
       resourceType = "concept",
       tags = List("a", "b", "c"),
       created = created,
-      path = "/subject/1/topic/1/resource/4"
+      path = "/subject/1/topic/1/resource/4",
+      resourceId = None
     )
     val apiData1 = api.Folder(
       id = subFolder1UUID.toString,
@@ -672,7 +674,8 @@ class ConverterServiceTest extends UnitSuite with UnitTestEnvironment {
         resourceType = "article",
         path = "/subject/1/topic/1/resource/4",
         created = created,
-        tags = List("a", "b", "c")
+        tags = List("a", "b", "c"),
+        resourceId = None
       )
     val expected =
       api.Resource(
@@ -680,7 +683,8 @@ class ConverterServiceTest extends UnitSuite with UnitTestEnvironment {
         resourceType = "article",
         path = "/subject/1/topic/1/resource/4",
         created = created,
-        tags = List("a", "b", "c")
+        tags = List("a", "b", "c"),
+        resourceId = None
       )
 
     service.toApiResource(existing) should be(Success(expected))
@@ -693,13 +697,15 @@ class ConverterServiceTest extends UnitSuite with UnitTestEnvironment {
       api.NewResource(
         resourceType = "audio",
         path = "/subject/1/topic/1/resource/4",
-        tags = Some(List("a", "b"))
+        tags = Some(List("a", "b")),
+        resourceId = None
       )
     val newResource2 =
-      api.NewResource(resourceType = "audio", path = "/subject/1/topic/1/resource/4", tags = None)
+      api.NewResource(resourceType = "audio", path = "/subject/1/topic/1/resource/4", tags = None, resourceId = None)
     val expected1 =
       domain.ResourceDocument(
-        tags = List("a", "b")
+        tags = List("a", "b"),
+        resourceId = None
       )
     val expected2 = expected1.copy(tags = List.empty)
 

--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/ConverterServiceTest.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/ConverterServiceTest.scala
@@ -577,7 +577,11 @@ class ConverterServiceTest extends UnitSuite with UnitTestEnvironment {
       isFavorite = false,
       resources = List(apiResource),
       subfolders = List(),
-      breadcrumbs = List("mainFolder", "folderData3", "folderData1"),
+      breadcrumbs = List(
+        api.Breadcrumb(id = mainFolderUUID.toString, name = "mainFolder"),
+        api.Breadcrumb(id = subFolder3UUID.toString, name = "folderData3"),
+        api.Breadcrumb(id = subFolder1UUID.toString, name = "folderData1")
+      ),
       parentId = Some(subFolder3UUID.toString)
     )
     val apiData2 = api.Folder(
@@ -587,7 +591,10 @@ class ConverterServiceTest extends UnitSuite with UnitTestEnvironment {
       isFavorite = false,
       resources = List.empty,
       subfolders = List.empty,
-      breadcrumbs = List("mainFolder", "folderData2"),
+      breadcrumbs = List(
+        api.Breadcrumb(id = mainFolderUUID.toString, name = "mainFolder"),
+        api.Breadcrumb(id = subFolder2UUID.toString, name = "folderData2")
+      ),
       parentId = Some(mainFolderUUID.toString)
     )
     val apiData3 = api.Folder(
@@ -597,7 +604,10 @@ class ConverterServiceTest extends UnitSuite with UnitTestEnvironment {
       isFavorite = false,
       subfolders = List(apiData1),
       resources = List(),
-      breadcrumbs = List("mainFolder", "folderData3"),
+      breadcrumbs = List(
+        api.Breadcrumb(id = mainFolderUUID.toString, name = "mainFolder"),
+        api.Breadcrumb(id = subFolder3UUID.toString, name = "folderData3")
+      ),
       parentId = Some(mainFolderUUID.toString)
     )
     val expected = api.Folder(
@@ -607,11 +617,14 @@ class ConverterServiceTest extends UnitSuite with UnitTestEnvironment {
       isFavorite = false,
       subfolders = List(apiData2, apiData3),
       resources = List(apiResource),
-      breadcrumbs = List("mainFolder"),
+      breadcrumbs = List(
+        api.Breadcrumb(id = mainFolderUUID.toString, name = "mainFolder")
+      ),
       parentId = None
     )
 
-    val Success(result) = service.toApiFolder(mainFolder, List("mainFolder"))
+    val Success(result) =
+      service.toApiFolder(mainFolder, List(api.Breadcrumb(id = mainFolderUUID.toString, name = "mainFolder")))
     result should be(expected)
   }
 

--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/ReadServiceTest.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/ReadServiceTest.scala
@@ -374,7 +374,7 @@ class ReadServiceTest extends UnitSuite with UnitTestEnvironment {
       name = "mainFolder",
       status = "public",
       isFavorite = false,
-      breadcrumbs = List("mainFolder"),
+      breadcrumbs = List(api.Breadcrumb(id = mainFolderUUID.toString, name = "mainFolder")),
       parentId = None,
       resources = List(
         api.Resource(
@@ -393,7 +393,10 @@ class ReadServiceTest extends UnitSuite with UnitTestEnvironment {
           subfolders = List.empty,
           resources = List.empty,
           isFavorite = false,
-          breadcrumbs = List("mainFolder", "subFolder1"),
+          breadcrumbs = List(
+            api.Breadcrumb(id = mainFolderUUID.toString, name = "mainFolder"),
+            api.Breadcrumb(id = subFolder1UUID.toString, name = "subFolder1")
+          ),
           parentId = Some(mainFolderUUID.toString)
         ),
         api.Folder(
@@ -403,7 +406,10 @@ class ReadServiceTest extends UnitSuite with UnitTestEnvironment {
           resources = List.empty,
           subfolders = List.empty,
           isFavorite = false,
-          breadcrumbs = List("mainFolder", "subFolder2"),
+          breadcrumbs = List(
+            api.Breadcrumb(id = mainFolderUUID.toString, name = "mainFolder"),
+            api.Breadcrumb(id = subFolder2UUID.toString, name = "subFolder2")
+          ),
           parentId = Some(mainFolderUUID.toString)
         )
       )
@@ -459,7 +465,7 @@ class ReadServiceTest extends UnitSuite with UnitTestEnvironment {
         name = "favorite",
         status = "private",
         isFavorite = true,
-        breadcrumbs = List("favorite")
+        breadcrumbs = List(api.Breadcrumb(id = favoriteUUID.toString, name = "favorite"))
       )
 
     when(feideApiClient.getUserFeideID(Some("token"))).thenReturn(Success(feideId))
@@ -494,7 +500,7 @@ class ReadServiceTest extends UnitSuite with UnitTestEnvironment {
         name = "favorite",
         status = "private",
         isFavorite = true,
-        breadcrumbs = List("favorite")
+        breadcrumbs = List(api.Breadcrumb(id = favoriteId.toString, name = "favorite"))
       )
     val apiResource =
       api.Resource(

--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/ReadServiceTest.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/ReadServiceTest.scala
@@ -372,6 +372,7 @@ class ReadServiceTest extends UnitSuite with UnitTestEnvironment {
       status = "public",
       isFavorite = false,
       breadcrumbs = List("mainFolder"),
+      parentId = None,
       data = List(
         api.Folder(
           id = subFolder1UUID.toString,
@@ -379,7 +380,8 @@ class ReadServiceTest extends UnitSuite with UnitTestEnvironment {
           status = "public",
           data = List.empty,
           isFavorite = false,
-          breadcrumbs = List("mainFolder", "subFolder1")
+          breadcrumbs = List("mainFolder", "subFolder1"),
+          parentId = Some(mainFolderUUID.toString)
         ),
         api.Folder(
           id = subFolder2UUID.toString,
@@ -387,7 +389,8 @@ class ReadServiceTest extends UnitSuite with UnitTestEnvironment {
           status = "private",
           data = List.empty,
           isFavorite = false,
-          breadcrumbs = List("mainFolder", "subFolder2")
+          breadcrumbs = List("mainFolder", "subFolder2"),
+          parentId = Some(mainFolderUUID.toString)
         ),
         api.Resource(
           id = resource1UUID.toString,

--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/ReadServiceTest.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/ReadServiceTest.scala
@@ -367,7 +367,7 @@ class ReadServiceTest extends UnitSuite with UnitTestEnvironment {
       path = "/subject/1/topic/1/resource/4",
       created = created,
       tags = List.empty,
-      resourceId = None
+      resourceId = 1
     )
 
     val expected = api.Folder(
@@ -384,7 +384,7 @@ class ReadServiceTest extends UnitSuite with UnitTestEnvironment {
           tags = List.empty,
           path = "/subject/1/topic/1/resource/4",
           created = created,
-          resourceId = None
+          resourceId = 1
         )
       ),
       subfolders = List(
@@ -511,7 +511,7 @@ class ReadServiceTest extends UnitSuite with UnitTestEnvironment {
         path = "",
         created = created,
         tags = List.empty,
-        resourceId = None
+        resourceId = 1
       )
     val folderResourcesResponse1 = Success(List(domainResource, domainResource))
     val folderResourcesResponse2 = Success(List(domainResource))

--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/ReadServiceTest.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/ReadServiceTest.scala
@@ -366,7 +366,8 @@ class ReadServiceTest extends UnitSuite with UnitTestEnvironment {
       resourceType = "article",
       path = "/subject/1/topic/1/resource/4",
       created = created,
-      tags = List.empty
+      tags = List.empty,
+      resourceId = None
     )
 
     val expected = api.Folder(
@@ -382,7 +383,8 @@ class ReadServiceTest extends UnitSuite with UnitTestEnvironment {
           resourceType = "article",
           tags = List.empty,
           path = "/subject/1/topic/1/resource/4",
-          created = created
+          created = created,
+          resourceId = None
         )
       ),
       subfolders = List(
@@ -508,7 +510,8 @@ class ReadServiceTest extends UnitSuite with UnitTestEnvironment {
         resourceType = "",
         path = "",
         created = created,
-        tags = List.empty
+        tags = List.empty,
+        resourceId = None
       )
     val folderResourcesResponse1 = Success(List(domainResource, domainResource))
     val folderResourcesResponse2 = Success(List(domainResource))

--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/UpdateServiceTest.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/UpdateServiceTest.scala
@@ -1474,7 +1474,8 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
       emptyDomainFolder.copy(
         id = id,
         feideId = "FEIDE",
-        data = List(Left(emptyDomainFolder), Left(emptyDomainFolder), Right(emptyDomainResource))
+        subfolders = List(emptyDomainFolder, emptyDomainFolder),
+        resources = List(emptyDomainResource)
       )
     val wrongFeideId = "nope"
 
@@ -1496,13 +1497,16 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
     val subFolder1Id = UUID.randomUUID()
     val subFolder2Id = UUID.randomUUID()
     val resourceId   = UUID.randomUUID()
-    val folder       = emptyDomainFolder.copy(id = mainFolderId, feideId = "FEIDE", data = List.empty)
+    val folder =
+      emptyDomainFolder.copy(id = mainFolderId, feideId = "FEIDE", resources = List.empty, subfolders = List.empty)
     val folderWithChildren =
       folder.copy(
-        data = List(
-          Left(emptyDomainFolder.copy(id = subFolder1Id)),
-          Left(emptyDomainFolder.copy(id = subFolder2Id)),
-          Right(emptyDomainResource.copy(id = resourceId))
+        subfolders = List(
+          emptyDomainFolder.copy(id = subFolder1Id),
+          emptyDomainFolder.copy(id = subFolder2Id)
+        ),
+        resources = List(
+          emptyDomainResource.copy(id = resourceId)
         )
       )
     val correctFeideId = "FEIDE"
@@ -1538,10 +1542,12 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
         id = mainFolderId,
         feideId = "FEIDE",
         isFavorite = true,
-        data = List(
-          Left(emptyDomainFolder.copy(id = subFolder1Id)),
-          Left(emptyDomainFolder.copy(id = subFolder2Id)),
-          Right(emptyDomainResource.copy(id = resourceId))
+        subfolders = List(
+          emptyDomainFolder.copy(id = subFolder1Id),
+          emptyDomainFolder.copy(id = subFolder2Id)
+        ),
+        resources = List(
+          emptyDomainResource.copy(id = resourceId)
         )
       )
 
@@ -1569,13 +1575,16 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
     val subFolder1Id = UUID.randomUUID()
     val subFolder2Id = UUID.randomUUID()
     val resourceId   = UUID.randomUUID()
-    val folder       = emptyDomainFolder.copy(id = mainFolderId, feideId = "FEIDE", data = List.empty)
+    val folder =
+      emptyDomainFolder.copy(id = mainFolderId, feideId = "FEIDE", resources = List.empty, subfolders = List.empty)
     val folderWithChildren =
       folder.copy(
-        data = List(
-          Left(emptyDomainFolder.copy(id = subFolder1Id)),
-          Left(emptyDomainFolder.copy(id = subFolder2Id)),
-          Right(emptyDomainResource.copy(id = resourceId))
+        subfolders = List(
+          emptyDomainFolder.copy(id = subFolder1Id),
+          emptyDomainFolder.copy(id = subFolder2Id)
+        ),
+        resources = List(
+          emptyDomainResource.copy(id = resourceId)
         )
       )
     val correctFeideId = "FEIDE"

--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/UpdateServiceTest.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/UpdateServiceTest.scala
@@ -1703,7 +1703,7 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
     val folderId     = UUID.randomUUID()
     val resourceId   = UUID.randomUUID()
     val resourcePath = "/subject/1/topic/2/resource/3"
-    val newResource  = api.NewResource(resourceType = "", path = resourcePath, tags = None, resourceId = None)
+    val newResource  = api.NewResource(resourceType = "", path = resourcePath, tags = None, resourceId = 1)
     val resource =
       domain.Resource(
         id = resourceId,
@@ -1712,7 +1712,7 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
         resourceType = "",
         created = created,
         tags = List.empty,
-        resourceId = None
+        resourceId = 1
       )
 
     when(feideApiClient.getUserFeideID(any)).thenReturn(Success(feideId))
@@ -1742,7 +1742,7 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
     val folderId     = UUID.randomUUID()
     val resourceId   = UUID.randomUUID()
     val resourcePath = "/subject/1/topic/2/resource/3"
-    val newResource  = api.NewResource(resourceType = "", path = resourcePath, tags = None, resourceId = None)
+    val newResource  = api.NewResource(resourceType = "", path = resourcePath, tags = None, resourceId = 1)
     val resource =
       domain.Resource(
         id = resourceId,
@@ -1751,7 +1751,7 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
         resourceType = "",
         created = created,
         tags = List.empty,
-        resourceId = None
+        resourceId = 1
       )
 
     when(feideApiClient.getUserFeideID(any)).thenReturn(Success(feideId))

--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/UpdateServiceTest.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/UpdateServiceTest.scala
@@ -1703,7 +1703,7 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
     val folderId     = UUID.randomUUID()
     val resourceId   = UUID.randomUUID()
     val resourcePath = "/subject/1/topic/2/resource/3"
-    val newResource  = api.NewResource(resourceType = "", path = resourcePath, tags = None)
+    val newResource  = api.NewResource(resourceType = "", path = resourcePath, tags = None, resourceId = None)
     val resource =
       domain.Resource(
         id = resourceId,
@@ -1711,7 +1711,8 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
         path = resourcePath,
         resourceType = "",
         created = created,
-        tags = List.empty
+        tags = List.empty,
+        resourceId = None
       )
 
     when(feideApiClient.getUserFeideID(any)).thenReturn(Success(feideId))
@@ -1741,7 +1742,7 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
     val folderId     = UUID.randomUUID()
     val resourceId   = UUID.randomUUID()
     val resourcePath = "/subject/1/topic/2/resource/3"
-    val newResource  = api.NewResource(resourceType = "", path = resourcePath, tags = None)
+    val newResource  = api.NewResource(resourceType = "", path = resourcePath, tags = None, resourceId = None)
     val resource =
       domain.Resource(
         id = resourceId,
@@ -1749,7 +1750,8 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
         path = resourcePath,
         resourceType = "",
         created = created,
-        tags = List.empty
+        tags = List.empty,
+        resourceId = None
       )
 
     when(feideApiClient.getUserFeideID(any)).thenReturn(Success(feideId))

--- a/learningpath-api/typescript/index.ts
+++ b/learningpath-api/typescript/index.ts
@@ -44,10 +44,11 @@ export interface IFolder {
   status: string
   isFavorite: boolean
   breadcrumbs: string[]
-  data: IFolderData[]
+  subfolders: IFolderData[]
+  resources: IResource[]
 }
 
-export type IFolderData = (IResource | IFolder)
+export type IFolderData = IFolder
 
 export interface IIntroduction {
   introduction: string

--- a/learningpath-api/typescript/index.ts
+++ b/learningpath-api/typescript/index.ts
@@ -5,6 +5,11 @@ export interface IAuthor {
   name: string
 }
 
+export interface IBreadcrumb {
+  id: string
+  name: string
+}
+
 export interface IConfigMeta {
   key: string
   value: string
@@ -43,7 +48,8 @@ export interface IFolder {
   name: string
   status: string
   isFavorite: boolean
-  breadcrumbs: string[]
+  parentId?: string
+  breadcrumbs: IBreadcrumb[]
   subfolders: IFolderData[]
   resources: IResource[]
 }
@@ -169,6 +175,7 @@ export interface INewResource {
   resourceType: string
   path: string
   tags?: string[]
+  resourceId?: number
 }
 
 export interface IResource {
@@ -177,6 +184,7 @@ export interface IResource {
   path: string
   created: string
   tags: string[]
+  resourceId?: number
 }
 
 export interface ISearchResultV2 {
@@ -199,4 +207,5 @@ export interface IUpdatedFolder {
 
 export interface IUpdatedResource {
   tags?: string[]
+  resourceId?: number
 }

--- a/learningpath-api/typescript/package.json
+++ b/learningpath-api/typescript/package.json
@@ -23,5 +23,5 @@
     "devDependencies": {
         "typescript": "^4.4.3"
     },
-    "version": "0.0.8"
+    "version": "0.0.9"
 }

--- a/learningpath-api/typescript/package.json
+++ b/learningpath-api/typescript/package.json
@@ -23,5 +23,5 @@
     "devDependencies": {
         "typescript": "^4.4.3"
     },
-    "version": "0.0.9"
+    "version": "0.0.10"
 }

--- a/scalatestsuite/src/main/scala/no/ndla/scalatestsuite/UnitTestSuite.scala
+++ b/scalatestsuite/src/main/scala/no/ndla/scalatestsuite/UnitTestSuite.scala
@@ -16,6 +16,7 @@ import org.scalatest.matchers.should.Matchers
 import java.io.IOException
 import java.net.ServerSocket
 import scala.util.Properties.{propOrNone, setProp}
+import scala.util.{Try, Success, Failure}
 
 abstract class UnitTestSuite
     extends AnyFunSuite
@@ -73,5 +74,14 @@ abstract class UnitTestSuite
       }
     }
     throw new IllegalStateException("Could not find a free TCP/IP port to start embedded Jetty HTTP Server on");
+  }
+
+  // Adds method to `Try`s in tests that will fail the test if a `Try` is `Failure`
+  // and return the result if it is a `Success`
+  implicit class failableTry[T](result: Try[T]) {
+    def failIfFailure: T = result match {
+      case Success(r)  => r
+      case Failure(ex) => fail("Failure gotten when Success was expected :^)", ex)
+    }
   }
 }


### PR DESCRIPTION
Første PR på div endringer for å gjøre det enklere å bruke fra frontend (Lager flere for at denne ikke skal bli alt for stor).
Hoved-endringen er at ressurser og subfolders er nå to felter istedet for et.

Gjør også noen andre "småting":
- Fikser så sortering på output fra rekursiv sql ikke har noe å si
  - Remote så var ikke alltid rekkefølgen på radene som forventet så ble litt krøll, nå depender vi ikke på det.
- `parentId` felt på folder
- `resourceId` for metadata id på ressurser
- Breadcrumb er nå objekt istedetfor kun streng
- Forslag (med hjelp fra @N4G1) på hvordan vi kan være mer eksplisitt på at en test feiler om en `Try` er fail
