### PR TITLE
learningpath-api: Add GET endpoint to fetch config data

### DIFF
--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/controller/ConfigController.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/controller/ConfigController.scala
@@ -52,11 +52,6 @@ trait ConfigController {
         "config_key",
         s"""Key of configuration value. Can only be one of '${ConfigKey.all.mkString("', '")}'""".stripMargin
       )
-    private val feideToken = Param[Option[String]]("FeideAuthorization", "Header containing FEIDE access token.")
-
-    private def requestFeideToken(implicit request: HttpServletRequest): Option[String] = {
-      request.header(this.feideToken.paramName).map(_.replaceFirst("Bearer ", ""))
-    }
 
     private def withConfigKey[T](callback: ConfigKey => T)(implicit request: HttpServletRequest) = {
       val configKeyString = params("config_key")
@@ -74,14 +69,13 @@ trait ConfigController {
           .summary("Get db configuration by key")
           .description("Get db configuration by key")
           .parameters(
-            asHeaderParam(feideToken),
             asPathParam(configKeyPathParam)
           )
           .responseMessages(response400, response403, response404, response500)
           .authorizations("oauth2")
       )
     ) {
-      withConfigKey(key => readService.getConfig(key, requestFeideToken))
+      withConfigKey(readService.getConfig)
     }
 
     post(

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/model/api/config/ConfigMetaRestricted.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/model/api/config/ConfigMetaRestricted.scala
@@ -1,0 +1,19 @@
+/*
+ * Part of NDLA learningpath-api.
+ * Copyright (C) 2022 NDLA
+ *
+ * See LICENSE
+ */
+
+package no.ndla.learningpathapi.model.api.config
+
+import org.scalatra.swagger.annotations.ApiModelProperty
+import org.scalatra.swagger.runtime.annotations.ApiModel
+
+import scala.annotation.meta.field
+
+@ApiModel(description = "Describes configuration value.")
+case class ConfigMetaRestricted(
+    @(ApiModelProperty @field)(description = "Configuration key") key: String,
+    @(ApiModelProperty @field)(description = "Configuration value.") value: String
+)

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/ConverterService.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/ConverterService.scala
@@ -676,6 +676,9 @@ trait ConverterService {
       )
     }
 
+    def asApiConfigRestricted(configValue: ConfigMeta): api.config.ConfigMetaRestricted =
+      api.config.ConfigMetaRestricted(key = configValue.key.entryName, value = configValue.value)
+
     def toUUIDValidated(maybeValue: Option[String], paramName: String): Try[UUID] = {
       val maybeUUID = maybeValue.map(value => Try(UUID.fromString(value)))
       maybeUUID match {

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/ReadService.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/ReadService.scala
@@ -31,7 +31,6 @@ import no.ndla.learningpathapi.repository.{
 }
 import no.ndla.network.clients.FeideApiClient
 import no.ndla.common.errors.AccessDeniedException
-import no.ndla.common.implicits.TryQuestionMark
 import scalikejdbc.DBSession
 
 import java.util.UUID
@@ -177,11 +176,7 @@ trait ReadService {
           .map(_.value.toBoolean)
       ).toOption.flatten.getOrElse(false)
 
-    def getConfig(
-        configKey: ConfigKey,
-        feideAccessToken: Option[FeideAccessToken]
-    ): Try[api.config.ConfigMetaRestricted] = {
-      getUserFeideID(feideAccessToken).?
+    def getConfig(configKey: ConfigKey): Try[api.config.ConfigMetaRestricted] = {
       configRepository.getConfigWithKey(configKey) match {
         case None      => Failure(NotFoundException(s"Configuration with key $configKey does not exist"))
         case Some(key) => Success(converterService.asApiConfigRestricted(key))


### PR DESCRIPTION
Legger til GET endepunkt  i ConfigController på `/:config_key` for å kunne se write-lock status i databasen under eksamen.