### PR TITLE
Add `MY_NDLA_WRITE_RESTRICTED` config-key

### DIFF
--- a/learningpath-api/src/main/resources/no/ndla/learningpathapi/db/migration/V25__RenameLearningpathWriteRestriction.sql
+++ b/learningpath-api/src/main/resources/no/ndla/learningpathapi/db/migration/V25__RenameLearningpathWriteRestriction.sql
@@ -1,0 +1,5 @@
+UPDATE configtable SET
+    value = jsonb_set(value, '{key}', '"LEARNINGPATH_WRITE_RESTRICTED"'),
+    configkey = 'LEARNINGPATH_WRITE_RESTRICTED'
+WHERE
+    configkey = 'IS_WRITE_RESTRICTED';

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/model/domain/config/ConfigKey.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/model/domain/config/ConfigKey.scala
@@ -12,7 +12,8 @@ import enumeratum._
 sealed abstract class ConfigKey(override val entryName: String) extends EnumEntry
 
 object ConfigKey extends Enum[ConfigKey] {
-  case object IsWriteRestricted extends ConfigKey("IS_WRITE_RESTRICTED")
+  case object IsWriteRestricted     extends ConfigKey("IS_WRITE_RESTRICTED")
+  case object MyNDLAWriteRestricted extends ConfigKey("MY_NDLA_WRITE_RESTRICTED")
 
   val values: IndexedSeq[ConfigKey] = findValues
 

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/model/domain/config/ConfigKey.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/model/domain/config/ConfigKey.scala
@@ -12,8 +12,8 @@ import enumeratum._
 sealed abstract class ConfigKey(override val entryName: String) extends EnumEntry
 
 object ConfigKey extends Enum[ConfigKey] {
-  case object IsWriteRestricted     extends ConfigKey("IS_WRITE_RESTRICTED")
-  case object MyNDLAWriteRestricted extends ConfigKey("MY_NDLA_WRITE_RESTRICTED")
+  case object LearningpathWriteRestricted extends ConfigKey("LEARNINGPATH_WRITE_RESTRICTED")
+  case object MyNDLAWriteRestricted       extends ConfigKey("MY_NDLA_WRITE_RESTRICTED")
 
   val values: IndexedSeq[ConfigKey] = findValues
 

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/model/domain/config/ConfigMeta.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/model/domain/config/ConfigMeta.scala
@@ -38,8 +38,8 @@ case class ConfigMeta(
   }
 
   def validate: Try[ConfigMeta] = key match {
-    case ConfigKey.IsWriteRestricted     => validateBooleanKey(ConfigKey.IsWriteRestricted)
-    case ConfigKey.MyNDLAWriteRestricted => validateBooleanKey(ConfigKey.MyNDLAWriteRestricted)
+    case ConfigKey.LearningpathWriteRestricted => validateBooleanKey(ConfigKey.LearningpathWriteRestricted)
+    case ConfigKey.MyNDLAWriteRestricted       => validateBooleanKey(ConfigKey.MyNDLAWriteRestricted)
   }
 }
 

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/model/domain/config/ConfigMeta.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/model/domain/config/ConfigMeta.scala
@@ -25,20 +25,21 @@ case class ConfigMeta(
     updatedBy: String
 ) {
 
-  def validate: Try[ConfigMeta] = {
-    key match {
-      case ConfigKey.IsWriteRestricted =>
-        Try(value.toBoolean) match {
-          case Success(_) => Success(this)
-          case Failure(_) =>
-            val validationMessage = ValidationMessage(
-              "value",
-              s"Value of '${ConfigKey.IsWriteRestricted.entryName}' must be a boolean string ('true' or 'false')"
-            )
-            Failure(new ValidationException(s"Invalid config value specified.", Seq(validationMessage)))
-        }
-      // Add case here for validation for new ConfigKeys
+  private def validateBooleanKey(configKey: ConfigKey): Try[ConfigMeta] = {
+    Try(value.toBoolean) match {
+      case Success(_) => Success(this)
+      case Failure(_) =>
+        val validationMessage = ValidationMessage(
+          "value",
+          s"Value of '${configKey.entryName}' must be a boolean string ('true' or 'false')"
+        )
+        Failure(new ValidationException(s"Invalid config value specified.", Seq(validationMessage)))
     }
+  }
+
+  def validate: Try[ConfigMeta] = key match {
+    case ConfigKey.IsWriteRestricted     => validateBooleanKey(ConfigKey.IsWriteRestricted)
+    case ConfigKey.MyNDLAWriteRestricted => validateBooleanKey(ConfigKey.MyNDLAWriteRestricted)
   }
 }
 

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/ReadService.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/ReadService.scala
@@ -187,7 +187,7 @@ trait ReadService {
     def isWriteRestricted: Boolean =
       Try(
         configRepository
-          .getConfigWithKey(ConfigKey.IsWriteRestricted)
+          .getConfigWithKey(ConfigKey.LearningpathWriteRestricted)
           .map(_.value.toBoolean)
       ).toOption.flatten.getOrElse(false)
 

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/ReadService.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/ReadService.scala
@@ -191,6 +191,13 @@ trait ReadService {
           .map(_.value.toBoolean)
       ).toOption.flatten.getOrElse(false)
 
+    def isMyNDLAWriteRestricted: Boolean =
+      Try(
+        configRepository
+          .getConfigWithKey(ConfigKey.MyNDLAWriteRestricted)
+          .map(_.value.toBoolean)
+      ).toOption.flatten.getOrElse(false)
+
     def getConfig(configKey: ConfigKey): Try[api.config.ConfigMetaRestricted] = {
       configRepository.getConfigWithKey(configKey) match {
         case None      => Failure(NotFoundException(s"Configuration with key $configKey does not exist"))

--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/TestData.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/TestData.scala
@@ -47,7 +47,7 @@ object TestData {
   val adminScopeAuthMap: Map[String, String] = Map("Authorization" -> s"Bearer $adminScopeClientToken")
 
   val testConfigMeta: ConfigMeta = domain.config.ConfigMeta(
-    ConfigKey.IsWriteRestricted,
+    ConfigKey.LearningpathWriteRestricted,
     value = "true",
     today,
     "EnKulFyr"

--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/controller/ConfigControllerTest.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/controller/ConfigControllerTest.scala
@@ -35,11 +35,11 @@ class ConfigControllerTest extends UnitSuite with TestEnvironment with ScalatraF
   test("That updating config returns 200 if all is good") {
     when(updateService.updateConfig(any[ConfigKey], any[UpdateConfigValue], any[UserInfo]))
       .thenReturn(
-        Success(ConfigMeta(ConfigKey.IsWriteRestricted.entryName, "true", LocalDateTime.now(), "someoneCool"))
+        Success(ConfigMeta(ConfigKey.LearningpathWriteRestricted.entryName, "true", LocalDateTime.now(), "someoneCool"))
       )
 
     post(
-      s"/${ConfigKey.IsWriteRestricted.entryName}",
+      s"/${ConfigKey.LearningpathWriteRestricted.entryName}",
       body = "{\"value\": \"true\"}",
       headers = Map("Authorization" -> s"Bearer $adminScopeClientToken")
     ) {
@@ -47,7 +47,7 @@ class ConfigControllerTest extends UnitSuite with TestEnvironment with ScalatraF
     }
 
     post(
-      s"/${ConfigKey.IsWriteRestricted.entryName}",
+      s"/${ConfigKey.LearningpathWriteRestricted.entryName}",
       body = "{\"value\": \"true\"}",
       headers = Map("Authorization" -> s"Bearer $adminAndWriteScopeClientToken")
     ) {

--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/repository/ConfigRepositoryTest.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/repository/ConfigRepositoryTest.scala
@@ -70,7 +70,7 @@ class ConfigRepositoryTest
 
   test("That updating configKey from empty database inserts config") {
     val newConfig = ConfigMeta(
-      key = ConfigKey.IsWriteRestricted,
+      key = ConfigKey.LearningpathWriteRestricted,
       value = "true",
       updatedAt = DateParser.fromUnixTime(0),
       updatedBy = "ndlaUser1"
@@ -79,12 +79,12 @@ class ConfigRepositoryTest
     repository.updateConfigParam(newConfig)
 
     repository.configCount should be(1)
-    repository.getConfigWithKey(ConfigKey.IsWriteRestricted) should be(Some(newConfig))
+    repository.getConfigWithKey(ConfigKey.LearningpathWriteRestricted) should be(Some(newConfig))
   }
 
   test("That updating config works as expected") {
     val originalConfig = ConfigMeta(
-      key = ConfigKey.IsWriteRestricted,
+      key = ConfigKey.LearningpathWriteRestricted,
       value = "true",
       updatedAt = DateParser.fromUnixTime(0),
       updatedBy = "ndlaUser1"
@@ -92,10 +92,10 @@ class ConfigRepositoryTest
 
     repository.updateConfigParam(originalConfig)
     repository.configCount should be(1)
-    repository.getConfigWithKey(ConfigKey.IsWriteRestricted) should be(Some(originalConfig))
+    repository.getConfigWithKey(ConfigKey.LearningpathWriteRestricted) should be(Some(originalConfig))
 
     val updatedConfig = ConfigMeta(
-      key = ConfigKey.IsWriteRestricted,
+      key = ConfigKey.LearningpathWriteRestricted,
       value = "false",
       updatedAt = DateParser.fromUnixTime(10000),
       updatedBy = "ndlaUser2"
@@ -103,6 +103,6 @@ class ConfigRepositoryTest
 
     repository.updateConfigParam(updatedConfig)
     repository.configCount should be(1)
-    repository.getConfigWithKey(ConfigKey.IsWriteRestricted) should be(Some(updatedConfig))
+    repository.getConfigWithKey(ConfigKey.LearningpathWriteRestricted) should be(Some(updatedConfig))
   }
 }

--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/UpdateServiceTest.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/UpdateServiceTest.scala
@@ -2225,7 +2225,7 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
     when(readService.getOrCreateMyNDLAUserIfNotExist(any, any)(any)).thenReturn(Success(myNDLAUser))
     when(readService.isWriteRestricted).thenReturn(true)
 
-    val result = service.canWriteDuringWriteRestrictionsOrAccessDenied("spiller ing", Some("en rolle"))
+    val result = service.canWriteDuringMyNDLAWriteRestrictionsOrAccessDenied("spiller ing", Some("en rolle"))
     result.isSuccess should be(true)
   }
 
@@ -2235,9 +2235,9 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
     val myNDLAUser = emptyMyNDLAUser.copy(userRole = UserRole.STUDENT)
 
     when(readService.getOrCreateMyNDLAUserIfNotExist(any, any)(any)).thenReturn(Success(myNDLAUser))
-    when(readService.isWriteRestricted).thenReturn(true)
+    when(readService.isMyNDLAWriteRestricted).thenReturn(true)
 
-    val result = service.canWriteDuringWriteRestrictionsOrAccessDenied("spiller ing", Some("en rolle"))
+    val result = service.canWriteDuringMyNDLAWriteRestrictionsOrAccessDenied("spiller ing", Some("en rolle"))
     result should be(Failure(AccessDeniedException("You do not have write access while write restriction is active.")))
   }
 
@@ -2247,9 +2247,9 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
     val myNDLAUser = emptyMyNDLAUser.copy(userRole = UserRole.STUDENT)
 
     when(readService.getOrCreateMyNDLAUserIfNotExist(any, any)(any)).thenReturn(Success(myNDLAUser))
-    when(readService.isWriteRestricted).thenReturn(false)
+    when(readService.isMyNDLAWriteRestricted).thenReturn(false)
 
-    val result = service.canWriteDuringWriteRestrictionsOrAccessDenied("spiller ing", Some("en rolle"))
+    val result = service.canWriteDuringMyNDLAWriteRestrictionsOrAccessDenied("spiller ing", Some("en rolle"))
     result.isSuccess should be(true)
   }
 }

--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/UpdateServiceTest.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/UpdateServiceTest.scala
@@ -1434,7 +1434,7 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
     when(configRepository.updateConfigParam(any[ConfigMeta])(any[DBSession]))
       .thenReturn(Success(TestData.testConfigMeta))
     val Failure(ex) = service.updateConfig(
-      ConfigKey.IsWriteRestricted,
+      ConfigKey.LearningpathWriteRestricted,
       UpdateConfigValue("true"),
       UserInfo("Kari", Set(LearningPathRole.PUBLISH))
     )
@@ -1445,7 +1445,7 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
     when(configRepository.updateConfigParam(any[ConfigMeta])(any[DBSession]))
       .thenReturn(Success(TestData.testConfigMeta))
     val Success(config) = service.updateConfig(
-      ConfigKey.IsWriteRestricted,
+      ConfigKey.LearningpathWriteRestricted,
       UpdateConfigValue("true"),
       UserInfo("Kari", Set(LearningPathRole.ADMIN))
     )
@@ -1455,7 +1455,7 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
     when(configRepository.updateConfigParam(any[ConfigMeta])(any[DBSession]))
       .thenReturn(Success(TestData.testConfigMeta))
     val Failure(ex) = service.updateConfig(
-      ConfigKey.IsWriteRestricted,
+      ConfigKey.LearningpathWriteRestricted,
       UpdateConfigValue("123"),
       UserInfo("Kari", Set(LearningPathRole.ADMIN))
     )
@@ -1467,7 +1467,7 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
     when(configRepository.updateConfigParam(any[ConfigMeta])(any[DBSession]))
       .thenReturn(Success(TestData.testConfigMeta))
     val res = service.updateConfig(
-      ConfigKey.IsWriteRestricted,
+      ConfigKey.LearningpathWriteRestricted,
       UpdateConfigValue("true"),
       UserInfo("Kari", Set(LearningPathRole.ADMIN))
     )


### PR DESCRIPTION
Fixes NDLANO/Issues#3346

Kan testes ved å se at å sette `MY_NDLA_WRITE_RESTRICTED` til "true" ikke lar en skrive til min-ndla, men vanlige læringsstier fortsatt fungerer, og motsatt for `IS_WRITE_RESTRICTED` flagget som allerede eksisterer.