### PR TITLE
Sort contexts with primary first.

### DIFF
--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
@@ -439,7 +439,8 @@ trait SearchConverterService {
       implicit val formats: Formats = SearchableLanguageFormats.JSonFormatsWithMillis
       val searchableArticle         = read[SearchableArticle](hit.sourceAsString)
 
-      val contexts = searchableArticle.contexts.map(c => searchableContextToApiContext(c, language))
+      val contexts =
+        searchableArticle.contexts.sortBy(!_.isPrimaryConnection).map(c => searchableContextToApiContext(c, language))
 
       val titles = searchableArticle.title.languageValues.map(lv => api.Title(lv.value, lv.language))
       val introductions =
@@ -489,7 +490,8 @@ trait SearchConverterService {
       implicit val formats: Formats = SearchableLanguageFormats.JSonFormatsWithMillis
       val searchableDraft           = read[SearchableDraft](hit.sourceAsString)
 
-      val contexts = searchableDraft.contexts.map(c => searchableContextToApiContext(c, language))
+      val contexts =
+        searchableDraft.contexts.sortBy(!_.isPrimaryConnection).map(c => searchableContextToApiContext(c, language))
 
       val titles = searchableDraft.title.languageValues.map(lv => api.Title(lv.value, lv.language))
       val introductions =

--- a/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceAtomicTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceAtomicTest.scala
@@ -679,7 +679,7 @@ class MultiDraftSearchServiceAtomicTest
     ctxFor(2).isPrimaryConnection should be(true)
     ctxFor(3).isPrimaryConnection should be(true)
     ctxFor(4).isPrimaryConnection should be(true)
-    ctxsFor(5).map(_.isPrimaryConnection) should be(Seq(true, false, true))
+    ctxsFor(5).map(_.isPrimaryConnection) should be(Seq(true, true, false)) // Sorted with primary first
 
   }
 }


### PR DESCRIPTION
This makes search-page display primary as main search-result