### PR TITLE
Improve logging in frontpage-api

### DIFF
--- a/common/src/main/scala/no/ndla/common/RequestLogger.scala
+++ b/common/src/main/scala/no/ndla/common/RequestLogger.scala
@@ -1,3 +1,11 @@
+/*
+ * Part of NDLA common.
+ * Copyright (C) 2022 NDLA
+ *
+ * See LICENSE
+ *
+ */
+
 package no.ndla.common
 
 object RequestLogger {

--- a/common/src/main/scala/no/ndla/common/RequestLogger.scala
+++ b/common/src/main/scala/no/ndla/common/RequestLogger.scala
@@ -1,0 +1,21 @@
+package no.ndla.common
+
+object RequestLogger {
+
+  def beforeRequestLogString(method: String, requestPath: String, queryString: String): String = {
+    val query = if (queryString.nonEmpty) s"?${queryString}" else queryString
+    s"$method $requestPath$query"
+  }
+
+  def afterRequestLogString(
+      method: String,
+      requestPath: String,
+      queryString: String,
+      latency: Long,
+      responseCode: Int
+  ): String = {
+    val query = if (queryString.nonEmpty) s"?${queryString}" else queryString
+    s"$method $requestPath$query executed in ${latency}ms with code $responseCode"
+  }
+
+}

--- a/common/src/main/scala/no/ndla/common/scalatra/NdlaControllerBase.scala
+++ b/common/src/main/scala/no/ndla/common/scalatra/NdlaControllerBase.scala
@@ -10,19 +10,19 @@ package no.ndla.common.scalatra
 
 import com.typesafe.scalalogging.StrictLogging
 import no.ndla.common.CorrelationID
+import no.ndla.common.RequestLogger.beforeRequestLogString
 import no.ndla.common.configuration.HasBaseProps
 import no.ndla.common.errors.{ValidationException, ValidationMessage}
+import org.json4s.ext.JavaTimeSerializers
 import org.json4s.native.Serialization.read
 import org.json4s.{DefaultFormats, Formats}
 import org.scalatra.json.NativeJsonSupport
-import org.scalatra.{ActionResult, HaltException, Ok, RenderPipeline, ScalatraServlet}
-
-import javax.servlet.http.HttpServletRequest
-import scala.util.{Failure, Success, Try}
-import org.json4s.ext.JavaTimeSerializers
+import org.scalatra._
 
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
+import javax.servlet.http.HttpServletRequest
+import scala.util.{Failure, Success, Try}
 
 trait NdlaControllerBase {
   this: HasBaseProps =>
@@ -37,10 +37,7 @@ trait NdlaControllerBase {
       CorrelationID.set(request)
 
       logger.info(
-        "{} {}{}",
-        request.getMethod,
-        request.getRequestURI,
-        Option(request.getQueryString).map(s => s"?$s").getOrElse("")
+        beforeRequestLogString(request.getMethod, request.getRequestURI, request.queryString)
       )
     }
 

--- a/common/src/main/scala/no/ndla/common/scalatra/NdlaRequestLogger.scala
+++ b/common/src/main/scala/no/ndla/common/scalatra/NdlaRequestLogger.scala
@@ -10,6 +10,7 @@ package no.ndla.common.scalatra
 
 import com.typesafe.scalalogging.StrictLogging
 import no.ndla.common.CorrelationID
+import no.ndla.common.RequestLogger.afterRequestLogString
 import no.ndla.common.configuration.BaseProps
 import org.eclipse.jetty.server.{Request, RequestLog, Response}
 
@@ -19,9 +20,15 @@ class NdlaRequestLogger[PROPS <: BaseProps](props: PROPS) extends RequestLog wit
     if (request.getRequestURI == "/health") return // Logging health-endpoints are very noisy
 
     val latency = System.currentTimeMillis() - request.getTimeStamp
-    val query   = Option(request.getQueryString).map(s => s"?$s").getOrElse("")
+    val query   = Option(request.getQueryString).getOrElse("")
     logger.info(
-      s"${request.getMethod} ${request.getRequestURI}${query} executed in ${latency}ms with code ${response.getStatus}"
+      afterRequestLogString(
+        method = request.getMethod,
+        requestPath = request.getRequestURI,
+        queryString = query,
+        latency = latency,
+        responseCode = response.getStatus
+      )
     )
 
     CorrelationID.clear()

--- a/project/Module.scala
+++ b/project/Module.scala
@@ -95,13 +95,10 @@ trait Module {
     assembly / assemblyJarName := name.value + ".jar",
     assembly / mainClass       := this.MainClass,
     assembly / assemblyMergeStrategy := {
-      case "module-info.class"                                   => MergeStrategy.discard
-      case x if x.endsWith("/module-info.class")                 => MergeStrategy.discard
-      case x if x.endsWith("io.netty.versions.properties")       => MergeStrategy.discard
-      case "mime.types"                                          => MergeStrategy.filterDistinctLines
-      case PathList("org", "convert", "ToString.class")          => MergeStrategy.first
-      case PathList("org", "convert", "FromString.class")        => MergeStrategy.first
-      case PathList("org", "time", "base", "BaseDateTime.class") => MergeStrategy.first
+      case "module-info.class"                             => MergeStrategy.discard
+      case x if x.endsWith("/module-info.class")           => MergeStrategy.discard
+      case x if x.endsWith("io.netty.versions.properties") => MergeStrategy.discard
+      case "mime.types"                                    => MergeStrategy.filterDistinctLines
       case x =>
         val oldStrategy = (assembly / assemblyMergeStrategy).value
         oldStrategy(x)


### PR DESCRIPTION
Flytter bygging av logge-strengene til en egen funksjon sånn at vi blir litt mer oppfordret til å ha samme format på loggingen i alle apiene (uavhengig av biblioteker)

Legger også til latency i frontpage-api :^)