### PR TITLE
change variable name from FeideUser to MyNDLAUser, to be more precise

### DIFF
--- a/learningpath-api/src/main/resources/no/ndla/learningpathapi/db/migration/V24__RenameFeideUserTable.sql
+++ b/learningpath-api/src/main/resources/no/ndla/learningpathapi/db/migration/V24__RenameFeideUserTable.sql
@@ -1,0 +1,1 @@
+ALTER TABLE feide_users RENAME TO my_ndla_users;

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/ComponentRegistry.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/ComponentRegistry.scala
@@ -27,7 +27,7 @@ import no.ndla.learningpathapi.model.domain.{
   DBFolderResource,
   DBLearningPath,
   DBLearningStep,
-  DBFeideUser,
+  DBMyNDLAUser,
   DBResource
 }
 import no.ndla.learningpathapi.model.domain.config.DBConfigMeta
@@ -87,7 +87,7 @@ class ComponentRegistry(properties: LearningpathApiProperties)
     with DBFolder
     with DBResource
     with DBFolderResource
-    with DBFeideUser
+    with DBMyNDLAUser
     with TextValidator
     with UrlValidator
     with CorrelationIdSupport

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/controller/UserController.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/controller/UserController.scala
@@ -9,7 +9,7 @@
 package no.ndla.learningpathapi.controller
 
 import no.ndla.common.scalatra.NdlaSwaggerSupport
-import no.ndla.learningpathapi.model.api.{FeideUser, UpdatedFeideUser, ValidationError}
+import no.ndla.learningpathapi.model.api.{MyNDLAUser, UpdatedMyNDLAUser, ValidationError}
 import no.ndla.learningpathapi.service.{ConverterService, ReadService, UpdateService}
 import org.json4s.ext.JavaTimeSerializers
 import org.json4s.{DefaultFormats, Formats}
@@ -45,7 +45,7 @@ trait UserController {
     get(
       "/",
       operation(
-        apiOperation[FeideUser]("GetFeideUser")
+        apiOperation[MyNDLAUser]("GetMyNDLAUser")
           .summary("Get user data")
           .description("Get user data")
           .parameters(
@@ -55,25 +55,25 @@ trait UserController {
           .authorizations("oauth2")
       )
     ) {
-      readService.getFeideUserData(requestFeideToken)
+      readService.getMyNDLAUserData(requestFeideToken)
     }
 
     patch(
       "/",
       operation(
-        apiOperation[FeideUser]("UpdateFeideUser")
+        apiOperation[MyNDLAUser]("UpdateMyNDLAUser")
           .summary("Update user data")
           .description("Update user data")
           .parameters(
             asHeaderParam(feideToken),
-            bodyParam[UpdatedFeideUser]
+            bodyParam[UpdatedMyNDLAUser]
           )
           .responseMessages(response403, response404, response500)
           .authorizations("oauth2")
       )
     ) {
-      val updatedUserData = extract[UpdatedFeideUser](request.body)
-      updateService.updateFeideUserData(updatedUserData, requestFeideToken)
+      val updatedUserData = extract[UpdatedMyNDLAUser](request.body)
+      updateService.updateMyNDLAUserData(updatedUserData, requestFeideToken)
     }
 
     delete(

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/model/api/MyNDLAUser.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/model/api/MyNDLAUser.scala
@@ -11,12 +11,12 @@ package no.ndla.learningpathapi.model.api
 import org.scalatra.swagger.runtime.annotations.ApiModelProperty
 import scala.annotation.meta.field
 
-case class FeideUser(
+case class MyNDLAUser(
     @(ApiModelProperty @field)(description = "ID of the user") id: Long,
     @(ApiModelProperty @field)(description = "Favorite subjects of the user") favoriteSubjects: Seq[String],
     @(ApiModelProperty @field)(description = "User role") role: String
 )
 
-case class UpdatedFeideUser(
+case class UpdatedMyNDLAUser(
     @(ApiModelProperty @field)(description = "Favorite subjects of the user") favoriteSubjects: Option[Seq[String]]
 )

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/model/domain/MyNDLAUser.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/model/domain/MyNDLAUser.scala
@@ -17,12 +17,12 @@ import scalikejdbc._
 
 import java.time.LocalDateTime
 
-case class FeideUserDocument(favoriteSubjects: Seq[String], userRole: UserRole.Value, lastUpdated: LocalDateTime) {
+case class MyNDLAUserDocument(favoriteSubjects: Seq[String], userRole: UserRole.Value, lastUpdated: LocalDateTime) {
   def toFullUser(
       id: Long,
       feideId: FeideID
-  ): FeideUser = {
-    FeideUser(
+  ): MyNDLAUser = {
+    MyNDLAUser(
       id = id,
       feideId = feideId,
       favoriteSubjects = favoriteSubjects,
@@ -32,14 +32,14 @@ case class FeideUserDocument(favoriteSubjects: Seq[String], userRole: UserRole.V
   }
 }
 
-case class FeideUser(
+case class MyNDLAUser(
     id: Long,
     feideId: FeideID,
     favoriteSubjects: Seq[String],
     userRole: UserRole.Value,
     lastUpdated: LocalDateTime
 ) {
-  def toDocument: FeideUserDocument = FeideUserDocument(
+  def toDocument: MyNDLAUserDocument = MyNDLAUserDocument(
     favoriteSubjects = favoriteSubjects,
     userRole = userRole,
     lastUpdated = lastUpdated
@@ -51,26 +51,26 @@ case class FeideUser(
   def isTeacher: Boolean = userRole == UserRole.TEACHER
 }
 
-trait DBFeideUser {
+trait DBMyNDLAUser {
   this: Props =>
 
-  object DBFeideUser extends SQLSyntaxSupport[FeideUser] {
+  object DBMyNDLAUser extends SQLSyntaxSupport[MyNDLAUser] {
     implicit val jsonEncoder: Formats = DefaultFormats + new EnumNameSerializer(UserRole) ++ JavaTimeSerializers.all
-    override val tableName            = "feide_users"
+    override val tableName            = "my_ndla_users"
     override lazy val schemaName: Option[String] = Some(props.MetaSchema)
 
-    val repositorySerializer: Formats = jsonEncoder + FieldSerializer[FeideUser](
+    val repositorySerializer: Formats = jsonEncoder + FieldSerializer[MyNDLAUser](
       ignore("id") orElse
         ignore("feideId")
     )
 
-    def fromResultSet(lp: SyntaxProvider[FeideUser])(rs: WrappedResultSet): FeideUser =
+    def fromResultSet(lp: SyntaxProvider[MyNDLAUser])(rs: WrappedResultSet): MyNDLAUser =
       fromResultSet((s: String) => lp.resultName.c(s))(rs)
 
-    def fromResultSet(rs: WrappedResultSet): FeideUser = fromResultSet((s: String) => s)(rs)
+    def fromResultSet(rs: WrappedResultSet): MyNDLAUser = fromResultSet((s: String) => s)(rs)
 
-    def fromResultSet(colNameWrapper: String => String)(rs: WrappedResultSet): FeideUser = {
-      val metaData = read[FeideUserDocument](rs.string(colNameWrapper("document")))
+    def fromResultSet(colNameWrapper: String => String)(rs: WrappedResultSet): MyNDLAUser = {
+      val metaData = read[MyNDLAUserDocument](rs.string(colNameWrapper("document")))
       val id       = rs.long(colNameWrapper("id"))
       val feideId  = rs.string(colNameWrapper("feide_id"))
 

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/ConverterService.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/ConverterService.scala
@@ -807,18 +807,18 @@ trait ConverterService {
       )
     }
 
-    def toApiUserData(domainUserData: domain.FeideUser): api.FeideUser = {
-      api.FeideUser(
+    def toApiUserData(domainUserData: domain.MyNDLAUser): api.MyNDLAUser = {
+      api.MyNDLAUser(
         id = domainUserData.id,
         favoriteSubjects = domainUserData.favoriteSubjects,
         role = domainUserData.userRole.toString
       )
     }
 
-    def mergeUserData(domainUserData: domain.FeideUser, updatedUser: api.UpdatedFeideUser): domain.FeideUser = {
+    def mergeUserData(domainUserData: domain.MyNDLAUser, updatedUser: api.UpdatedMyNDLAUser): domain.MyNDLAUser = {
       val favoriteSubjects = updatedUser.favoriteSubjects.getOrElse(domainUserData.favoriteSubjects)
 
-      domain.FeideUser(
+      domain.MyNDLAUser(
         id = domainUserData.id,
         feideId = domainUserData.feideId,
         favoriteSubjects = favoriteSubjects,

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/ReadService.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/ReadService.scala
@@ -334,11 +334,11 @@ trait ReadService {
       } yield converted
     }
 
-    private def createFeideUser(feideId: FeideID, feideAccessToken: FeideAccessToken): Try[domain.FeideUser] = {
+    private def createMyNDLAUser(feideId: FeideID, feideAccessToken: FeideAccessToken): Try[domain.MyNDLAUser] = {
       for {
         feideExtendedUserData <- feideApiClient.getUser(feideAccessToken)
         newUser = domain
-          .FeideUserDocument(
+          .MyNDLAUserDocument(
             favoriteSubjects = Seq.empty,
             userRole = if (feideExtendedUserData.isTeacher) UserRole.TEACHER else UserRole.STUDENT,
             lastUpdated = clock.now().plusDays(1)
@@ -347,23 +347,23 @@ trait ReadService {
       } yield inserted
     }
 
-    def getOrCreateFeideUserIfNotExist(
+    def getOrCreateMyNDLAUserIfNotExist(
         feideId: FeideID,
         feideAccessToken: Option[FeideAccessToken]
-    ): Try[domain.FeideUser] = {
+    ): Try[domain.MyNDLAUser] = {
       userRepository.userWithFeideId(feideId).flatMap {
         case None =>
-          feideApiClient.getFeideAccessTokenOrFail(feideAccessToken).flatMap(token => createFeideUser(feideId, token))
+          feideApiClient.getFeideAccessTokenOrFail(feideAccessToken).flatMap(token => createMyNDLAUser(feideId, token))
         case Some(userData) =>
           if (userData.wasUpdatedLast24h) Success(userData)
           else userRepository.updateUser(feideId, userData.copy(lastUpdated = clock.now().plusDays(1)))
       }
     }
 
-    def getFeideUserData(feideAccessToken: Option[FeideAccessToken]): Try[api.FeideUser] = {
+    def getMyNDLAUserData(feideAccessToken: Option[FeideAccessToken]): Try[api.MyNDLAUser] = {
       for {
         feideId  <- getUserFeideID(feideAccessToken)
-        userData <- getOrCreateFeideUserIfNotExist(feideId, feideAccessToken)
+        userData <- getOrCreateMyNDLAUserIfNotExist(feideId, feideAccessToken)
         api = converterService.toApiUserData(userData)
       } yield api
     }

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/UpdateService.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/UpdateService.scala
@@ -90,8 +90,8 @@ trait UpdateService {
         "You do not have write access while write restriction is active."
       )(w)
 
-    private def canWriteNow(feideUser: domain.FeideUser): Boolean =
-      feideUser.isTeacher || !readService.isWriteRestricted
+    private def canWriteNow(myNDLAUser: domain.MyNDLAUser): Boolean =
+      myNDLAUser.isTeacher || !readService.isWriteRestricted
 
     private[service] def writeOrAccessDenied[T](
         willExecute: Boolean,
@@ -452,9 +452,9 @@ trait UpdateService {
         feideAccessToken: Option[FeideAccessToken]
     ): Try[_] = {
       readService
-        .getOrCreateFeideUserIfNotExist(feideId, feideAccessToken)
-        .flatMap(feideUser => {
-          if (canWriteNow(feideUser)) Success(())
+        .getOrCreateMyNDLAUserIfNotExist(feideId, feideAccessToken)
+        .flatMap(myNDLAUser => {
+          if (canWriteNow(myNDLAUser)) Success(())
           else Failure(AccessDeniedException("You do not have write access while write restriction is active."))
         })
     }
@@ -743,7 +743,7 @@ trait UpdateService {
       } yield ()
     }
 
-    private[service] def getFeideUserOrFail(feideId: FeideID): Try[domain.FeideUser] = {
+    private[service] def getMyNDLAUserOrFail(feideId: FeideID): Try[domain.MyNDLAUser] = {
       userRepository.userWithFeideId(feideId) match {
         case Failure(ex)         => Failure(ex)
         case Success(None)       => Failure(NotFoundException(s"User with feide_id $feideId was not found"))
@@ -751,14 +751,14 @@ trait UpdateService {
       }
     }
 
-    def updateFeideUserData(
-        updatedUser: api.UpdatedFeideUser,
+    def updateMyNDLAUserData(
+        updatedUser: api.UpdatedMyNDLAUser,
         feideAccessToken: Option[FeideAccessToken]
-    ): Try[api.FeideUser] = {
+    ): Try[api.MyNDLAUser] = {
       for {
         feideId          <- getUserFeideID(feideAccessToken)
         _                <- canWriteDuringWriteRestrictionsOrAccessDenied(feideId, feideAccessToken)
-        existingUserData <- getFeideUserOrFail(feideId)
+        existingUserData <- getMyNDLAUserOrFail(feideId)
         combined = converterService.mergeUserData(existingUserData, updatedUser)
         updated <- userRepository.updateUser(feideId, combined)
         api = converterService.toApiUserData(updated)

--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/TestData.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/TestData.scala
@@ -157,7 +157,7 @@ object TestData {
     rank = None
   )
 
-  val emptyFeideUser: domain.FeideUser = domain.FeideUser(
+  val emptyMyNDLAUser: domain.MyNDLAUser = domain.MyNDLAUser(
     id = 1,
     feideId = "",
     favoriteSubjects = Seq.empty,

--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/TestEnvironment.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/TestEnvironment.scala
@@ -26,7 +26,7 @@ import no.ndla.learningpathapi.model.domain.{
   DBFolderResource,
   DBLearningPath,
   DBLearningStep,
-  DBFeideUser,
+  DBMyNDLAUser,
   DBResource
 }
 import no.ndla.learningpathapi.repository.{
@@ -80,7 +80,7 @@ trait TestEnvironment
     with DBFolder
     with DBResource
     with DBFolderResource
-    with DBFeideUser
+    with DBMyNDLAUser
     with NdlaController
     with CorrelationIdSupport
     with ErrorHelpers

--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/ConverterServiceTest.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/ConverterServiceTest.scala
@@ -745,45 +745,45 @@ class ConverterServiceTest extends UnitSuite with UnitTestEnvironment {
 
   test("That toApiUserData works correctly") {
     val domainUserData =
-      domain.FeideUser(
+      domain.MyNDLAUser(
         id = 42,
         feideId = "feide",
         favoriteSubjects = Seq("a", "b"),
         userRole = UserRole.STUDENT,
         lastUpdated = clock.now()
       )
-    val expectedUserData = api.FeideUser(id = 42, favoriteSubjects = Seq("a", "b"), role = "student")
+    val expectedUserData = api.MyNDLAUser(id = 42, favoriteSubjects = Seq("a", "b"), role = "student")
 
     service.toApiUserData(domainUserData) should be(expectedUserData)
   }
 
   test("That mergeUserData works correctly") {
-    val domainUserData = domain.FeideUser(
+    val domainUserData = domain.MyNDLAUser(
       id = 42,
       feideId = "feide",
       favoriteSubjects = Seq("a", "b"),
       userRole = UserRole.STUDENT,
       lastUpdated = clock.now()
     )
-    val updatedUserData1 = api.UpdatedFeideUser(favoriteSubjects = None)
-    val updatedUserData2 = api.UpdatedFeideUser(favoriteSubjects = Some(Seq.empty))
-    val updatedUserData3 = api.UpdatedFeideUser(favoriteSubjects = Some(Seq("x", "y", "z")))
+    val updatedUserData1 = api.UpdatedMyNDLAUser(favoriteSubjects = None)
+    val updatedUserData2 = api.UpdatedMyNDLAUser(favoriteSubjects = Some(Seq.empty))
+    val updatedUserData3 = api.UpdatedMyNDLAUser(favoriteSubjects = Some(Seq("x", "y", "z")))
 
-    val expectedUserData1 = domain.FeideUser(
+    val expectedUserData1 = domain.MyNDLAUser(
       id = 42,
       feideId = "feide",
       favoriteSubjects = Seq("a", "b"),
       userRole = UserRole.STUDENT,
       lastUpdated = clock.now()
     )
-    val expectedUserData2 = domain.FeideUser(
+    val expectedUserData2 = domain.MyNDLAUser(
       id = 42,
       feideId = "feide",
       favoriteSubjects = Seq.empty,
       userRole = UserRole.STUDENT,
       lastUpdated = clock.now()
     )
-    val expectedUserData3 = domain.FeideUser(
+    val expectedUserData3 = domain.MyNDLAUser(
       id = 42,
       feideId = "feide",
       favoriteSubjects = Seq("x", "y", "z"),

--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/ReadServiceTest.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/ReadServiceTest.scala
@@ -546,18 +546,18 @@ class ReadServiceTest extends UnitSuite with UnitTestEnvironment {
     result.message should be("Folder does not exist")
   }
 
-  test("That getFeideUserData creates new UserData if no user exist") {
+  test("That getMyNDLAUserData creates new UserData if no user exist") {
     when(clock.now()).thenReturn(LocalDateTime.now())
 
     val feideId = "feide"
-    val domainUserData = domain.FeideUser(
+    val domainUserData = domain.MyNDLAUser(
       id = 42,
       feideId = feideId,
       favoriteSubjects = Seq("r", "e"),
       userRole = UserRole.STUDENT,
       lastUpdated = clock.now()
     )
-    val apiUserData = api.FeideUser(id = 42, favoriteSubjects = Seq("r", "e"), role = "student")
+    val apiUserData = api.MyNDLAUser(id = 42, favoriteSubjects = Seq("r", "e"), role = "student")
     val feideUserInfo = FeideExtendedUserInfo(
       displayName = "David",
       eduPersonAffiliation = Seq("student")
@@ -567,10 +567,10 @@ class ReadServiceTest extends UnitSuite with UnitTestEnvironment {
     when(feideApiClient.getFeideAccessTokenOrFail(any)).thenReturn(Success(feideId))
     when(feideApiClient.getUser(any)).thenReturn(Success(feideUserInfo))
     when(userRepository.userWithFeideId(any)(any)).thenReturn(Success(None))
-    when(userRepository.insertUser(any, any[domain.FeideUserDocument])(any))
+    when(userRepository.insertUser(any, any[domain.MyNDLAUserDocument])(any))
       .thenReturn(Success(domainUserData))
 
-    service.getFeideUserData(Some(feideId)).get should be(apiUserData)
+    service.getMyNDLAUserData(Some(feideId)).get should be(apiUserData)
 
     verify(feideApiClient, times(1)).getUser(any)
     verify(userRepository, times(1)).userWithFeideId(any)(any)
@@ -578,23 +578,23 @@ class ReadServiceTest extends UnitSuite with UnitTestEnvironment {
     verify(userRepository, times(0)).updateUser(any, any)(any)
   }
 
-  test("That getFeideUserData returns already created user if it exists and was updated lately") {
+  test("That getMyNDLAUserData returns already created user if it exists and was updated lately") {
     when(clock.now()).thenReturn(LocalDateTime.now())
 
     val feideId = "feide"
-    val domainUserData = domain.FeideUser(
+    val domainUserData = domain.MyNDLAUser(
       id = 42,
       feideId = feideId,
       favoriteSubjects = Seq("r", "e"),
       userRole = UserRole.STUDENT,
       lastUpdated = clock.now().plusDays(1)
     )
-    val apiUserData = api.FeideUser(id = 42, favoriteSubjects = Seq("r", "e"), role = "student")
+    val apiUserData = api.MyNDLAUser(id = 42, favoriteSubjects = Seq("r", "e"), role = "student")
 
     when(feideApiClient.getUserFeideID(Some(feideId))).thenReturn(Success(feideId))
     when(userRepository.userWithFeideId(eqTo(feideId))(any)).thenReturn(Success(Some(domainUserData)))
 
-    service.getFeideUserData(Some(feideId)).get should be(apiUserData)
+    service.getMyNDLAUserData(Some(feideId)).get should be(apiUserData)
 
     verify(feideApiClient, times(0)).getUser(any)
     verify(userRepository, times(1)).userWithFeideId(any)(any)
@@ -602,24 +602,24 @@ class ReadServiceTest extends UnitSuite with UnitTestEnvironment {
     verify(userRepository, times(0)).updateUser(any, any)(any)
   }
 
-  test("That getFeideUserData returns already created user if it exists but needs update") {
+  test("That getMyNDLAUserData returns already created user if it exists but needs update") {
     when(clock.now()).thenReturn(LocalDateTime.now())
 
     val feideId = "feide"
-    val domainUserData = domain.FeideUser(
+    val domainUserData = domain.MyNDLAUser(
       id = 42,
       feideId = feideId,
       favoriteSubjects = Seq("r", "e"),
       userRole = UserRole.STUDENT,
       lastUpdated = clock.now().minusDays(1)
     )
-    val apiUserData = api.FeideUser(id = 42, favoriteSubjects = Seq("r", "e"), role = "student")
+    val apiUserData = api.MyNDLAUser(id = 42, favoriteSubjects = Seq("r", "e"), role = "student")
 
     when(feideApiClient.getUserFeideID(Some(feideId))).thenReturn(Success(feideId))
     when(userRepository.userWithFeideId(eqTo(feideId))(any)).thenReturn(Success(Some(domainUserData)))
     when(userRepository.updateUser(any, any)(any)).thenReturn(Success(domainUserData))
 
-    service.getFeideUserData(Some(feideId)).get should be(apiUserData)
+    service.getMyNDLAUserData(Some(feideId)).get should be(apiUserData)
 
     verify(feideApiClient, times(0)).getUser(any)
     verify(userRepository, times(1)).userWithFeideId(any)(any)

--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/UpdateServiceTest.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/UpdateServiceTest.scala
@@ -1487,7 +1487,7 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
 
     when(folderRepository.foldersWithFeideAndParentID(any, any)(any)).thenReturn(Success(List.empty))
     when(feideApiClient.getUserFeideID(any)).thenReturn(Success(wrongFeideId))
-    when(readService.getOrCreateFeideUserIfNotExist(any, any)).thenReturn(Success(emptyFeideUser))
+    when(readService.getOrCreateMyNDLAUserIfNotExist(any, any)).thenReturn(Success(emptyMyNDLAUser))
     when(folderRepository.folderResourceConnectionCount(any)(any)).thenReturn(Success(0))
     when(folderRepository.folderWithId(eqTo(id))(any)).thenReturn(Success(folderWithChildren))
 
@@ -1525,7 +1525,7 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
     })
     when(folderRepository.foldersWithFeideAndParentID(any, any)(any)).thenReturn(Success(List.empty))
     when(feideApiClient.getUserFeideID(any)).thenReturn(Success(correctFeideId))
-    when(readService.getOrCreateFeideUserIfNotExist(any, any)).thenReturn(Success(emptyFeideUser))
+    when(readService.getOrCreateMyNDLAUserIfNotExist(any, any)).thenReturn(Success(emptyMyNDLAUser))
     when(folderRepository.folderResourceConnectionCount(any)(any[DBSession])).thenReturn(Success(1))
     when(folderRepository.folderWithId(eqTo(mainFolderId))(any)).thenReturn(Success(folder))
     when(readService.getSingleFolderWithContent(eqTo(folder.id), any, eqTo(true))(any))
@@ -1569,7 +1569,7 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
     })
     when(folderRepository.foldersWithFeideAndParentID(any, any)(any)).thenReturn(Success(List.empty))
     when(feideApiClient.getUserFeideID(any)).thenReturn(Success(correctFeideId))
-    when(readService.getOrCreateFeideUserIfNotExist(any, any)).thenReturn(Success(emptyFeideUser))
+    when(readService.getOrCreateMyNDLAUserIfNotExist(any, any)).thenReturn(Success(emptyMyNDLAUser))
     when(folderRepository.folderResourceConnectionCount(eqTo(resourceId))(any)).thenReturn(Success(5))
     when(folderRepository.folderWithId(eqTo(mainFolderId))(any)).thenReturn(Success(folder))
     when(readService.getSingleFolderWithContent(eqTo(folder.id), any, eqTo(true))(any))
@@ -1598,7 +1598,7 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
     val folderResource = FolderResource(folderId = folder.id, resourceId = resource.id, rank = 1)
 
     when(feideApiClient.getUserFeideID(any)).thenReturn(Success(correctFeideId))
-    when(readService.getOrCreateFeideUserIfNotExist(any, any)).thenReturn(Success(emptyFeideUser))
+    when(readService.getOrCreateMyNDLAUserIfNotExist(any, any)).thenReturn(Success(emptyMyNDLAUser))
     when(folderRepository.folderWithId(eqTo(folderId))(any)).thenReturn(Success(folder))
     when(folderRepository.resourceWithId(eqTo(resourceId))(any)).thenReturn(Success(resource))
     when(folderRepository.folderResourceConnectionCount(eqTo(resourceId))(any)).thenReturn(Success(2))
@@ -1631,7 +1631,7 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
     val folderResource = FolderResource(folderId = folder.id, resourceId = resource.id, rank = 1)
 
     when(feideApiClient.getUserFeideID(any)).thenReturn(Success(correctFeideId))
-    when(readService.getOrCreateFeideUserIfNotExist(any, any)).thenReturn(Success(emptyFeideUser))
+    when(readService.getOrCreateMyNDLAUserIfNotExist(any, any)).thenReturn(Success(emptyMyNDLAUser))
     when(folderRepository.folderWithId(eqTo(folderId))(any)).thenReturn(Success(folder))
     when(folderRepository.resourceWithId(eqTo(resourceId))(any)).thenReturn(Success(resource))
     when(folderRepository.folderResourceConnectionCount(eqTo(resourceId))(any)).thenReturn(Success(1))
@@ -1663,7 +1663,7 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
     val folder         = emptyDomainFolder.copy(id = folderId, feideId = "asd")
 
     when(feideApiClient.getUserFeideID(any)).thenReturn(Success(correctFeideId))
-    when(readService.getOrCreateFeideUserIfNotExist(any, any)).thenReturn(Success(emptyFeideUser))
+    when(readService.getOrCreateMyNDLAUserIfNotExist(any, any)).thenReturn(Success(emptyMyNDLAUser))
     when(folderRepository.folderWithId(eqTo(folderId))(any)).thenReturn(Success(folder))
 
     val res = service.deleteConnection(folderId, resourceId, None)
@@ -1685,7 +1685,7 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
     val resource       = emptyDomainResource.copy(id = resourceId, feideId = "asd")
 
     when(feideApiClient.getUserFeideID(any)).thenReturn(Success(correctFeideId))
-    when(readService.getOrCreateFeideUserIfNotExist(any, any)).thenReturn(Success(emptyFeideUser))
+    when(readService.getOrCreateMyNDLAUserIfNotExist(any, any)).thenReturn(Success(emptyMyNDLAUser))
     when(folderRepository.folderWithId(eqTo(folderId))(any)).thenReturn(Success(folder))
     when(folderRepository.resourceWithId(eqTo(resourceId))(any)).thenReturn(Success(resource))
 
@@ -1828,7 +1828,7 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
       )
 
     when(feideApiClient.getUserFeideID(any)).thenReturn(Success("FEIDEF"))
-    when(readService.getOrCreateFeideUserIfNotExist(any, any)).thenReturn(Success(emptyFeideUser))
+    when(readService.getOrCreateMyNDLAUserIfNotExist(any, any)).thenReturn(Success(emptyMyNDLAUser))
     when(folderRepository.folderWithId(eqTo(folder1Id))(any[DBSession])).thenReturn(Success(folder1))
     when(readService.getSingleFolderWithContent(eqTo(folder1Id), eqTo(true), eqTo(true))(any[DBSession]))
       .thenReturn(Success(folder1))
@@ -1882,7 +1882,7 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
     val newFolder = api.NewFolder(name = "asd", parentId = Some(parentId.toString), status = None)
 
     when(feideApiClient.getUserFeideID(any)).thenReturn(Success(feideId))
-    when(readService.getOrCreateFeideUserIfNotExist(any, any)).thenReturn(Success(emptyFeideUser))
+    when(readService.getOrCreateMyNDLAUserIfNotExist(any, any)).thenReturn(Success(emptyMyNDLAUser))
     when(converterService.toUUIDValidated(eqTo(Some(parentId.toString)), eqTo("parentId")))
       .thenReturn(Success(parentId))
     when(folderRepository.folderWithFeideId(eqTo(parentId), eqTo(feideId))(any[DBSession]))
@@ -1928,7 +1928,7 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
     val belowLimit = props.MaxFolderDepth - 2
 
     when(feideApiClient.getUserFeideID(any)).thenReturn(Success(feideId))
-    when(readService.getOrCreateFeideUserIfNotExist(any, any)).thenReturn(Success(emptyFeideUser))
+    when(readService.getOrCreateMyNDLAUserIfNotExist(any, any)).thenReturn(Success(emptyMyNDLAUser))
     when(converterService.toUUIDValidated(eqTo(Some(parentId.toString)), eqTo("parentId")))
       .thenReturn(Success(parentId))
     when(folderRepository.folderWithFeideId(eqTo(parentId), eqTo(feideId))(any[DBSession]))
@@ -1974,7 +1974,7 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
     val belowLimit = props.MaxFolderDepth - 2
 
     when(feideApiClient.getUserFeideID(any)).thenReturn(Success(feideId))
-    when(readService.getOrCreateFeideUserIfNotExist(any, any)).thenReturn(Success(emptyFeideUser))
+    when(readService.getOrCreateMyNDLAUserIfNotExist(any, any)).thenReturn(Success(emptyMyNDLAUser))
     when(converterService.toUUIDValidated(eqTo(Some(parentId.toString)), eqTo("parentId")))
       .thenReturn(Success(parentId))
     when(folderRepository.folderWithFeideId(eqTo(parentId), eqTo(feideId))(any[DBSession]))
@@ -2024,7 +2024,7 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
     val belowLimit = props.MaxFolderDepth - 2
 
     when(feideApiClient.getUserFeideID(any)).thenReturn(Success(feideId))
-    when(readService.getOrCreateFeideUserIfNotExist(any, any)).thenReturn(Success(emptyFeideUser))
+    when(readService.getOrCreateMyNDLAUserIfNotExist(any, any)).thenReturn(Success(emptyMyNDLAUser))
     when(converterService.toUUIDValidated(eqTo(Some(parentId.toString)), eqTo("parentId")))
       .thenReturn(Success(parentId))
     when(folderRepository.folderWithFeideId(eqTo(parentId), eqTo(feideId))(any[DBSession]))
@@ -2086,7 +2086,7 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
     val belowLimit = props.MaxFolderDepth - 2
 
     when(feideApiClient.getUserFeideID(any)).thenReturn(Success(feideId))
-    when(readService.getOrCreateFeideUserIfNotExist(any, any)).thenReturn(Success(emptyFeideUser))
+    when(readService.getOrCreateMyNDLAUserIfNotExist(any, any)).thenReturn(Success(emptyMyNDLAUser))
     when(converterService.toUUIDValidated(eqTo(Some(parentId.toString)), eqTo("parentId")))
       .thenReturn(Success(parentId))
     when(folderRepository.folderWithFeideId(eqTo(parentId), eqTo(feideId))(any[DBSession]))
@@ -2121,29 +2121,29 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
 
   test("That updateUserData updates user if user exist") {
     val feideId = "feide"
-    val userBefore = domain.FeideUser(
+    val userBefore = domain.MyNDLAUser(
       id = 42,
       feideId = feideId,
       favoriteSubjects = Seq("h", "b"),
       userRole = UserRole.STUDENT,
       lastUpdated = clock.now()
     )
-    val updatedUserData = api.UpdatedFeideUser(favoriteSubjects = Some(Seq("r", "e")))
-    val userAfterMerge = domain.FeideUser(
+    val updatedUserData = api.UpdatedMyNDLAUser(favoriteSubjects = Some(Seq("r", "e")))
+    val userAfterMerge = domain.MyNDLAUser(
       id = 42,
       feideId = feideId,
       favoriteSubjects = Seq("r", "e"),
       userRole = UserRole.STUDENT,
       lastUpdated = clock.now()
     )
-    val expected = api.FeideUser(id = 42, favoriteSubjects = Seq("r", "e"), role = "student")
+    val expected = api.MyNDLAUser(id = 42, favoriteSubjects = Seq("r", "e"), role = "student")
 
     when(feideApiClient.getUserFeideID(any)).thenReturn(Success(feideId))
-    when(readService.getOrCreateFeideUserIfNotExist(any, any)).thenReturn(Success(emptyFeideUser))
+    when(readService.getOrCreateMyNDLAUserIfNotExist(any, any)).thenReturn(Success(emptyMyNDLAUser))
     when(userRepository.userWithFeideId(eqTo(feideId))(any)).thenReturn(Success(Some(userBefore)))
     when(userRepository.updateUser(eqTo(feideId), any)(any)).thenReturn(Success(userAfterMerge))
 
-    service.updateFeideUserData(updatedUserData, Some(feideId)) should be(Success(expected))
+    service.updateMyNDLAUserData(updatedUserData, Some(feideId)) should be(Success(expected))
 
     verify(userRepository, times(1)).userWithFeideId(any)(any)
     verify(userRepository, times(1)).updateUser(any, any)(any)
@@ -2151,13 +2151,13 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
 
   test("That updateUserData fails if user does not exist") {
     val feideId         = "feide"
-    val updatedUserData = api.UpdatedFeideUser(favoriteSubjects = Some(Seq("r", "e")))
+    val updatedUserData = api.UpdatedMyNDLAUser(favoriteSubjects = Some(Seq("r", "e")))
 
     when(feideApiClient.getUserFeideID(any)).thenReturn(Success(feideId))
-    when(readService.getOrCreateFeideUserIfNotExist(any, any)).thenReturn(Success(emptyFeideUser))
+    when(readService.getOrCreateMyNDLAUserIfNotExist(any, any)).thenReturn(Success(emptyMyNDLAUser))
     when(userRepository.userWithFeideId(eqTo(feideId))(any)).thenReturn(Success(None))
 
-    service.updateFeideUserData(updatedUserData, Some(feideId)) should be(
+    service.updateMyNDLAUserData(updatedUserData, Some(feideId)) should be(
       Failure(NotFoundException(s"User with feide_id $feideId was not found"))
     )
 
@@ -2198,7 +2198,7 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
       func(mock[DBSession])
     })
     when(feideApiClient.getUserFeideID(any)).thenReturn(Success(feideId))
-    when(readService.getOrCreateFeideUserIfNotExist(any, any)).thenReturn(Success(emptyFeideUser))
+    when(readService.getOrCreateMyNDLAUserIfNotExist(any, any)).thenReturn(Success(emptyMyNDLAUser))
     when(folderRepository.setFolderRank(any, any, any)(any)).thenReturn(Success(()))
     when(folderRepository.setResourceConnectionRank(any, any, any)(any)).thenReturn(Success(()))
     when(folderRepository.folderWithFeideId(eqTo(parent.id), any)(any)).thenReturn(Success(parent))
@@ -2220,9 +2220,9 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
   test(
     "that canWriteDuringWriteRestrictionsOrAccessDenied returns Success if user is a Teacher during write restriction"
   ) {
-    val feideUser = emptyFeideUser.copy(userRole = UserRole.TEACHER)
+    val myNDLAUser = emptyMyNDLAUser.copy(userRole = UserRole.TEACHER)
 
-    when(readService.getOrCreateFeideUserIfNotExist(any, any)).thenReturn(Success(feideUser))
+    when(readService.getOrCreateMyNDLAUserIfNotExist(any, any)).thenReturn(Success(myNDLAUser))
     when(readService.isWriteRestricted).thenReturn(true)
 
     val result = service.canWriteDuringWriteRestrictionsOrAccessDenied("spiller ing", Some("en rolle"))
@@ -2232,9 +2232,9 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
   test(
     "that canWriteDuringWriteRestrictionsOrAccessDenied returns Failure if user is a Student during write restriction"
   ) {
-    val feideUser = emptyFeideUser.copy(userRole = UserRole.STUDENT)
+    val myNDLAUser = emptyMyNDLAUser.copy(userRole = UserRole.STUDENT)
 
-    when(readService.getOrCreateFeideUserIfNotExist(any, any)).thenReturn(Success(feideUser))
+    when(readService.getOrCreateMyNDLAUserIfNotExist(any, any)).thenReturn(Success(myNDLAUser))
     when(readService.isWriteRestricted).thenReturn(true)
 
     val result = service.canWriteDuringWriteRestrictionsOrAccessDenied("spiller ing", Some("en rolle"))
@@ -2244,9 +2244,9 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
   test(
     "that canWriteDuringWriteRestrictionsOrAccessDenied returns Success if user is a Student not during write restriction"
   ) {
-    val feideUser = emptyFeideUser.copy(userRole = UserRole.STUDENT)
+    val myNDLAUser = emptyMyNDLAUser.copy(userRole = UserRole.STUDENT)
 
-    when(readService.getOrCreateFeideUserIfNotExist(any, any)).thenReturn(Success(feideUser))
+    when(readService.getOrCreateMyNDLAUserIfNotExist(any, any)).thenReturn(Success(myNDLAUser))
     when(readService.isWriteRestricted).thenReturn(false)
 
     val result = service.canWriteDuringWriteRestrictionsOrAccessDenied("spiller ing", Some("en rolle"))

--- a/learningpath-api/typescript/index.ts
+++ b/learningpath-api/typescript/index.ts
@@ -48,12 +48,6 @@ export interface IError {
   occuredAt: string
 }
 
-export interface IFeideUser {
-  id: number
-  favoriteSubjects: string[]
-  role: string
-}
-
 export interface IFolder {
   id: string
   name: string
@@ -174,6 +168,12 @@ export interface ILicense {
 export interface IMessage {
   message: string
   date: string
+}
+
+export interface IMyNDLAUser {
+  id: number
+  favoriteSubjects: string[]
+  role: string
 }
 
 export interface INewFolder {

--- a/project/learningpathapi.scala
+++ b/project/learningpathapi.scala
@@ -40,7 +40,6 @@ object learningpathapi extends Module {
     exports = Seq(
       "Author",
       "Error",
-      "FeideUser",
       "ConfigMetaRestricted",
       "LearningPathStatus",
       "LearningPathSummaryV2",
@@ -53,6 +52,7 @@ object learningpathapi extends Module {
       "LearningStepV2",
       "License",
       "SearchResultV2",
+      "MyNDLAUser",
       "config.ConfigMeta",
       "Folder",
       "FolderData",


### PR DESCRIPTION
Bytter navn fra `FeideUser` til `MyNDLAUser` for å unngå confusion. Vi bruker `feideUser` i feide sammenheng og den ble også brukt som navn på brukerprofil på min NDLA.