### PR TITLE
add nesting limitation to folders and subfolders

### DIFF
--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/LearningpathApiProperties.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/LearningpathApiProperties.scala
@@ -32,6 +32,7 @@ class LearningpathApiProperties extends LazyLogging {
   def ContactUrl: String      = propOrElse("CONTACT_URL", "ndla.no")
   def ContactEmail: String    = propOrElse("CONTACT_EMAIL", "support+api@ndla.no")
   def TermsUrl: String        = propOrElse("TERMS_URL", "https://om.ndla.no/tos")
+  def MaxFolderDepth: Long    = propOrElse("MAX_FOLDER_DEPTH", "5").toLong
 
   def Domain: String = propOrElse("BACKEND_API_DOMAIN", Domains.get(Environment))
 

--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/UpdateServiceTest.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/UpdateServiceTest.scala
@@ -21,7 +21,6 @@ import no.ndla.learningpathapi.model.api.{
   UpdatedLearningPathV2,
   UpdatedLearningStepV2
 }
-import no.ndla.learningpathapi.validation.TextValidatorTest
 import no.ndla.learningpathapi.model.domain._
 import no.ndla.learningpathapi.model.domain.config.{ConfigKey, ConfigMeta}
 import org.mockito.invocation.InvocationOnMock


### PR DESCRIPTION
Begrenser antall nesta foldre. Limit er tentativt satt til `5`. Vi tar utgangspunktet i at parent er rota og da er depth 0, og så kan det være max 5 nesta barn. Så praktisk sett kan det være 6 nesta foldre.

Kom med forslag hvis det er noe :)