### PR TITLE
Disallow duplicate folder names in folder

### DIFF
--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/UpdateServiceTest.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/UpdateServiceTest.scala
@@ -1820,6 +1820,8 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
       .thenReturn(Success(parentId))
     when(folderRepository.folderWithFeideId(eqTo(parentId), eqTo(feideId))(any[DBSession]))
       .thenReturn(Success(emptyDomainFolder))
+    when(folderRepository.foldersWithFeideAndParentID(eqTo(Some(parentId)), eqTo(feideId))(any))
+      .thenReturn(Success(List.empty))
     when(folderRepository.getFoldersDepth(eqTo(parentId))(any[DBSession])).thenReturn(Success(props.MaxFolderDepth))
 
     val Failure(result: ValidationException) = service.newFolder(newFolder, Some(feideId))
@@ -1863,9 +1865,56 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
     when(folderRepository.getFoldersDepth(eqTo(parentId))(any[DBSession])).thenReturn(Success(belowLimit))
     when(folderRepository.insertFolder(any, any, any)(any[DBSession])).thenReturn(Success(domainFolder))
     when(readService.getBreadcrumbs(any)(any)).thenReturn(Success(List.empty))
+    when(folderRepository.foldersWithFeideAndParentID(eqTo(Some(parentId)), eqTo(feideId))(any))
+      .thenReturn(Success(List.empty))
 
     service.newFolder(newFolder, Some(feideId)) should be(Success(apiFolder))
 
     verify(folderRepository, times(1)).insertFolder(any, any, any)(any)
+  }
+
+  test("that folder is not created if name already exists as a sibling") {
+    val feideId   = "FEIDE"
+    val folderId  = UUID.randomUUID()
+    val parentId  = UUID.randomUUID()
+    val newFolder = api.NewFolder(name = "asd", parentId = Some(parentId.toString), status = None)
+    val domainFolder = domain.Folder(
+      id = folderId,
+      feideId = feideId,
+      parentId = Some(parentId),
+      name = "asd",
+      status = domain.FolderStatus.PRIVATE,
+      subfolders = List.empty,
+      resources = List.empty
+    )
+    val siblingFolder = domain.Folder(
+      id = UUID.randomUUID(),
+      feideId = feideId,
+      parentId = Some(parentId),
+      name = "aSd",
+      status = domain.FolderStatus.PRIVATE,
+      subfolders = List.empty,
+      resources = List.empty
+    )
+    val belowLimit = props.MaxFolderDepth - 2
+
+    when(feideApiClient.getUserFeideID(any)).thenReturn(Success(feideId))
+    when(converterService.toUUIDValidated(eqTo(Some(parentId.toString)), eqTo("parentId")))
+      .thenReturn(Success(parentId))
+    when(folderRepository.folderWithFeideId(eqTo(parentId), eqTo(feideId))(any[DBSession]))
+      .thenReturn(Success(emptyDomainFolder))
+    when(folderRepository.getFoldersDepth(eqTo(parentId))(any[DBSession])).thenReturn(Success(belowLimit))
+    when(folderRepository.insertFolder(any, any, any)(any[DBSession])).thenReturn(Success(domainFolder))
+    when(readService.getBreadcrumbs(any)(any)).thenReturn(Success(List.empty))
+    when(folderRepository.foldersWithFeideAndParentID(eqTo(Some(parentId)), eqTo(feideId))(any))
+      .thenReturn(Success(List(siblingFolder)))
+
+    service.newFolder(newFolder, Some(feideId)) should be(
+      Failure(
+        ValidationException("name", s"The folder name must be unique within its parent.")
+      )
+    )
+
+    verify(folderRepository, times(0)).insertFolder(any, any, any)(any)
   }
 }

--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/UpdateServiceTest.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/UpdateServiceTest.scala
@@ -1917,4 +1917,51 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
 
     verify(folderRepository, times(0)).insertFolder(any, any, any)(any)
   }
+
+  test("that folder is not updated if name already exists as a sibling") {
+    val feideId      = "FEIDE"
+    val folderId     = UUID.randomUUID()
+    val parentId     = UUID.randomUUID()
+    val updateFolder = api.UpdatedFolder(name = Some("asd"), status = None)
+
+    val existingFolder = domain.Folder(
+      id = folderId,
+      feideId = feideId,
+      parentId = Some(parentId),
+      name = "noe unikt",
+      status = domain.FolderStatus.PRIVATE,
+      subfolders = List.empty,
+      resources = List.empty
+    )
+    val siblingFolder = domain.Folder(
+      id = UUID.randomUUID(),
+      feideId = feideId,
+      parentId = Some(parentId),
+      name = "aSd",
+      status = domain.FolderStatus.PRIVATE,
+      subfolders = List.empty,
+      resources = List.empty
+    )
+    val belowLimit = props.MaxFolderDepth - 2
+
+    when(feideApiClient.getUserFeideID(any)).thenReturn(Success(feideId))
+    when(converterService.toUUIDValidated(eqTo(Some(parentId.toString)), eqTo("parentId")))
+      .thenReturn(Success(parentId))
+    when(folderRepository.folderWithFeideId(eqTo(parentId), eqTo(feideId))(any[DBSession]))
+      .thenReturn(Success(emptyDomainFolder))
+    when(folderRepository.getFoldersDepth(eqTo(parentId))(any[DBSession])).thenReturn(Success(belowLimit))
+    when(readService.getBreadcrumbs(any)(any)).thenReturn(Success(List.empty))
+    when(folderRepository.foldersWithFeideAndParentID(eqTo(Some(parentId)), eqTo(feideId))(any))
+      .thenReturn(Success(List(siblingFolder)))
+    when(folderRepository.folderWithId(eqTo(folderId))(any)).thenReturn(Success(existingFolder))
+
+    service.updateFolder(folderId, updateFolder, Some(feideId)) should be(
+      Failure(
+        ValidationException("name", s"The folder name must be unique within its parent.")
+      )
+    )
+
+    verify(folderRepository, times(0)).insertFolder(any, any, any)(any)
+    verify(folderRepository, times(0)).updateFolder(any, any, any)(any)
+  }
 }


### PR DESCRIPTION
Kan testes ved å sjekke at vi returnerer 400 om man forsøker å opprette en mappe med samme navn som en av mappene som allerede finnes i mappen man oppretter i :^)