### PR TITLE
Force to update taxonomy draft

### DIFF
--- a/draft-api/src/main/scala/no/ndla/draftapi/DraftApiProperties.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/DraftApiProperties.scala
@@ -100,6 +100,9 @@ class DraftApiProperties extends LazyLogging {
   def CorrelationIdKey    = "correlationID"
   def CorrelationIdHeader = "X-Correlation-ID"
 
+  def TaxonomyVersionIdKey  = "versionHash"
+  def TaxonomyVersionHeader = "VersionHash"
+
   def AttachmentStorageName: String =
     propOrElse("ARTICLE_ATTACHMENT_S3_BUCKET", s"$Environment.article-attachments.ndla")
 

--- a/draft-api/src/main/scala/no/ndla/draftapi/controller/NdlaController.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/controller/NdlaController.scala
@@ -38,6 +38,7 @@ trait NdlaController {
       contentType = formats("json")
       CorrelationID.set(Option(request.getHeader(CorrelationIdHeader)))
       ThreadContext.put(CorrelationIdKey, CorrelationID.get.getOrElse(""))
+      ThreadContext.put(TaxonomyVersionIdKey, Option(request.getHeader(TaxonomyVersionHeader)).getOrElse("default"))
       ApplicationUrl.set(request)
       AuthUser.set(request)
     }
@@ -45,6 +46,7 @@ trait NdlaController {
     after() {
       CorrelationID.clear()
       ThreadContext.remove(CorrelationIdKey)
+      ThreadContext.remove(TaxonomyVersionIdKey)
       AuthUser.clear()
       ApplicationUrl.clear()
     }

--- a/draft-api/src/main/scala/no/ndla/draftapi/integration/TaxonomyApiClient.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/integration/TaxonomyApiClient.scala
@@ -210,13 +210,15 @@ trait TaxonomyApiClient {
     }
 
     private def get[A](url: String, params: (String, String)*)(implicit mf: Manifest[A]): Try[A] =
-      ndlaClient.fetchWithForwardedAuth[A](Http(url).timeout(taxonomyTimeout, taxonomyTimeout).params(params))
+      ndlaClient.fetchWithForwardedAuth[A](
+        Http(url).timeout(taxonomyTimeout, taxonomyTimeout).header("VersionHash", "default").params(params)
+      )
 
     def queryResource(articleId: Long): Try[List[Resource]] =
-      get[List[Resource]](s"$TaxonomyApiEndpoint/queries/resources", "contentURI" -> s"urn:article:$articleId")
+      get[List[Resource]](s"$TaxonomyApiEndpoint/resources", "contentURI" -> s"urn:article:$articleId")
 
     def queryTopic(articleId: Long): Try[List[Topic]] =
-      get[List[Topic]](s"$TaxonomyApiEndpoint/queries/topics", "contentURI" -> s"urn:article:$articleId")
+      get[List[Topic]](s"$TaxonomyApiEndpoint/topics", "contentURI" -> s"urn:article:$articleId")
 
     def getNode(uri: String): Try[Topic] = get[Topic](s"$TaxonomyApiEndpoint/nodes/${uri}")
 

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/integration/TaxonomyApiClient.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/integration/TaxonomyApiClient.scala
@@ -221,7 +221,9 @@ trait TaxonomyApiClient {
       get[List[Topic]](s"$TaxonomyApiEndpoint/queries/topics", "contentURI" -> s"urn:article:$articleId")
 
     private def get[A](url: String, params: (String, String)*)(implicit mf: Manifest[A]): Try[A] = {
-      ndlaClient.fetchWithForwardedAuth[A](Http(url).timeout(taxonomyTimeout, taxonomyTimeout).params(params))
+      ndlaClient.fetchWithForwardedAuth[A](
+        Http(url).timeout(taxonomyTimeout, taxonomyTimeout).header("VersionHash", "default").params(params)
+      )
     }
 
     private def put[A, B <: AnyRef](url: String, data: B, params: (String, String)*)(implicit


### PR DESCRIPTION
Fikser problemet med at emner ikkje oppdateres etter endring av contenturi. Problemet var rett og slett at uten taxonomyhash header så hentes data fra publisert versjon, og der er det jo ikkje endra noko.

Har deploya release fra denne branchen i test for å verifisere at det virker, og då fikk eg oppdatert emnet i ed-pr. Men du må laste struktur på nytt for at nytt navn på emnet skal oppdateres. Kanskje oppdatere meldinga til bruker om at "Artikkel er bytta ut. Last sida på nytt for å vise endring."