### PR TITLE
#3199: Handle deleting of file meta when deleting language

### DIFF
--- a/image-api/src/main/scala/no/ndla/imageapi/repository/ImageRepository.scala
+++ b/image-api/src/main/scala/no/ndla/imageapi/repository/ImageRepository.scala
@@ -90,6 +90,14 @@ trait ImageRepository {
       sql"delete from imagemetadata where id = ${imageId}".update()
     }
 
+    def deleteImageFileMeta(imageId: Long, language: String)(implicit session: DBSession = AutoSession): Try[Int] = {
+      Try(sql"""
+            delete from imagefiledata
+            where image_meta_id = $imageId
+            and metadata->>'language' = $language
+         """.update())
+    }
+
     def minMaxId: (Long, Long) = {
       DB readOnly { implicit session =>
         sql"select coalesce(MIN(id),0) as mi, coalesce(MAX(id),0) as ma from imagemetadata"

--- a/image-api/src/test/scala/no/ndla/imageapi/service/WriteServiceTest.scala
+++ b/image-api/src/test/scala/no/ndla/imageapi/service/WriteServiceTest.scala
@@ -687,6 +687,7 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
     when(imageRepository.update(any, any)(any)).thenAnswer((i: InvocationOnMock) => {
       i.getArgument[domain.ImageMetaInformation](0)
     })
+    when(imageRepository.deleteImageFileMeta(eqTo(imageId), eqTo("nn"))(any)).thenReturn(Success(1))
     when(imageStorage.cloneObject(any, any)).thenReturn(Success(()))
     when(imageStorage.uploadFromStream(any, any, any, any)).thenAnswer((i: InvocationOnMock) => {
       Success(i.getArgument[String](1))
@@ -717,6 +718,7 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
     verify(imageStorage, times(0)).cloneObject(any, any)
     verify(imageRepository, times(1)).update(any, any)(any)
     verify(imageRepository, times(0)).insertImageFile(any, any, any)(any)
+    verify(imageRepository, times(1)).deleteImageFileMeta(imageId, "nn")
   }
 
   test("Deleting language version should not delete file if it used by more languages") {
@@ -756,6 +758,7 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
     when(imageRepository.update(any, any)(any)).thenAnswer((i: InvocationOnMock) => {
       i.getArgument[domain.ImageMetaInformation](0)
     })
+    when(imageRepository.deleteImageFileMeta(eqTo(imageId), eqTo("nn"))(any)).thenReturn(Success(1))
     when(imageStorage.cloneObject(any, any)).thenReturn(Success(()))
     when(imageStorage.uploadFromStream(any, any, any, any)).thenAnswer((i: InvocationOnMock) => {
       Success(i.getArgument[String](1))
@@ -786,5 +789,6 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
     verify(imageStorage, times(0)).cloneObject(any, any)
     verify(imageRepository, times(1)).update(any, any)(any)
     verify(imageRepository, times(0)).insertImageFile(any, any, any)(any)
+    verify(imageRepository, times(1)).deleteImageFileMeta(imageId, "nn")
   }
 }


### PR DESCRIPTION
Fixes NDLANO/Issues#3199

Vi slettet ikke fra imagefiledata tabellen med mindre imagemetadata også ble slettet. :smile:
Kan testes ved å se at sletting av språkvariant fjerner metadata (og "supportedLanguages" for språket man sletter)