### PR TITLE
Fix automatic rank for root folder

### DIFF
--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/model/domain/FolderAndDirectChildren.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/model/domain/FolderAndDirectChildren.scala
@@ -9,7 +9,7 @@
 package no.ndla.learningpathapi.model.domain
 
 case class FolderAndDirectChildren(
-    folder: Folder,
+    folder: Option[Folder],
     childrenFolders: Seq[Folder],
     childrenResources: Seq[FolderResource]
 )

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/repository/FolderRepository.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/repository/FolderRepository.scala
@@ -39,7 +39,7 @@ trait FolderRepository {
         feideId: FeideID,
         parentId: Option[UUID],
         document: FolderDocument,
-        rank: Option[Int]
+        rank: Int
     )(implicit session: DBSession = AutoSession): Try[Folder] =
       Try {
         val dataObject = new PGobject()
@@ -60,7 +60,7 @@ trait FolderRepository {
           parentId = parentId,
           resources = List.empty,
           subfolders = List.empty,
-          rank = rank
+          rank = rank.some
         )
       }
 

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/ReadService.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/ReadService.scala
@@ -195,7 +195,7 @@ trait ReadService {
         name = FavoriteFolderDefaultName,
         status = domain.FolderStatus.PRIVATE
       )
-      folderRepository.insertFolder(feideId, None, favoriteFolder, None)
+      folderRepository.insertFolder(feideId, None, favoriteFolder, 1)
     }
 
     def getBreadcrumbs(folder: domain.Folder)(implicit session: DBSession): Try[List[api.Breadcrumb]] = {

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/UpdateService.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/UpdateService.scala
@@ -478,32 +478,33 @@ trait UpdateService {
     private def getFolderWithDirectChildren(
         maybeParentId: Option[UUID],
         feideId: FeideID
-    ): Try[Option[FolderAndDirectChildren]] = maybeParentId match {
-      case None => Success(None)
+    ): Try[FolderAndDirectChildren] = maybeParentId match {
+      case None =>
+        folderRepository
+          .foldersWithFeideAndParentID(None, feideId)
+          .map(siblingFolders => {
+            FolderAndDirectChildren(None, siblingFolders, Seq.empty)
+          })
       case Some(parentId) =>
         folderRepository.folderWithFeideId(parentId, feideId) match {
-          case Failure(_: NotFoundException) => Success(None)
-          case Failure(ex)                   => Failure(ex)
+          case Failure(ex) => Failure(ex)
           case Success(parent) =>
             for {
               siblingFolders   <- folderRepository.foldersWithFeideAndParentID(parentId.some, feideId)
               siblingResources <- folderRepository.getConnections(parentId)
-            } yield Some(FolderAndDirectChildren(parent, siblingFolders, siblingResources))
+            } yield FolderAndDirectChildren(Some(parent), siblingFolders, siblingResources)
         }
     }
 
     private def validateSiblingNames(
         name: String,
-        maybeParentAndSiblings: Option[FolderAndDirectChildren]
+        maybeParentAndSiblings: FolderAndDirectChildren
     ): Try[Unit] = {
-      maybeParentAndSiblings
-        .map { case FolderAndDirectChildren(_, siblings, _) =>
-          val hasNameDuplicate = siblings.map(_.name).exists(_.toLowerCase == name.toLowerCase)
-          if (hasNameDuplicate) {
-            Failure(ValidationException("name", s"The folder name must be unique within its parent."))
-          } else Success(())
-        }
-        .getOrElse(Success(()))
+      val FolderAndDirectChildren(_, siblings, _) = maybeParentAndSiblings
+      val hasNameDuplicate                        = siblings.map(_.name).exists(_.toLowerCase == name.toLowerCase)
+      if (hasNameDuplicate) {
+        Failure(ValidationException("name", s"The folder name must be unique within its parent."))
+      } else Success(())
     }
 
     private def getMaybeParentId(parentId: Option[String]): Try[Option[UUID]] = {
@@ -513,17 +514,14 @@ trait UpdateService {
     private def validateFolder(
         folderName: String,
         parentId: Option[UUID],
-        maybeParentAndSiblings: Option[FolderAndDirectChildren]
+        maybeParentAndSiblings: FolderAndDirectChildren
     ): Try[Option[UUID]] = for {
-      validatedParentId <- validateParentId(parentId, maybeParentAndSiblings.map(_.folder))
+      validatedParentId <- validateParentId(parentId, maybeParentAndSiblings.folder)
       _                 <- validateSiblingNames(folderName, maybeParentAndSiblings)
       _                 <- checkDepth(validatedParentId)
     } yield validatedParentId
 
-    private def getNextRank(siblings: Option[FolderAndDirectChildren]): Option[Int] = siblings.map {
-      case FolderAndDirectChildren(_, siblingFolders, siblingResources) =>
-        (siblingFolders.length + siblingResources.length) + 1
-    }
+    private def getNextRank(siblings: Seq[_]): Int = siblings.length + 1
 
     def newFolder(newFolder: api.NewFolder, feideAccessToken: Option[FeideAccessToken]): Try[api.Folder] =
       for {
@@ -531,7 +529,7 @@ trait UpdateService {
         document          <- converterService.toDomainFolderDocument(newFolder)
         parentId          <- getMaybeParentId(newFolder.parentId)
         maybeSiblings     <- getFolderWithDirectChildren(parentId, feideId)
-        nextRank          <- Try(getNextRank(maybeSiblings)) // `Try` for align
+        nextRank          <- Try(getNextRank(maybeSiblings.childrenFolders)) // `Try` for align
         validatedParentId <- validateFolder(newFolder.name, parentId, maybeSiblings)
         inserted          <- folderRepository.insertFolder(feideId, validatedParentId, document, nextRank)
         crumbs            <- readService.getBreadcrumbs(inserted)(ReadOnlyAutoSession)
@@ -557,10 +555,10 @@ trait UpdateService {
     private[service] def createNewResourceOrUpdateExisting(
         newResource: api.NewResource,
         folderId: UUID,
-        siblings: Option[FolderAndDirectChildren],
+        siblings: FolderAndDirectChildren,
         feideId: FeideID
     ): Try[(domain.Resource, domain.FolderResource)] = {
-      val rank = getNextRank(siblings).getOrElse(1)
+      val rank = getNextRank(siblings.childrenResources)
       folderRepository
         .resourceWithPathAndTypeAndFeideId(newResource.path, newResource.resourceType, feideId)
         .flatMap {
@@ -742,20 +740,16 @@ trait UpdateService {
         folderId: UUID,
         sortRequest: FolderSortRequest,
         feideId: FeideID
-    ): Try[Unit] = getFolderWithDirectChildren(folderId.some, feideId) match {
-      case Failure(ex)   => Failure(ex)
-      case Success(None) => Failure(NotFoundException(s"Folder with id $folderId was not found."))
-      case Success(Some(FolderAndDirectChildren(_, _, resources))) => performSort(resources, sortRequest, feideId)
+    ): Try[Unit] = getFolderWithDirectChildren(folderId.some, feideId).map {
+      case FolderAndDirectChildren(_, _, resources) => performSort(resources, sortRequest, feideId)
     }
 
     private def sortNonRootFolderSubfolders(
         folderId: UUID,
         sortRequest: FolderSortRequest,
         feideId: FeideID
-    ): Try[Unit] = getFolderWithDirectChildren(folderId.some, feideId) match {
-      case Failure(ex)   => Failure(ex)
-      case Success(None) => Failure(NotFoundException(s"Folder with id $folderId was not found."))
-      case Success(Some(FolderAndDirectChildren(_, subfolders, _))) => performSort(subfolders, sortRequest, feideId)
+    ): Try[Unit] = getFolderWithDirectChildren(folderId.some, feideId).map {
+      case FolderAndDirectChildren(_, subfolders, _) => performSort(subfolders, sortRequest, feideId)
     }
 
     def sortFolder(

--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/repository/FolderRepositoryTest.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/repository/FolderRepositoryTest.scala
@@ -101,9 +101,9 @@ class FolderRepositoryTest
   }
 
   test("that inserting and retrieving a folder works as expected") {
-    val folder1 = repository.insertFolder("feide", None, TestData.baseFolderDocument, None)
-    val folder2 = repository.insertFolder("feide", None, TestData.baseFolderDocument, None)
-    val folder3 = repository.insertFolder("feide", None, TestData.baseFolderDocument, None)
+    val folder1 = repository.insertFolder("feide", None, TestData.baseFolderDocument, 1)
+    val folder2 = repository.insertFolder("feide", None, TestData.baseFolderDocument, 2)
+    val folder3 = repository.insertFolder("feide", None, TestData.baseFolderDocument, 3)
 
     repository.folderWithId(folder1.get.id) should be(folder1)
     repository.folderWithId(folder2.get.id) should be(folder2)
@@ -124,8 +124,8 @@ class FolderRepositoryTest
   }
 
   test("that connecting folders and resources works as expected") {
-    val folder1 = repository.insertFolder("feide", None, TestData.baseFolderDocument, None)
-    val folder2 = repository.insertFolder("feide", None, TestData.baseFolderDocument, None)
+    val folder1 = repository.insertFolder("feide", None, TestData.baseFolderDocument, 1)
+    val folder2 = repository.insertFolder("feide", None, TestData.baseFolderDocument, 2)
 
     val created = LocalDateTime.now()
 
@@ -142,8 +142,8 @@ class FolderRepositoryTest
   test("that deleting a folder deletes folder-resource connection") {
     val created = LocalDateTime.now()
 
-    val folder1 = repository.insertFolder("feide", None, TestData.baseFolderDocument, None)
-    val folder2 = repository.insertFolder("feide", None, TestData.baseFolderDocument, None)
+    val folder1 = repository.insertFolder("feide", None, TestData.baseFolderDocument, 1)
+    val folder2 = repository.insertFolder("feide", None, TestData.baseFolderDocument, 2)
 
     val resource1 = repository.insertResource("feide", "/path1", "type", created, TestData.baseResourceDocument)
     val resource2 = repository.insertResource("feide", "/path2", "type", created, TestData.baseResourceDocument)
@@ -159,8 +159,8 @@ class FolderRepositoryTest
   test("that deleting a resource deletes folder-resource connection") {
     val created = LocalDateTime.now()
 
-    val folder1 = repository.insertFolder("feide", None, TestData.baseFolderDocument, None)
-    val folder2 = repository.insertFolder("feide", None, TestData.baseFolderDocument, None)
+    val folder1 = repository.insertFolder("feide", None, TestData.baseFolderDocument, 1)
+    val folder2 = repository.insertFolder("feide", None, TestData.baseFolderDocument, 2)
 
     val resource1 = repository.insertResource("feide", "/path1", "type", created, TestData.baseResourceDocument)
     val resource2 = repository.insertResource("feide", "/path2", "type", created, TestData.baseResourceDocument)
@@ -206,11 +206,11 @@ class FolderRepositoryTest
   }
 
   test("that foldersWithParentID works correctly") {
-    val parent1 = repository.insertFolder("feide", None, TestData.baseFolderDocument, None)
-    val parent2 = repository.insertFolder("feide", None, TestData.baseFolderDocument, None)
+    val parent1 = repository.insertFolder("feide", None, TestData.baseFolderDocument, 1)
+    val parent2 = repository.insertFolder("feide", None, TestData.baseFolderDocument, 2)
 
-    repository.insertFolder("feide", Some(parent1.get.id), TestData.baseFolderDocument, None)
-    repository.insertFolder("feide", Some(parent2.get.id), TestData.baseFolderDocument, None)
+    repository.insertFolder("feide", Some(parent1.get.id), TestData.baseFolderDocument, 3)
+    repository.insertFolder("feide", Some(parent2.get.id), TestData.baseFolderDocument, 4)
 
     repository.foldersWithFeideAndParentID(None, "feide").get.length should be(2)
     repository.foldersWithFeideAndParentID(Some(parent1.get.id), "feide").get.length should be(1)
@@ -221,8 +221,8 @@ class FolderRepositoryTest
     val created = LocalDateTime.now()
     val doc     = FolderDocument(name = "some name", status = FolderStatus.PUBLIC)
 
-    val folder1 = repository.insertFolder("feide", None, doc, None)
-    val folder2 = repository.insertFolder("feide", Some(folder1.get.id), doc, None)
+    val folder1 = repository.insertFolder("feide", None, doc, 1)
+    val folder2 = repository.insertFolder("feide", Some(folder1.get.id), doc, 2)
 
     val resource1 = repository.insertResource("feide", "/path1", "type", created, TestData.baseResourceDocument)
     val resource2 = repository.insertResource("feide", "/path2", "type", created, TestData.baseResourceDocument)
@@ -335,11 +335,11 @@ class FolderRepositoryTest
       parentId = child1.id.some
     )
 
-    val insertedMain   = repository.insertFolder("feide", None, mainParent.toDocument, None).failIfFailure
-    val insertedChild1 = repository.insertFolder("feide", insertedMain.id.some, child1.toDocument, None).failIfFailure
-    val insertedChild2 = repository.insertFolder("feide", insertedMain.id.some, child2.toDocument, None).failIfFailure
+    val insertedMain   = repository.insertFolder("feide", None, mainParent.toDocument, 1).failIfFailure
+    val insertedChild1 = repository.insertFolder("feide", insertedMain.id.some, child1.toDocument, 2).failIfFailure
+    val insertedChild2 = repository.insertFolder("feide", insertedMain.id.some, child2.toDocument, 3).failIfFailure
     val insertedChild3 =
-      repository.insertFolder("feide", insertedChild1.id.some, nestedChild1.toDocument, None).failIfFailure
+      repository.insertFolder("feide", insertedChild1.id.some, nestedChild1.toDocument, 4).failIfFailure
     val insertedResource = repository
       .insertResource(
         "feide",
@@ -371,12 +371,12 @@ class FolderRepositoryTest
   }
 
   test("that deleteAllUserFolders works as expected") {
-    repository.insertFolder("feide1", None, TestData.baseFolderDocument, None)
-    repository.insertFolder("feide2", None, TestData.baseFolderDocument, None)
-    repository.insertFolder("feide3", None, TestData.baseFolderDocument, None)
-    repository.insertFolder("feide1", None, TestData.baseFolderDocument, None)
-    repository.insertFolder("feide2", None, TestData.baseFolderDocument, None)
-    repository.insertFolder("feide1", None, TestData.baseFolderDocument, None)
+    repository.insertFolder("feide1", None, TestData.baseFolderDocument, 1)
+    repository.insertFolder("feide2", None, TestData.baseFolderDocument, 2)
+    repository.insertFolder("feide3", None, TestData.baseFolderDocument, 3)
+    repository.insertFolder("feide1", None, TestData.baseFolderDocument, 4)
+    repository.insertFolder("feide2", None, TestData.baseFolderDocument, 5)
+    repository.insertFolder("feide1", None, TestData.baseFolderDocument, 6)
 
     folderCount() should be(6)
     repository.deleteAllUserFolders(feideId = "feide1") should be(Success(3))
@@ -404,9 +404,9 @@ class FolderRepositoryTest
     val created = LocalDateTime.now()
     val doc     = FolderDocument(name = "some name", status = FolderStatus.PUBLIC)
 
-    val folder1 = repository.insertFolder("feide1", None, doc, None)
-    val folder2 = repository.insertFolder("feide1", Some(folder1.get.id), doc, None)
-    val folder3 = repository.insertFolder("feide2", None, doc, None)
+    val folder1 = repository.insertFolder("feide1", None, doc, 1)
+    val folder2 = repository.insertFolder("feide1", Some(folder1.get.id), doc, 2)
+    val folder3 = repository.insertFolder("feide2", None, doc, 3)
 
     val resource1 = repository.insertResource("feide1", "/path1", "type", created, TestData.baseResourceDocument)
     val resource2 = repository.insertResource("feide1", "/path2", "type", created, TestData.baseResourceDocument)

--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/UpdateServiceTest.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/UpdateServiceTest.scala
@@ -1692,7 +1692,14 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
       Success(FolderResource(folderId = i.getArgument(0), resourceId = i.getArgument(1), rank = i.getArgument(2)))
     })
 
-    service.createNewResourceOrUpdateExisting(newResource, folderId, None, feideId).isSuccess should be(true)
+    service
+      .createNewResourceOrUpdateExisting(
+        newResource,
+        folderId,
+        FolderAndDirectChildren(None, Seq.empty, Seq.empty),
+        feideId
+      )
+      .isSuccess should be(true)
 
     verify(folderRepository, times(1)).resourceWithPathAndTypeAndFeideId(eqTo(resourcePath), eqTo(""), eqTo(feideId))(
       any
@@ -1735,7 +1742,14 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
       Success(FolderResource(folderId = i.getArgument(0), resourceId = i.getArgument(1), rank = i.getArgument(2)))
     })
 
-    service.createNewResourceOrUpdateExisting(newResource, folderId, None, feideId).get
+    service
+      .createNewResourceOrUpdateExisting(
+        newResource,
+        folderId,
+        FolderAndDirectChildren(None, Seq.empty, Seq.empty),
+        feideId
+      )
+      .get
 
     verify(folderRepository, times(1)).resourceWithPathAndTypeAndFeideId(eqTo(resourcePath), eqTo(""), eqTo(feideId))(
       any

--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/UpdateServiceTest.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/UpdateServiceTest.scala
@@ -1485,6 +1485,7 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
       )
     val wrongFeideId = "nope"
 
+    when(folderRepository.foldersWithFeideAndParentID(any, any)(any)).thenReturn(Success(List.empty))
     when(feideApiClient.getUserFeideID(any)).thenReturn(Success(wrongFeideId))
     when(folderRepository.folderResourceConnectionCount(any)(any)).thenReturn(Success(0))
     when(folderRepository.folderWithId(eqTo(id))(any)).thenReturn(Success(folderWithChildren))
@@ -1517,6 +1518,11 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
       )
     val correctFeideId = "FEIDE"
 
+    when(folderRepository.withTx(any[DBSession => Try[Unit]])).thenAnswer((i: InvocationOnMock) => {
+      val func = i.getArgument[DBSession => Try[Unit]](0)
+      func(mock[DBSession])
+    })
+    when(folderRepository.foldersWithFeideAndParentID(any, any)(any)).thenReturn(Success(List.empty))
     when(feideApiClient.getUserFeideID(any)).thenReturn(Success(correctFeideId))
     when(folderRepository.folderResourceConnectionCount(any)(any[DBSession])).thenReturn(Success(1))
     when(folderRepository.folderWithId(eqTo(mainFolderId))(any)).thenReturn(Success(folder))
@@ -1526,7 +1532,7 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
       .thenReturn(Success(mainFolderId), Success(subFolder1Id), Success(subFolder2Id))
     when(folderRepository.deleteResource(any)(any[DBSession])).thenReturn(Success(resourceId))
 
-    service.deleteFolder(mainFolderId, Some("token")) should be(Success(mainFolderId))
+    service.deleteFolder(mainFolderId, Some("token")).get should be(mainFolderId)
 
     verify(folderRepository, times(1)).deleteFolder(eqTo(mainFolderId))(any)
     verify(folderRepository, times(1)).deleteFolder(eqTo(subFolder1Id))(any)
@@ -1555,6 +1561,11 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
       )
     val correctFeideId = "FEIDE"
 
+    when(folderRepository.withTx(any[DBSession => Try[Unit]])).thenAnswer((i: InvocationOnMock) => {
+      val func = i.getArgument[DBSession => Try[Unit]](0)
+      func(mock[DBSession])
+    })
+    when(folderRepository.foldersWithFeideAndParentID(any, any)(any)).thenReturn(Success(List.empty))
     when(feideApiClient.getUserFeideID(any)).thenReturn(Success(correctFeideId))
     when(folderRepository.folderResourceConnectionCount(eqTo(resourceId))(any)).thenReturn(Success(5))
     when(folderRepository.folderWithId(eqTo(mainFolderId))(any)).thenReturn(Success(folder))
@@ -1581,15 +1592,24 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
     val correctFeideId = "FEIDE"
     val folder         = emptyDomainFolder.copy(id = folderId, feideId = "FEIDE")
     val resource       = emptyDomainResource.copy(id = resourceId, feideId = "FEIDE")
+    val folderResource = FolderResource(folderId = folder.id, resourceId = resource.id, rank = 1)
 
     when(feideApiClient.getUserFeideID(any)).thenReturn(Success(correctFeideId))
     when(folderRepository.folderWithId(eqTo(folderId))(any)).thenReturn(Success(folder))
     when(folderRepository.resourceWithId(eqTo(resourceId))(any)).thenReturn(Success(resource))
     when(folderRepository.folderResourceConnectionCount(eqTo(resourceId))(any)).thenReturn(Success(2))
+    when(folderRepository.withTx(any[DBSession => Try[Unit]])).thenAnswer((i: InvocationOnMock) => {
+      val func = i.getArgument[DBSession => Try[Unit]](0)
+      func(mock[DBSession])
+    })
+    when(folderRepository.foldersWithFeideAndParentID(any, any)(any)).thenReturn(Success(List.empty))
+    when(folderRepository.folderWithFeideId(eqTo(folderId), any)(any)).thenReturn(Success(folder))
+    when(folderRepository.foldersWithFeideAndParentID(eqTo(Some(folderId)), any)(any)).thenReturn(Success(List.empty))
+    when(folderRepository.getConnections(eqTo(folderId))(any)).thenReturn(Success(List(folderResource)))
     when(folderRepository.deleteFolderResourceConnection(eqTo(folderId), eqTo(resourceId))(any))
       .thenReturn(Success(resourceId))
 
-    service.deleteConnection(folderId, resourceId, None).isSuccess should be(true)
+    service.deleteConnection(folderId, resourceId, None).failIfFailure
 
     verify(folderRepository, times(1)).folderResourceConnectionCount(eqTo(resourceId))(any)
     verify(folderRepository, times(1)).folderWithId(eqTo(folderId))(any)
@@ -1604,6 +1624,7 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
     val correctFeideId = "FEIDE"
     val folder         = emptyDomainFolder.copy(id = folderId, feideId = "FEIDE")
     val resource       = emptyDomainResource.copy(id = resourceId, feideId = "FEIDE")
+    val folderResource = FolderResource(folderId = folder.id, resourceId = resource.id, rank = 1)
 
     when(feideApiClient.getUserFeideID(any)).thenReturn(Success(correctFeideId))
     when(folderRepository.folderWithId(eqTo(folderId))(any)).thenReturn(Success(folder))
@@ -1612,8 +1633,16 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
     when(folderRepository.deleteFolderResourceConnection(eqTo(folderId), eqTo(resourceId))(any))
       .thenReturn(Success(resourceId))
     when(folderRepository.deleteResource(eqTo(resourceId))(any)).thenReturn(Success(resourceId))
+    when(folderRepository.withTx(any[DBSession => Try[Unit]])).thenAnswer((i: InvocationOnMock) => {
+      val func = i.getArgument[DBSession => Try[Unit]](0)
+      func(mock[DBSession])
+    })
+    when(folderRepository.folderWithFeideId(eqTo(folderId), any)(any)).thenReturn(Success(folder))
+    when(folderRepository.foldersWithFeideAndParentID(eqTo(Some(folderId)), any)(any)).thenReturn(Success(List.empty))
+    when(folderRepository.getConnections(eqTo(folderId))(any)).thenReturn(Success(List(folderResource)))
+    when(folderRepository.foldersWithFeideAndParentID(any, any)(any)).thenReturn(Success(List.empty))
 
-    service.deleteConnection(folderId, resourceId, None) should be(Success(resourceId))
+    service.deleteConnection(folderId, resourceId, None).failIfFailure should be(resourceId)
 
     verify(folderRepository, times(1)).folderResourceConnectionCount(eqTo(resourceId))(any)
     verify(folderRepository, times(1)).folderWithId(eqTo(folderId))(any)
@@ -1810,6 +1839,11 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
     when(folderRepository.deleteFolder(eqTo(folder3Id))(any[DBSession])).thenReturn(Success(folder3Id))
     when(folderRepository.deleteFolder(eqTo(folder2Id))(any[DBSession])).thenReturn(Success(folder2Id))
     when(folderRepository.deleteFolder(eqTo(folder1Id))(any[DBSession])).thenReturn(Success(folder1Id))
+    when(folderRepository.withTx(any[DBSession => Try[Unit]])).thenAnswer((i: InvocationOnMock) => {
+      val func = i.getArgument[DBSession => Try[Unit]](0)
+      func(mock[DBSession])
+    })
+    when(folderRepository.foldersWithFeideAndParentID(any, any)(any)).thenReturn(Success(List.empty))
 
     service.deleteFolder(folder1Id, Some("FEIDEF")) should be(Success(folder1Id))
 


### PR DESCRIPTION
Rydder også litt opp i at automatisk rank ikke slår sammen ressurser og mapper 😄 

Kan testes ved å se at nye mapper på rotnivå får rank tilsvarende siste på rot + 1