### PR TITLE
#3302: Add `exclude-revision-log` flag to multi draft search

### DIFF
--- a/search-api/src/main/scala/no/ndla/searchapi/controller/SearchController.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/controller/SearchController.scala
@@ -209,6 +209,10 @@ trait SearchController {
         "revision-date-to",
         "Return only results having next revision before this date."
       )
+    private val excludeRevisionLog = Param[Option[Boolean]](
+      "exclude-revision-log",
+      "Set to true to avoid including hits from the revision history log."
+    )
 
     private val feideToken = Param[Option[String]]("FeideAuthorization", "Header containing FEIDE access token.")
 
@@ -466,6 +470,7 @@ trait SearchController {
       val includeOtherStatuses     = booleanOrDefault(this.includeOtherStatuses.paramName, default = false)
       val revisionDateFrom         = paramAsDateOrNone(this.revisionDateFilterFrom.paramName)
       val revisionDateTo           = paramAsDateOrNone(this.revisionDateFilterTo.paramName)
+      val excludeRevisionHistory   = booleanOrDefault(this.excludeRevisionLog.paramName, default = false)
 
       MultiDraftSearchSettings(
         query = query,
@@ -493,7 +498,8 @@ trait SearchController {
         embedId = embedId,
         includeOtherStatuses = includeOtherStatuses,
         revisionDateFilterFrom = revisionDateFrom,
-        revisionDateFilterTo = revisionDateTo
+        revisionDateFilterTo = revisionDateTo,
+        excludeRevisionHistory = excludeRevisionHistory
       )
     }
 
@@ -609,7 +615,8 @@ trait SearchController {
             asQueryParam(embedId),
             asQueryParam(includeOtherStatuses),
             asQueryParam(revisionDateFilterFrom),
-            asQueryParam(revisionDateFilterTo)
+            asQueryParam(revisionDateFilterTo),
+            asQueryParam(excludeRevisionLog)
           )
           .authorizations("oauth2")
           .responseMessages(response500)

--- a/search-api/src/main/scala/no/ndla/searchapi/model/search/settings/MultiDraftSearchSettings.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/model/search/settings/MultiDraftSearchSettings.scala
@@ -39,5 +39,6 @@ case class MultiDraftSearchSettings(
     embedId: Option[String],
     includeOtherStatuses: Boolean,
     revisionDateFilterFrom: Option[LocalDateTime],
-    revisionDateFilterTo: Option[LocalDateTime]
+    revisionDateFilterTo: Option[LocalDateTime],
+    excludeRevisionHistory: Boolean
 )

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/MultiDraftSearchService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/MultiDraftSearchService.scala
@@ -209,10 +209,10 @@ trait MultiDraftSearchService {
     }
 
     private def getRevisionHistoryLogQuery(queryString: String, excludeHistoryLog: Boolean): Seq[Query] = {
-      if (excludeHistoryLog) Seq.empty
-      else
-        Seq(
-          simpleStringQuery(queryString).field("notes", 1),
+      Seq(
+        simpleStringQuery(queryString).field("notes", 1)
+      ) ++ Option
+        .when(!excludeHistoryLog)(
           simpleStringQuery(queryString).field("previousVersionsNotes", 1)
         )
     }

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/MultiDraftSearchService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/MultiDraftSearchService.scala
@@ -65,12 +65,11 @@ trait MultiDraftSearchService {
             langQueryFunc("tags", 1),
             langQueryFunc("embedAttributes", 1),
             simpleStringQuery(queryString).field("authors", 1),
-            simpleStringQuery(queryString).field("notes", 1),
-            simpleStringQuery(queryString).field("previousVersionsNotes", 1),
             simpleStringQuery(queryString).field("grepContexts.title", 1),
             idsQuery(queryString),
             nestedQuery("revisionMeta", simpleStringQuery(queryString).field("revisionMeta.note")).ignoreUnmapped(true)
           ) ++
+            getRevisionHistoryLogQuery(queryString, settings.excludeRevisionHistory) ++
             buildNestedEmbedField(List(queryString), None, settings.language, settings.fallback) ++
             buildNestedEmbedField(List.empty, Some(queryString), settings.language, settings.fallback)
         )
@@ -207,6 +206,15 @@ trait MultiDraftSearchService {
         embedResourceAndIdFilter,
         dateFilter
       ).flatten
+    }
+
+    private def getRevisionHistoryLogQuery(queryString: String, excludeHistoryLog: Boolean): Seq[Query] = {
+      if (excludeHistoryLog) Seq.empty
+      else
+        Seq(
+          simpleStringQuery(queryString).field("notes", 1),
+          simpleStringQuery(queryString).field("previousVersionsNotes", 1)
+        )
     }
 
     private def dateToEs(date: LocalDateTime): Long = date.toEpochSecond(ZoneOffset.UTC) * 1000

--- a/search-api/src/test/scala/no/ndla/searchapi/TestData.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/TestData.scala
@@ -1414,7 +1414,8 @@ object TestData {
     embedId = None,
     includeOtherStatuses = false,
     revisionDateFilterFrom = None,
-    revisionDateFilterTo = None
+    revisionDateFilterTo = None,
+    excludeRevisionHistory = false
   )
 
   val searchableResourceTypes = List(

--- a/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceAtomicTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceAtomicTest.scala
@@ -349,28 +349,29 @@ class MultiDraftSearchServiceAtomicTest
     val today = LocalDateTime.now().withNano(0)
 
     val status = Status(current = DraftStatus.DRAFT, other = Set.empty)
-    val not    = (n: String) => EditorNote(n, "some-user", status, today)
+    val mkNote = (n: String) => EditorNote(n, "some-user", status, today)
 
     val draft1 = TestData.draft1.copy(
       id = Some(1),
       notes = Seq(
-        not("Katt"),
-        not("Hund"),
-        not("Gris")
+        mkNote("Katt"),
+        mkNote("Hund")
       ),
       previousVersionsNotes = Seq(
-        not("Tiger")
+        mkNote("Tiger"),
+        mkNote("Gris")
       )
     )
     val draft2 = TestData.draft1.copy(
       id = Some(2),
       notes = Seq(
-        not("Kinakål"),
-        not("Grevling"),
-        not("Apekatt")
+        mkNote("Kinakål"),
+        mkNote("Grevling"),
+        mkNote("Apekatt"),
+        mkNote("Gris")
       ),
       previousVersionsNotes = Seq(
-        not("Giraff")
+        mkNote("Giraff")
       )
     )
     val draft3 = TestData.draft1.copy(
@@ -394,7 +395,7 @@ class MultiDraftSearchServiceAtomicTest
       )
       .get
       .results
-      .map(_.id) should be(Seq(3))
+      .map(_.id) should be(Seq(2, 3))
 
     multiDraftSearchService
       .matchingQuery(
@@ -405,6 +406,6 @@ class MultiDraftSearchServiceAtomicTest
       )
       .get
       .results
-      .map(_.id) should be(Seq(1, 3))
+      .map(_.id) should be(Seq(1, 2, 3))
   }
 }


### PR DESCRIPTION
Relates to NDLANO/Issues#3302

Kan testes ved å se at søk på draft-søket (`/editorial/`) inkluderer treff fra revisjons-loggen til vanlig, men ikke med `?exclude-revision-log=true`