### PR TITLE
Add stats-endpoint for fetching data about my ndla

### DIFF
--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/ComponentRegistry.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/ComponentRegistry.scala
@@ -19,6 +19,7 @@ import no.ndla.learningpathapi.controller.{
   InternController,
   LearningpathControllerV2,
   NdlaController,
+  StatsController,
   UserController
 }
 import no.ndla.learningpathapi.integration._
@@ -59,6 +60,7 @@ class ComponentRegistry(properties: LearningpathApiProperties)
     with HealthController
     with ConfigController
     with FolderController
+    with StatsController
     with NdlaSwaggerSupport
     with NdlaControllerBase
     with UserController
@@ -123,6 +125,7 @@ class ComponentRegistry(properties: LearningpathApiProperties)
   lazy val internController         = new InternController
   lazy val configController         = new ConfigController
   lazy val folderController         = new FolderController
+  lazy val statsController          = new StatsController
   lazy val userController           = new UserController
   lazy val resourcesApp             = new ResourcesApp
   lazy val taxononyApiClient        = new TaxonomyApiClient

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/ScalatraBootstrap.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/ScalatraBootstrap.scala
@@ -18,6 +18,7 @@ class ScalatraBootstrap extends NdlaScalatraBootstrapBase[ComponentRegistry] {
     context.mount(componentRegistry.resourcesApp, "/learningpath-api/api-docs")
     context.mount(componentRegistry.healthController, "/health")
     context.mount(componentRegistry.configController, "/learningpath-api/v1/config", "config")
+    context.mount(componentRegistry.statsController, "/learningpath-api/v1/stats", "stats")
     context.mount(componentRegistry.folderController, "/learningpath-api/v1/folders", "folders")
     context.mount(componentRegistry.userController, "/learningpath-api/v1/users", "users")
   }

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/controller/StatsController.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/controller/StatsController.scala
@@ -1,3 +1,10 @@
+/*
+ * Part of NDLA learningpath-api.
+ * Copyright (C) 2022 NDLA
+ *
+ * See LICENSE
+ */
+
 package no.ndla.learningpathapi.controller
 
 import no.ndla.common.scalatra.NdlaSwaggerSupport

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/controller/StatsController.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/controller/StatsController.scala
@@ -1,0 +1,43 @@
+package no.ndla.learningpathapi.controller
+
+import no.ndla.common.scalatra.NdlaSwaggerSupport
+import no.ndla.learningpathapi.Props
+import no.ndla.learningpathapi.model.api.{Error, Stats}
+import no.ndla.learningpathapi.service.ReadService
+import org.json4s.{DefaultFormats, Formats}
+import org.scalatra.swagger.{ResponseMessage, Swagger}
+import org.scalatra.{NotFound, Ok}
+
+trait StatsController {
+  this: ReadService with NdlaController with Props with NdlaSwaggerSupport =>
+  val statsController: StatsController
+
+  class StatsController(implicit val swagger: Swagger) extends NdlaController with NdlaSwaggerSupport {
+    protected implicit override val jsonFormats: Formats = DefaultFormats
+
+    protected val applicationDescription = "API for getting stats for my-ndla usage."
+
+    // Additional models used in error responses
+    registerModel[Error]()
+
+    val response404: ResponseMessage = ResponseMessage(404, "Not found", Some("Error"))
+    val response500: ResponseMessage = ResponseMessage(500, "Unknown error", Some("Error"))
+    val response502: ResponseMessage = ResponseMessage(502, "Remote error", Some("Error"))
+
+    get(
+      "/",
+      operation(
+        apiOperation[Stats]("getStats")
+          .summary("Get stats for my-ndla usage.")
+          .description("Get stats for my-ndla usage.")
+          .responseMessages(response404, response500, response502)
+      )
+    ) {
+      readService.getStats() match {
+        case Some(c) => Ok(c)
+        case None    => NotFound("No stats found")
+      }
+    }
+  }
+
+}

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/model/api/Stats.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/model/api/Stats.scala
@@ -1,3 +1,10 @@
+/*
+ * Part of NDLA learningpath-api.
+ * Copyright (C) 2022 NDLA
+ *
+ * See LICENSE
+ */
+
 package no.ndla.learningpathapi.model.api
 
 import org.scalatra.swagger.annotations.ApiModel

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/model/api/Stats.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/model/api/Stats.scala
@@ -1,0 +1,14 @@
+package no.ndla.learningpathapi.model.api
+
+import org.scalatra.swagger.annotations.ApiModel
+import org.scalatra.swagger.runtime.annotations.ApiModelProperty
+
+import scala.annotation.meta.field
+
+@ApiModel(description = "Stats for my-ndla usage")
+case class Stats(
+    @(ApiModelProperty @field)(description = "The total number of users registered ") numberOfUsers: Long,
+    @(ApiModelProperty @field)(description = "The total number of created folders") numberOfFolders: Long,
+    @(ApiModelProperty @field)(description = "The total number of favourited resources ") numberOfResources: Long,
+    @(ApiModelProperty @field)(description = "The total number of created tags") numberOfTags: Long
+) {}

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/repository/FolderRepository.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/repository/FolderRepository.scala
@@ -517,5 +517,29 @@ trait FolderRepository {
           Failure(NDLASQLException(s"This is a Bug! The expected rows count should be 1 and was $count."))
       }
 
+    def numberOfTags()(implicit session: DBSession = ReadOnlyAutoSession): Option[Long] = {
+      sql"select count(distinct document->'tags') from ${DBResource.table}"
+        .map(rs => rs.long("count"))
+        .single()
+    }
+
+    def numberOfResources()(implicit session: DBSession = ReadOnlyAutoSession): Option[Long] = {
+      sql"select count(*) from ${DBResource.table}"
+        .map(rs => rs.long("count"))
+        .single()
+    }
+
+    def numberOfFolders()(implicit session: DBSession = ReadOnlyAutoSession): Option[Long] = {
+      sql"select count(*) from ${DBFolder.table}"
+        .map(rs => rs.long("count"))
+        .single()
+    }
+
+    def numberOfUsers()(implicit session: DBSession = ReadOnlyAutoSession): Option[Long] = {
+      sql"select count(distinct feide_id) from ${DBFolder.table}"
+        .map(rs => rs.long("count"))
+        .single()
+    }
+
   }
 }

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/repository/FolderRepository.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/repository/FolderRepository.scala
@@ -518,7 +518,7 @@ trait FolderRepository {
       }
 
     def numberOfTags()(implicit session: DBSession = ReadOnlyAutoSession): Option[Long] = {
-      sql"select count(distinct document->'tags') from ${DBResource.table}"
+      sql"select count(tag) from (select distinct jsonb_array_elements_text(document->'tags') from ${DBResource.table}) as tag"
         .map(rs => rs.long("count"))
         .single()
     }

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/repository/UserRepository.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/repository/UserRepository.scala
@@ -100,6 +100,11 @@ trait UserRepository {
         .single()
     }
 
+    def numberOfUsers()(implicit session: DBSession = ReadOnlyAutoSession): Option[Long] = {
+      sql"select count(*) from ${DBMyNDLAUser.table}"
+        .map(rs => rs.long("count"))
+        .single()
+    }
   }
 
 }

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/ReadService.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/ReadService.scala
@@ -406,5 +406,16 @@ trait ReadService {
         api = converterService.toApiUserData(userData)
       } yield api
     }
+
+    def getStats(): Option[Stats] = {
+      implicit val session: DBSession = folderRepository.getSession(true)
+      for {
+        numberOfUsers     <- folderRepository.numberOfUsers()
+        numberOfFolders   <- folderRepository.numberOfFolders()
+        numberOfResources <- folderRepository.numberOfResources()
+        numberOfTags      <- folderRepository.numberOfTags()
+        stats = Stats(numberOfUsers, numberOfFolders, numberOfResources, numberOfTags)
+      } yield stats
+    }
   }
 }

--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/TestEnvironment.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/TestEnvironment.scala
@@ -16,7 +16,8 @@ import no.ndla.learningpathapi.controller.{
   HealthController,
   InternController,
   LearningpathControllerV2,
-  NdlaController
+  NdlaController,
+  StatsController
 }
 import no.ndla.learningpathapi.integration._
 import no.ndla.learningpathapi.model.api.ErrorHelpers
@@ -45,6 +46,7 @@ import org.mockito.scalatest.MockitoSugar
 
 trait TestEnvironment
     extends LearningpathControllerV2
+    with StatsController
     with ConfigController
     with NdlaControllerBase
     with NdlaSwaggerSupport
@@ -111,6 +113,7 @@ trait TestEnvironment
   val languageValidator: LanguageValidator                             = mock[LanguageValidator]
   val learningpathControllerV2: LearningpathControllerV2               = mock[LearningpathControllerV2]
   val configController: ConfigController                               = mock[ConfigController]
+  val statsController: StatsController                                 = mock[StatsController]
   val healthController: HealthController                               = mock[HealthController]
   val internController: InternController                               = mock[InternController]
   val learningStepValidator: LearningStepValidator                     = mock[LearningStepValidator]

--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/controller/StatsControllerTest.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/controller/StatsControllerTest.scala
@@ -1,0 +1,27 @@
+package no.ndla.learningpathapi.controller
+
+import no.ndla.learningpathapi.model.api.Stats
+import no.ndla.learningpathapi.{TestEnvironment, UnitSuite}
+import org.json4s.DefaultFormats
+import org.scalatra.test.scalatest.ScalatraFunSuite
+
+class StatsControllerTest extends UnitSuite with TestEnvironment with ScalatraFunSuite {
+
+  implicit val formats: DefaultFormats.type = org.json4s.DefaultFormats
+  implicit val swagger: LearningpathSwagger = new LearningpathSwagger
+
+  lazy val controller = new StatsController()
+  addServlet(controller, "/*")
+
+  override def beforeEach(): Unit = {
+    resetMocks()
+  }
+
+  test("That getting stats returns in fact stats") {
+    when(readService.getStats()).thenReturn(Some(Stats(1, 2, 3, 4)))
+    get("/") {
+      status should be(200)
+    }
+  }
+
+}

--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/controller/StatsControllerTest.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/controller/StatsControllerTest.scala
@@ -1,3 +1,10 @@
+/*
+ * Part of NDLA learningpath-api.
+ * Copyright (C) 2022 NDLA
+ *
+ * See LICENSE
+ */
+
 package no.ndla.learningpathapi.controller
 
 import no.ndla.learningpathapi.model.api.Stats


### PR DESCRIPTION
Fixes NDLANO/Issues#3341

Adds stats-endpoint

Kan testes med lokal database:
* `ndla migrate db test local -c learningpath-api`
* `ndla  deploy local learningpath-api`
* `curl http://localhost/learningpath-api/v1/stats` 

Bør få resultat `{"numberOfUsers":49,"numberOfFolders":196,"numberOfResources":163,"numberOfTags":63}`