### PR TITLE
Return `Resource` on `POST`

### DIFF
--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/controller/FolderController.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/controller/FolderController.scala
@@ -142,9 +142,8 @@ trait FolderController {
     ) {
       val newFolder = extract[NewFolder](request.body)
       updateService.newFolder(newFolder, requestFeideToken) match {
-        case Failure(ex) => errorHandler(ex)
-        case Success(folder) =>
-          folder
+        case Failure(ex)     => errorHandler(ex)
+        case Success(folder) => folder
       }
     }
 
@@ -219,7 +218,7 @@ trait FolderController {
     post(
       "/:folder_id/resources/?",
       operation(
-        apiOperation[Unit]("createFolderResource")
+        apiOperation[Resource]("createFolderResource")
           .summary("Creates new folder resource")
           .description("Creates new folder resource")
           .parameters(

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/controller/FolderController.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/controller/FolderController.scala
@@ -182,12 +182,11 @@ trait FolderController {
           .authorizations("oauth2")
       )
     ) {
-      uuidParam(this.folderId.paramName).flatMap(id => {
-        updateService.deleteFolder(id, requestFeideToken)
-      }) match {
-        case Success(_)  => NoContent()
-        case Failure(ex) => errorHandler(ex)
-      }
+      uuidParam(this.folderId.paramName)
+        .flatMap(id => {
+          updateService.deleteFolder(id, requestFeideToken)
+        })
+        .map(_ => NoContent())
     }
 
     get(
@@ -272,14 +271,13 @@ trait FolderController {
           .authorizations("oauth2")
       )
     ) {
-      uuidParam(this.folderId.paramName).flatMap(folderId => {
-        uuidParam(this.resourceId.paramName).flatMap(resourceId => {
-          updateService.deleteConnection(folderId, resourceId, requestFeideToken)
+      uuidParam(this.folderId.paramName)
+        .flatMap(folderId => {
+          uuidParam(this.resourceId.paramName).flatMap(resourceId => {
+            updateService.deleteConnection(folderId, resourceId, requestFeideToken)
+          })
         })
-      }) match {
-        case Success(_)  => NoContent()
-        case Failure(ex) => errorHandler(ex)
-      }
+        .map(_ => NoContent())
     }
   }
 }

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/controller/NdlaController.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/controller/NdlaController.scala
@@ -56,7 +56,7 @@ trait NdlaController {
 
     // This lets us return Try[T] and handle errors automatically, otherwise return 200 OK :^)
     val tryRenderer: RenderPipeline = {
-      case Success(value) => Ok(value)
+      case Success(value) => value
       case Failure(ex) =>
         Try(errorHandler(ex)) match {
           case Failure(ex: HaltException) => renderHaltException(ex)

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/UpdateService.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/UpdateService.scala
@@ -457,20 +457,21 @@ trait UpdateService {
         folderId: UUID,
         newResource: api.NewResource,
         feideAccessToken: Option[FeideAccessToken]
-    ): Try[_] =
+    ): Try[api.Resource] =
       for {
         feideId <- feideApiClient.getUserFeideID(feideAccessToken)
         _ <- folderRepository
           .folderWithFeideId(folderId, feideId)
           .orElse(Failure(NotFoundException(s"Can't connect resource to non-existing folder")))
-        _ <- createNewResourceOrUpdateExisting(newResource, folderId, feideId)
-      } yield ()
+        insertedOrUpdated <- createNewResourceOrUpdateExisting(newResource, folderId, feideId)
+        converted         <- converterService.toApiResource(insertedOrUpdated)
+      } yield converted
 
     private[service] def createNewResourceOrUpdateExisting(
         newResource: api.NewResource,
         folderId: UUID,
         feideId: FeideID
-    ): Try[_] =
+    ): Try[domain.Resource] =
       folderRepository
         .resourceWithPathAndTypeAndFeideId(newResource.path, newResource.resourceType, feideId)
         .flatMap {
@@ -485,13 +486,13 @@ trait UpdateService {
                 document
               )
               _ <- folderRepository.createFolderResourceConnection(folderId, inserted.id)
-            } yield ()
+            } yield inserted
           case Some(existingResource) =>
             val mergedResource = converterService.mergeResource(existingResource, newResource)
             for {
-              _ <- folderRepository.updateResource(mergedResource)
-              _ <- connectIfNotConnected(folderId, mergedResource.id)
-            } yield ()
+              updated <- folderRepository.updateResource(mergedResource)
+              _       <- connectIfNotConnected(folderId, mergedResource.id)
+            } yield updated
         }
 
     private def connectIfNotConnected(folderId: UUID, resourceId: UUID): Try[Unit] =


### PR DESCRIPTION
Fikser så vi returnerer ressursen på `POST` av ressurser, og rydder opp i litt swagger-doc consistencies.