### PR TITLE
Rename `embed` to `ndlaembed`

### DIFF
--- a/article-api/README.md
+++ b/article-api/README.md
@@ -14,13 +14,13 @@ The application can be configured by specifying several parameters as environmen
 
 ## Article format
 The endpoint `GET /article-api/v2/articles/<id>` will fetch a json-object containing the article in the selected language.
-The article body contained in this json-object consists of a strict subset of permitted HTML tags. It may also contain a special tag, `<embed>`,
+The article body contained in this json-object consists of a strict subset of permitted HTML tags. It may also contain a special tag, `<ndlaembed>`,
 which is used to refer to content located in other APIs (including, but not limited to images, audio, video and H5P).
 
 Some example usages of the embed tag:
-* `<embed data-resource="external" data-url="https://youtu.be/7ZVyNjKSr0M" data-id="0" />` refers content from an external source (data-resource). In this case Youtube.
+* `<ndlaembed data-resource="external" data-url="https://youtu.be/7ZVyNjKSr0M" data-id="0" />` refers content from an external source (data-resource). In this case Youtube.
   `data-url` is the url where the resource can be found, `data-id` is an embed tag-identifier used to identify unique embeds in this article and is located in every embed tag.
-* `<embed data-align="" data-alt="Fyrlykt med hav og horisont" data-caption="" data-resource="image" data-size="fullbredde" data-id="1" data-url="http://image-api-url/image-api/v1/images/179" />`
+* `<ndlaembed data-align="" data-alt="Fyrlykt med hav og horisont" data-caption="" data-resource="image" data-size="fullbredde" data-id="1" data-url="http://image-api-url/image-api/v1/images/179" />`
   refers to an image (`data-resource`) located in the [image API](https://github.com/NDLANO/image-api), along with alignment info (`data-align`), alternative text (`data-alt`),
   image caption (`data-caption`), intended display size in the article (`data-size`), the unique embed tag-identifier (`data-id`) and the url where image metadata can be found (`data-url`).
 
@@ -37,12 +37,12 @@ used.
 A list of permitted HTML/MathML tags and attributes are specified in the repo [validation](https://github.com/NDLANO/validation) in the files `src/main/resources/html-rules.json` and `src/main/resources/mathml-rules.json`.
 The `tags` section defines permitted tags without attributes. The `attributes` section defines tags with a list of permitted attributes.
 
-Extra validation is performed on the `<embed>` tag: based on the `data-resource` attribute a different set of **required** attributes must also be present.
+Extra validation is performed on the `<ndlaembed>` tag: based on the `data-resource` attribute a different set of **required** attributes must also be present.
 These rules are defined in `src/main/resources/embed-tag-rules.json` in validation-repo. Should any attribute other than those in the required list be present,
-they will be stripped before validation (this step is only performed on `<embed>` tags).
+they will be stripped before validation (this step is only performed on `<ndlaembed>` tags).
 
-When an article is fetched with the `GET` API endpoint, the api will add a `data-url` attribute on every `<embed>` tag which also contains a `data-resource_id` attribute.
-A `data-id` attribute is appended to each `<embed>` tag.
+When an article is fetched with the `GET` API endpoint, the api will add a `data-url` attribute on every `<ndlaembed>` tag which also contains a `data-resource_id` attribute.
+A `data-id` attribute is appended to each `<ndlaembed>` tag.
 
 ### Resource types for embed tags
 The embed tag contains a set of attributes which define what content should be inserted. The list below provides an explaination of each recognized attribute.

--- a/article-api/src/main/scala/no/ndla/articleapi/db/migration/V39__RenameEmbedTag.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/db/migration/V39__RenameEmbedTag.scala
@@ -1,0 +1,115 @@
+/*
+ * Part of NDLA article-api.
+ * Copyright (C) 2022 NDLA
+ *
+ * See LICENSE
+ */
+
+package no.ndla.articleapi.db.migration
+
+import org.flywaydb.core.api.migration.{BaseJavaMigration, Context}
+import org.json4s
+import org.json4s.DefaultFormats
+import org.json4s.JsonAST.{JArray, JString}
+import org.json4s.native.JsonMethods.{compact, parse, render}
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Element
+import org.jsoup.nodes.Entities.EscapeMode
+import org.postgresql.util.PGobject
+import scalikejdbc.{DB, DBSession, _}
+
+class V39__RenameEmbedTag extends BaseJavaMigration {
+  implicit val formats: DefaultFormats.type = org.json4s.DefaultFormats
+
+  override def migrate(context: Context): Unit = {
+    val db = DB(context.getConnection)
+    db.autoClose(false)
+
+    db.withinTx { implicit session =>
+      migrateArticles
+    }
+  }
+
+  def migrateArticles(implicit session: DBSession): Unit = {
+    val count        = countAllArticles.get
+    var numPagesLeft = (count / 1000) + 1
+    var offset       = 0L
+
+    while (numPagesLeft > 0) {
+      allArticles(offset * 1000).map { case (id, document) =>
+        updateArticle(convertArticleUpdate(document), id)
+      }
+      numPagesLeft -= 1
+      offset += 1
+    }
+  }
+
+  def countAllArticles(implicit session: DBSession): Option[Long] = {
+    sql"select count(*) from contentdata where document is not NULL"
+      .map(rs => rs.long("count"))
+      .single()
+  }
+
+  def allArticles(offset: Long)(implicit session: DBSession): Seq[(Long, String)] = {
+    sql"select id, document, article_id from contentdata where document is not null order by id limit 1000 offset $offset"
+      .map(rs => {
+        (rs.long("id"), rs.string("document"))
+      })
+      .list()
+  }
+
+  def updateArticle(document: String, id: Long)(implicit session: DBSession): Int = {
+    val dataObject = new PGobject()
+    dataObject.setType("jsonb")
+    dataObject.setValue(document)
+
+    sql"update contentdata set document = $dataObject where id = $id"
+      .update()
+  }
+
+  private def stringToJsoupDocument(htmlString: String): Element = {
+    val document = Jsoup.parseBodyFragment(htmlString)
+    document.outputSettings().escapeMode(EscapeMode.xhtml).prettyPrint(false)
+    document.select("body").first()
+  }
+
+  private def jsoupDocumentToString(element: Element): String = {
+    element.select("body").html()
+  }
+
+  def renameEmbedTag(html: String): String = {
+    val doc = stringToJsoupDocument(html)
+    doc
+      .select("embed")
+      .forEach(embed => {
+        embed.tagName("ndlaembed")
+
+      })
+    jsoupDocumentToString(doc)
+  }
+
+  def updateContent(contents: JArray, contentType: String): json4s.JValue = {
+    contents.map(content =>
+      content.mapField {
+        case (`contentType`, JString(html)) => (`contentType`, JString(renameEmbedTag(html)))
+        case z                              => z
+      }
+    )
+  }
+
+  private[migration] def convertArticleUpdate(document: String): String = {
+    val oldArticle = parse(document)
+
+    val newArticle = oldArticle.mapField {
+      case ("content", contents: JArray) =>
+        val updatedContent = updateContent(contents, "content")
+        ("content", updatedContent)
+      case ("visualElement", visualElements: JArray) =>
+        val updatedVisualElement = updateContent(visualElements, "resource")
+        ("visualElement", updatedVisualElement)
+      case x => x
+    }
+
+    compact(render(newArticle))
+  }
+}

--- a/article-api/src/main/scala/no/ndla/articleapi/service/ConverterService.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/service/ConverterService.scala
@@ -19,6 +19,7 @@ import no.ndla.articleapi.model.search.SearchableArticle
 import no.ndla.articleapi.model.{api, domain}
 import no.ndla.articleapi.repository.ArticleRepository
 import no.ndla.common.Clock
+import no.ndla.common.configuration.Constants.EmbedTagName
 import no.ndla.common.model.domain.{Author, Tag, Title, VisualElement}
 import no.ndla.common.model.domain.article.Copyright
 import no.ndla.language.Language.{AllLanguages, UnknownLanguage, findByLanguageOrBestEffort, getSupportedLanguages}
@@ -347,7 +348,7 @@ trait ConverterService {
     private def removeUnknownEmbedTagAttributes(html: String): String = {
       val document = stringToJsoupDocument(html)
       document
-        .select("embed")
+        .select(EmbedTagName)
         .asScala
         .map(el => {
           ResourceType

--- a/article-api/src/main/scala/no/ndla/articleapi/service/ReadService.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/service/ReadService.scala
@@ -19,10 +19,10 @@ import no.ndla.articleapi.model.domain._
 import no.ndla.articleapi.model.search.SearchResult
 import no.ndla.articleapi.repository.ArticleRepository
 import no.ndla.articleapi.service.search.{ArticleSearchService, SearchConverterService}
+import no.ndla.common.configuration.Constants.EmbedTagName
 import no.ndla.common.errors.{AccessDeniedException, ValidationException}
 import no.ndla.common.model.domain.Availability
 import no.ndla.network.clients.FeideApiClient
-import no.ndla.validation.EmbedTagRules.ResourceHtmlEmbedTag
 import no.ndla.validation.HtmlTagRules.{jsoupDocumentToString, stringToJsoupDocument}
 import no.ndla.validation.{ResourceType, TagAttributes}
 import org.jsoup.nodes.Element
@@ -111,7 +111,7 @@ trait ReadService {
     private[service] def addUrlOnResource(content: String): String = {
       val doc = stringToJsoupDocument(content)
 
-      val embedTags = doc.select(s"$ResourceHtmlEmbedTag").asScala.toList
+      val embedTags = doc.select(EmbedTagName).asScala.toList
       embedTags.foreach(addUrlOnEmbedTag)
       jsoupDocumentToString(doc)
     }

--- a/article-api/src/test/scala/no/ndla/articleapi/TestData.scala
+++ b/article-api/src/test/scala/no/ndla/articleapi/TestData.scala
@@ -10,10 +10,10 @@ package no.ndla.articleapi
 
 import no.ndla.articleapi.model.api
 import no.ndla.articleapi.model.domain._
+import no.ndla.common.configuration.Constants.EmbedTagName
 import no.ndla.common.model.domain.{Author, Availability, Tag, Title, VisualElement}
 import no.ndla.common.model.domain.article.Copyright
 import no.ndla.mapping.License
-import no.ndla.validation.EmbedTagRules.ResourceHtmlEmbedTag
 
 import java.time.LocalDateTime
 
@@ -268,7 +268,7 @@ trait TestData {
     val sampleTitle       = Title("title", "en")
 
     val visualElement = VisualElement(
-      s"""<$ResourceHtmlEmbedTag  data-align="" data-alt="" data-caption="" data-resource="image" data-resource_id="1" data-size="" />""",
+      s"""<$EmbedTagName  data-align="" data-alt="" data-caption="" data-resource="image" data-resource_id="1" data-size="" />""",
       "nb"
     )
 

--- a/common/src/main/scala/no/ndla/common/configuration/Constants.scala
+++ b/common/src/main/scala/no/ndla/common/configuration/Constants.scala
@@ -3,4 +3,5 @@ package no.ndla.common.configuration
 object Constants {
   def CorrelationIdKey: String    = "correlationID"
   def CorrelationIdHeader: String = "X-Correlation-ID"
+  val EmbedTagName: String        = "ndlaembed"
 }

--- a/concept-api/src/main/scala/no/ndla/conceptapi/ConceptApiProperties.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/ConceptApiProperties.scala
@@ -44,7 +44,6 @@ class ConceptApiProperties extends BaseProps with StrictLogging {
   def MetaSchema: String   = prop(PropertyKeys.MetaSchemaKey)
   def MetaMaxConnections   = 10
 
-  def resourceHtmlEmbedTag         = "embed"
   def ApiClientsCacheAgeInMs: Long = 1000 * 60 * 60 // 1 hour caching
 
   def ArticleApiHost: String = propOrElse("ARTICLE_API_HOST", "article-api.ndla-local")

--- a/concept-api/src/main/scala/no/ndla/conceptapi/db/migration/R__MetaImageAsVisualElement.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/db/migration/R__MetaImageAsVisualElement.scala
@@ -7,6 +7,7 @@
 
 package no.ndla.conceptapi.db.migration
 
+import no.ndla.common.configuration.Constants.EmbedTagName
 import org.flywaydb.core.api.migration.{BaseJavaMigration, Context}
 import org.json4s.JsonAST.JObject
 import org.json4s.native.JsonMethods.{compact, parse, render}
@@ -115,7 +116,7 @@ class R__MetaImageAsVisualElement extends BaseJavaMigration {
     if (image.imageId.isEmpty) None
     else {
       val embedString =
-        s"""<embed data-resource="image" data-resource_id="${image.imageId}" data-alt="${image.altText}" data-size="full" data-align="" />"""
+        s"""<$EmbedTagName data-resource="image" data-resource_id="${image.imageId}" data-alt="${image.altText}" data-size="full" data-align="" />"""
       Some(NewVisualElement(embedString, image.language))
     }
   }

--- a/concept-api/src/main/scala/no/ndla/conceptapi/db/migration/V12__RenameEmbedsInVisualElements.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/db/migration/V12__RenameEmbedsInVisualElements.scala
@@ -1,0 +1,151 @@
+/*
+ * Part of NDLA concept-api
+ * Copyright (C) 2022 NDLA
+ *
+ * See LICENSE
+ */
+
+package no.ndla.conceptapi.db.migration
+
+import org.flywaydb.core.api.migration.{BaseJavaMigration, Context}
+import org.json4s
+import org.json4s.JsonAST.JArray
+import org.json4s.native.JsonMethods.{compact, parse, render}
+import org.json4s.{DefaultFormats, JString}
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Element
+import org.jsoup.nodes.Entities.EscapeMode
+import org.postgresql.util.PGobject
+import scalikejdbc.{DB, DBSession, _}
+
+class V12__RenameEmbedsInVisualElements extends BaseJavaMigration {
+  implicit val formats: DefaultFormats.type = DefaultFormats
+
+  override def migrate(context: Context): Unit = {
+    val db = DB(context.getConnection)
+    db.autoClose(false)
+
+    db.withinTx { implicit session =>
+      migrateConcepts()
+      migratePublishedConcepts()
+    }
+  }
+
+  def migratePublishedConcepts()(implicit session: DBSession): Unit = {
+    val count        = countAllPublishedConcepts.get
+    var numPagesLeft = (count / 1000) + 1
+    var offset       = 0L
+
+    while (numPagesLeft > 0) {
+      allPublishedConcepts(offset * 1000).map { case (id, document) =>
+        updatePublishedConcept(convertToNewConcept(document, id), id)
+      }
+      numPagesLeft -= 1
+      offset += 1
+    }
+  }
+
+  def migrateConcepts()(implicit session: DBSession): Unit = {
+    val count        = countAllConcepts.get
+    var numPagesLeft = (count / 1000) + 1
+    var offset       = 0L
+
+    while (numPagesLeft > 0) {
+      allConcepts(offset * 1000).map { case (id, document) =>
+        updateConcept(convertToNewConcept(document, id), id)
+      }
+      numPagesLeft -= 1
+      offset += 1
+    }
+  }
+
+  def countAllPublishedConcepts(implicit session: DBSession): Option[Long] = {
+    sql"select count(*) from publishedconceptdata where document is not NULL"
+      .map(rs => rs.long("count"))
+      .single()
+  }
+
+  def countAllConcepts(implicit session: DBSession): Option[Long] = {
+    sql"select count(*) from conceptdata where document is not NULL"
+      .map(rs => rs.long("count"))
+      .single()
+  }
+
+  def allPublishedConcepts(offset: Long)(implicit session: DBSession): Seq[(Long, String)] = {
+    sql"select id, document from publishedconceptdata where document is not null order by id limit 1000 offset $offset"
+      .map(rs => {
+        (rs.long("id"), rs.string("document"))
+      })
+      .list()
+  }
+
+  def allConcepts(offset: Long)(implicit session: DBSession): Seq[(Long, String)] = {
+    sql"select id, document from conceptdata where document is not null order by id limit 1000 offset $offset"
+      .map(rs => {
+        (rs.long("id"), rs.string("document"))
+      })
+      .list()
+  }
+
+  def updatePublishedConcept(document: String, id: Long)(implicit session: DBSession): Int = {
+    val dataObject = new PGobject()
+    dataObject.setType("jsonb")
+    dataObject.setValue(document)
+
+    sql"update publishedconceptdata set document = $dataObject where id = $id"
+      .update()
+  }
+
+  def updateConcept(document: String, id: Long)(implicit session: DBSession): Int = {
+    val dataObject = new PGobject()
+    dataObject.setType("jsonb")
+    dataObject.setValue(document)
+
+    sql"update conceptdata set document = $dataObject where id = $id"
+      .update()
+  }
+
+  private def stringToJsoupDocument(htmlString: String): Element = {
+    val document = Jsoup.parseBodyFragment(htmlString)
+    document.outputSettings().escapeMode(EscapeMode.xhtml).prettyPrint(false)
+    document.select("body").first()
+  }
+
+  private def jsoupDocumentToString(element: Element): String = {
+    element.select("body").html()
+  }
+
+  def renameEmbedTag(html: String): String = {
+    val doc = stringToJsoupDocument(html)
+    doc
+      .select("embed")
+      .forEach(embed => {
+        embed.tagName("ndlaembed")
+
+      })
+    jsoupDocumentToString(doc)
+  }
+
+  def updateContent(contents: JArray, contentType: String): json4s.JValue = {
+    contents.map(content =>
+      content.mapField {
+        case (`contentType`, JString(html)) => (`contentType`, JString(renameEmbedTag(html)))
+        case z                              => z
+      }
+    )
+  }
+
+  def convertToNewConcept(document: String, id: Long): String = {
+    val concept = parse(document)
+    val newConcept = concept
+      .mapField {
+        case ("visualElement", visualElements: JArray) =>
+          val updatedVisualElement = updateContent(visualElements, "visualElement")
+          ("visualElement", updatedVisualElement)
+        case x => x
+      }
+    compact(render(newConcept))
+  }
+
+  case class NewVisualElement(visualElement: String, language: String)
+}

--- a/concept-api/src/main/scala/no/ndla/conceptapi/service/ConverterService.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/service/ConverterService.scala
@@ -12,6 +12,7 @@ import com.typesafe.scalalogging.StrictLogging
 import io.lemonlabs.uri.{Path, Url}
 import no.ndla.common.model.domain.{Tag, Title}
 import no.ndla.common.Clock
+import no.ndla.common.configuration.Constants.EmbedTagName
 import no.ndla.conceptapi.Props
 import no.ndla.conceptapi.auth.UserInfo
 import no.ndla.conceptapi.model.api.NotFoundException
@@ -20,7 +21,6 @@ import no.ndla.conceptapi.model.{api, domain}
 import no.ndla.conceptapi.repository.DraftConceptRepository
 import no.ndla.language.Language.{AllLanguages, UnknownLanguage, findByLanguageOrBestEffort, mergeLanguageFields}
 import no.ndla.mapping.License.getLicense
-import no.ndla.validation.EmbedTagRules.ResourceHtmlEmbedTag
 import no.ndla.validation.HtmlTagRules.{jsoupDocumentToString, stringToJsoupDocument}
 import no.ndla.validation.{EmbedTagRules, HtmlTagRules, ResourceType, TagAttributes}
 import org.jsoup.nodes.Element
@@ -163,7 +163,7 @@ trait ConverterService {
     private def removeUnknownEmbedTagAttributes(html: String): String = {
       val document = HtmlTagRules.stringToJsoupDocument(html)
       document
-        .select("embed")
+        .select(EmbedTagName)
         .asScala
         .map(el => {
           ResourceType
@@ -309,7 +309,7 @@ trait ConverterService {
     private[service] def addUrlOnElement(content: String): String = {
       val doc = stringToJsoupDocument(content)
 
-      val embedTags = doc.select(s"$ResourceHtmlEmbedTag").asScala.toList
+      val embedTags = doc.select(EmbedTagName).asScala.toList
       embedTags.foreach(addUrlOnEmbedTag)
       jsoupDocumentToString(doc)
     }

--- a/concept-api/src/main/scala/no/ndla/conceptapi/service/search/SearchConverterService.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/service/search/SearchConverterService.scala
@@ -9,6 +9,7 @@ package no.ndla.conceptapi.service.search
 
 import com.sksamuel.elastic4s.requests.searches.SearchHit
 import com.typesafe.scalalogging.StrictLogging
+import no.ndla.common.configuration.Constants.EmbedTagName
 import no.ndla.common.model.domain.{Tag, Title}
 import no.ndla.conceptapi.model.api.{ConceptSearchResult, SubjectTags}
 import no.ndla.conceptapi.model.domain.{Concept, Copyright, SearchResult}
@@ -43,7 +44,7 @@ trait SearchConverterService {
     // To be removed
     private[service] def getEmbedResources(html: String): List[String] = {
       parseHtml(html)
-        .select("embed")
+        .select(EmbedTagName)
         .asScala
         .flatMap(getEmbedResources)
         .toList
@@ -66,7 +67,7 @@ trait SearchConverterService {
     // To be removed
     private[service] def getEmbedIds(html: String): List[String] = {
       parseHtml(html)
-        .select("embed")
+        .select(EmbedTagName)
         .asScala
         .flatMap(getEmbedIds)
         .toList
@@ -103,7 +104,7 @@ trait SearchConverterService {
 
     private[service] def getEmbedValues(html: String, language: String): List[EmbedValues] = {
       parseHtml(html)
-        .select("embed")
+        .select(EmbedTagName)
         .asScala
         .flatMap(embed => Some(getEmbedValuesFromEmbed(embed, language)))
         .toList

--- a/concept-api/src/test/scala/no/ndla/conceptapi/TestData.scala
+++ b/concept-api/src/test/scala/no/ndla/conceptapi/TestData.scala
@@ -7,10 +7,12 @@
 
 package no.ndla.conceptapi
 
+import no.ndla.common.configuration.Constants.EmbedTagName
 import no.ndla.common.model.{domain => common}
 import no.ndla.conceptapi.auth.{Role, UserInfo}
 import no.ndla.conceptapi.model.{api, domain}
 import no.ndla.conceptapi.model.domain.{ConceptContent, Copyright, Status}
+
 import java.time.LocalDateTime
 
 object TestData {
@@ -34,10 +36,10 @@ object TestData {
   val yesterday = LocalDateTime.now().minusDays(1)
 
   val visualElementString =
-    """<embed data-caption="some capt" data-align="" data-resource_id="1" data-resource="image" data-alt="some alt" data-size="full" />"""
+    s"""<$EmbedTagName data-caption="some capt" data-align="" data-resource_id="1" data-resource="image" data-alt="some alt" data-size="full" />"""
 
   val visualElementStringWithUrl =
-    """<embed data-caption="some capt" data-align="" data-resource_id="1" data-resource="image" data-alt="some alt" data-size="full" data-url="http://api-gateway.ndla-local/image-api/v2/images/1">"""
+    s"""<$EmbedTagName data-caption="some capt" data-align="" data-resource_id="1" data-resource="image" data-alt="some alt" data-size="full" data-url="http://api-gateway.ndla-local/image-api/v2/images/1" />"""
 
   val sampleNbApiConcept = api.Concept(
     1.toLong,

--- a/concept-api/src/test/scala/no/ndla/conceptapi/db/migration/R__MetaImageAsVisualElementTest.scala
+++ b/concept-api/src/test/scala/no/ndla/conceptapi/db/migration/R__MetaImageAsVisualElementTest.scala
@@ -7,6 +7,7 @@
 
 package no.ndla.conceptapi.db.migration
 
+import no.ndla.common.configuration.Constants.EmbedTagName
 import no.ndla.conceptapi.db.migration.R__MetaImageAsVisualElement
 import no.ndla.conceptapi.{TestEnvironment, UnitSuite}
 
@@ -29,7 +30,7 @@ class R__MetaImageAsVisualElementTest extends UnitSuite with TestEnvironment {
       s"""{"metaImage":[$oldMetaImage],"visualElement":[$oldVisualElement]}"""
 
     val visualElementString =
-      s"""<embed data-resource=\\"image\\" data-resource_id=\\"1\\" data-alt=\\"alt\\" data-size=\\"full\\" data-align=\\"\\" />"""
+      s"""<$EmbedTagName data-resource=\\"image\\" data-resource_id=\\"1\\" data-alt=\\"alt\\" data-size=\\"full\\" data-align=\\"\\" />"""
     val expectedVisualElement = s"""{"visualElement":"$visualElementString","language":"nb"}"""
 
     val expected =
@@ -41,7 +42,7 @@ class R__MetaImageAsVisualElementTest extends UnitSuite with TestEnvironment {
     val oldMetaImageNb = """{"imageId":"1","altText":"alt","language":"nb"}"""
     val oldMetaImageNn = """{"imageId":"1","altText":"alt2","language":"nn"}"""
     val oldVisualElementString =
-      """<embed data-resource_id=\"123\" data-resource=\"image\" data-alt=\"somealt\" data-size=\"full\" data-align=\"\" />"""
+      s"""<$EmbedTagName data-resource_id=\\"123\\" data-resource=\\"image\\" data-alt=\\"somealt\\" data-size=\\"full\\" data-align=\\"\\" />"""
 
     val oldVisualElement = s"""{"visualElement":"$oldVisualElementString","language":"nb"}"""
 
@@ -49,14 +50,14 @@ class R__MetaImageAsVisualElementTest extends UnitSuite with TestEnvironment {
       s"""{"metaImage":[$oldMetaImageNb,$oldMetaImageNn],"visualElement":[$oldVisualElement]}"""
 
     val newVisualElementString =
-      """<embed data-resource=\"image\" data-resource_id=\"1\" data-alt=\"alt2\" data-size=\"full\" data-align=\"\" />"""
+      s"""<$EmbedTagName data-resource=\\"image\\" data-resource_id=\\"1\\" data-alt=\\"alt2\\" data-size=\\"full\\" data-align=\\"\\" />"""
 
     val expectedNewVisualElement = s"""{"visualElement":"$newVisualElementString","language":"nn"}"""
 
     val expected =
       s"""{"metaImage":[$oldMetaImageNb,$oldMetaImageNn],"visualElement":[$oldVisualElement,$expectedNewVisualElement]}"""
-    migration.convertToNewConcept(old) should be(expected)
-
+    val result = migration.convertToNewConcept(old)
+    result should be(expected)
   }
 
 }

--- a/concept-api/src/test/scala/no/ndla/conceptapi/service/ReadServiceTest.scala
+++ b/concept-api/src/test/scala/no/ndla/conceptapi/service/ReadServiceTest.scala
@@ -7,6 +7,7 @@
 
 package no.ndla.conceptapi.service
 
+import no.ndla.common.configuration.Constants.EmbedTagName
 import no.ndla.common.model.{domain => common}
 import no.ndla.conceptapi.model.domain.VisualElement
 import no.ndla.conceptapi.{TestData, TestEnvironment, UnitSuite}
@@ -51,20 +52,20 @@ class ReadServiceTest extends UnitSuite with TestEnvironment {
   test("that visualElement gets url-property added") {
     val visualElements = Seq(
       VisualElement(
-        "<embed data-resource=\"image\" data-resource_id=\"1\" data-alt=\"Alt\" data-size=\"full\" data-align=\"\">",
+        s"<$EmbedTagName data-resource=\"image\" data-resource_id=\"1\" data-alt=\"Alt\" data-size=\"full\" data-align=\"\" />",
         "nb"
       ),
-      VisualElement("<embed data-resource=\"h5p\" data-path=\"/resource/uuid\" data-title=\"Title\">", "nn")
+      VisualElement(s"<$EmbedTagName data-resource=\"h5p\" data-path=\"/resource/uuid\" data-title=\"Title\" />", "nn")
     )
     when(publishedConceptRepository.withId(anyLong))
       .thenReturn(Some(TestData.sampleConcept.copy(visualElement = visualElements)))
     val concept = service.publishedConceptWithId(id = 1L, language = "nb", fallback = true)
     concept.get.visualElement.get.visualElement should equal(
-      "<embed data-resource=\"image\" data-resource_id=\"1\" data-alt=\"Alt\" data-size=\"full\" data-align=\"\" data-url=\"http://api-gateway.ndla-local/image-api/v2/images/1\">"
+      s"<$EmbedTagName data-resource=\"image\" data-resource_id=\"1\" data-alt=\"Alt\" data-size=\"full\" data-align=\"\" data-url=\"http://api-gateway.ndla-local/image-api/v2/images/1\" />"
     )
     val concept2 = service.publishedConceptWithId(id = 1L, language = "nn", fallback = true)
     concept2.get.visualElement.get.visualElement should equal(
-      "<embed data-resource=\"h5p\" data-path=\"/resource/uuid\" data-title=\"Title\" data-url=\"https://h5p.ndla.no/resource/uuid\">"
+      s"<$EmbedTagName data-resource=\"h5p\" data-path=\"/resource/uuid\" data-title=\"Title\" data-url=\"https://h5p.ndla.no/resource/uuid\" />"
     )
 
   }

--- a/concept-api/src/test/scala/no/ndla/conceptapi/service/search/DraftConceptSearchServiceTest.scala
+++ b/concept-api/src/test/scala/no/ndla/conceptapi/service/search/DraftConceptSearchServiceTest.scala
@@ -7,6 +7,7 @@
 
 package no.ndla.conceptapi.service.search
 
+import no.ndla.common.configuration.Constants.EmbedTagName
 import no.ndla.common.model.domain.{Tag, Title}
 import no.ndla.conceptapi.{TestEnvironment, _}
 import no.ndla.conceptapi.model.api.SubjectTags
@@ -164,7 +165,7 @@ class DraftConceptSearchServiceTest extends IntegrationSuite(EnableElasticsearch
     updatedBy = Seq("Test1"),
     visualElement = List(
       VisualElement(
-        """<embed data-resource="image" data-url="test.url" /><embed data-resource="brightcove" data-url="test.url2" data-videoid="test.id2" />""",
+        s"""<$EmbedTagName data-resource="image" data-url="test.url" /><$EmbedTagName data-resource="brightcove" data-url="test.url2" data-videoid="test.id2" />""",
         "nb"
       )
     )

--- a/concept-api/src/test/scala/no/ndla/conceptapi/service/search/PublishedConceptSearchServiceTest.scala
+++ b/concept-api/src/test/scala/no/ndla/conceptapi/service/search/PublishedConceptSearchServiceTest.scala
@@ -7,6 +7,7 @@
 
 package no.ndla.conceptapi.service.search
 
+import no.ndla.common.configuration.Constants.EmbedTagName
 import no.ndla.common.model.domain.{Tag, Title}
 import no.ndla.conceptapi.model.api.SubjectTags
 import no.ndla.conceptapi.model.domain._
@@ -158,7 +159,7 @@ class PublishedConceptSearchServiceTest
     subjectIds = Set("urn:subject:2"),
     visualElement = List(
       VisualElement(
-        """<embed data-resource="image" data-url="test.url" /><embed data-resource="brightcove" data-url="test.url2" data-videoid="test.id2" />""",
+        s"""<$EmbedTagName data-resource="image" data-url="test.url" /><$EmbedTagName data-resource="brightcove" data-url="test.url2" data-videoid="test.id2" />""",
         "nb"
       )
     )

--- a/draft-api/src/main/scala/no/ndla/draftapi/DraftApiProperties.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/DraftApiProperties.scala
@@ -42,7 +42,6 @@ class DraftApiProperties extends BaseProps with StrictLogging {
   def MetaSchema: String   = prop(PropertyKeys.MetaSchemaKey)
   def MetaMaxConnections   = 10
 
-  def resourceHtmlEmbedTag         = "embed"
   def ApiClientsCacheAgeInMs: Long = 1000 * 60 * 60 // 1 hour caching
 
   def Domain: String = propOrElse("BACKEND_API_DOMAIN", Domains.get(Environment))

--- a/draft-api/src/main/scala/no/ndla/draftapi/db/migration/V40__RenameEmbedTag.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/db/migration/V40__RenameEmbedTag.scala
@@ -1,0 +1,115 @@
+/*
+ * Part of NDLA draft-api.
+ * Copyright (C) 2022 NDLA
+ *
+ * See LICENSE
+ */
+
+package no.ndla.draftapi.db.migration
+
+import org.flywaydb.core.api.migration.{BaseJavaMigration, Context}
+import org.json4s
+import org.json4s.DefaultFormats
+import org.json4s.JsonAST.{JArray, JString}
+import org.json4s.native.JsonMethods.{compact, parse, render}
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Element
+import org.jsoup.nodes.Entities.EscapeMode
+import org.postgresql.util.PGobject
+import scalikejdbc.{DB, DBSession, _}
+
+class V40__RenameEmbedTag extends BaseJavaMigration {
+  implicit val formats: DefaultFormats.type = org.json4s.DefaultFormats
+
+  override def migrate(context: Context): Unit = {
+    val db = DB(context.getConnection)
+    db.autoClose(false)
+
+    db.withinTx { implicit session =>
+      migrateArticles
+    }
+  }
+
+  def migrateArticles(implicit session: DBSession): Unit = {
+    val count        = countAllArticles.get
+    var numPagesLeft = (count / 1000) + 1
+    var offset       = 0L
+
+    while (numPagesLeft > 0) {
+      allArticles(offset * 1000).map { case (id, document) =>
+        updateArticle(convertArticleUpdate(document), id)
+      }
+      numPagesLeft -= 1
+      offset += 1
+    }
+  }
+
+  def countAllArticles(implicit session: DBSession): Option[Long] = {
+    sql"select count(*) from articledata where document is not NULL"
+      .map(rs => rs.long("count"))
+      .single()
+  }
+
+  def allArticles(offset: Long)(implicit session: DBSession): Seq[(Long, String)] = {
+    sql"select id, document, article_id from articledata where document is not null order by id limit 1000 offset $offset"
+      .map(rs => {
+        (rs.long("id"), rs.string("document"))
+      })
+      .list()
+  }
+
+  def updateArticle(document: String, id: Long)(implicit session: DBSession): Int = {
+    val dataObject = new PGobject()
+    dataObject.setType("jsonb")
+    dataObject.setValue(document)
+
+    sql"update articledata set document = $dataObject where id = $id"
+      .update()
+  }
+
+  private def stringToJsoupDocument(htmlString: String): Element = {
+    val document = Jsoup.parseBodyFragment(htmlString)
+    document.outputSettings().escapeMode(EscapeMode.xhtml).prettyPrint(false)
+    document.select("body").first()
+  }
+
+  private def jsoupDocumentToString(element: Element): String = {
+    element.select("body").html()
+  }
+
+  def renameEmbedTag(html: String): String = {
+    val doc = stringToJsoupDocument(html)
+    doc
+      .select("embed")
+      .forEach(embed => {
+        embed.tagName("ndlaembed")
+
+      })
+    jsoupDocumentToString(doc)
+  }
+
+  def updateContent(contents: JArray, contentType: String): json4s.JValue = {
+    contents.map(content =>
+      content.mapField {
+        case (`contentType`, JString(html)) => (`contentType`, JString(renameEmbedTag(html)))
+        case z                              => z
+      }
+    )
+  }
+
+  private[migration] def convertArticleUpdate(document: String): String = {
+    val oldArticle = parse(document)
+
+    val newArticle = oldArticle.mapField {
+      case ("content", contents: JArray) =>
+        val updatedContent = updateContent(contents, "content")
+        ("content", updatedContent)
+      case ("visualElement", visualElements: JArray) =>
+        val updatedVisualElement = updateContent(visualElements, "resource")
+        ("visualElement", updatedVisualElement)
+      case x => x
+    }
+
+    compact(render(newArticle))
+  }
+}

--- a/draft-api/src/main/scala/no/ndla/draftapi/service/ReadService.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/service/ReadService.scala
@@ -9,6 +9,7 @@ package no.ndla.draftapi.service
 
 import cats.implicits._
 import io.lemonlabs.uri.{Path, Url}
+import no.ndla.common.configuration.Constants.EmbedTagName
 import no.ndla.common.errors.ValidationException
 import no.ndla.common.model.domain.draft.Draft
 import no.ndla.draftapi.Props
@@ -111,7 +112,7 @@ trait ReadService {
     private[service] def addUrlOnResource(content: String): String = {
       val doc = HtmlTagRules.stringToJsoupDocument(content)
 
-      val embedTags = doc.select(s"$resourceHtmlEmbedTag").asScala.toList
+      val embedTags = doc.select(EmbedTagName).asScala.toList
       embedTags.foreach(addUrlOnEmbedTag)
       HtmlTagRules.jsoupDocumentToString(doc)
     }

--- a/draft-api/src/main/scala/no/ndla/draftapi/service/WriteService.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/service/WriteService.scala
@@ -14,6 +14,7 @@ import io.lemonlabs.uri.Path
 import io.lemonlabs.uri.typesafe.dsl._
 import no.ndla.common.Clock
 import no.ndla.common.ContentURIUtil.parseArticleIdAndRevision
+import no.ndla.common.configuration.Constants.EmbedTagName
 import no.ndla.common.errors.ValidationException
 import no.ndla.common.model.domain.draft.DraftStatus
 import no.ndla.common.model.domain.draft.DraftStatus.{DRAFT, PROPOSAL, PUBLISHED}
@@ -137,7 +138,7 @@ trait WriteService {
     def contentWithClonedFiles(contents: List[common.ArticleContent]): Try[List[common.ArticleContent]] = {
       contents.toList.traverse(content => {
         val doc    = HtmlTagRules.stringToJsoupDocument(content.content)
-        val embeds = doc.select(s"embed[${TagAttributes.DataResource}='${ResourceType.File}']").asScala
+        val embeds = doc.select(s"$EmbedTagName[${TagAttributes.DataResource}='${ResourceType.File}']").asScala
 
         embeds.toList.traverse(cloneEmbedAndUpdateElement) match {
           case Failure(ex) => Failure(ex)

--- a/draft-api/src/test/scala/no/ndla/draftapi/TestData.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/TestData.scala
@@ -7,6 +7,7 @@
 
 package no.ndla.draftapi
 
+import no.ndla.common.configuration.Constants.EmbedTagName
 import no.ndla.common.model.{domain => common}
 import no.ndla.common.model.domain.draft.DraftStatus._
 import no.ndla.draftapi.auth.{Role, UserInfo}
@@ -476,7 +477,7 @@ object TestData {
   val sampleTitle: common.Title = common.Title("title", "en")
 
   val visualElement: common.VisualElement = common.VisualElement(
-    s"""<embed data-align="" data-alt="" data-caption="" data-resource="image" data-resource_id="1" data-size="" />""",
+    s"""<$EmbedTagName data-align="" data-alt="" data-caption="" data-resource="image" data-resource_id="1" data-size="" />""",
     "nb"
   )
 

--- a/draft-api/src/test/scala/no/ndla/draftapi/service/ConverterServiceTest.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/service/ConverterServiceTest.scala
@@ -9,6 +9,7 @@ package no.ndla.draftapi.service
 
 import cats.effect.unsafe.implicits.global
 import no.ndla.common.DateParser
+import no.ndla.common.configuration.Constants.EmbedTagName
 import no.ndla.common.errors.ValidationException
 import no.ndla.common.model.domain.{
   ArticleContent,
@@ -86,11 +87,11 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
 
   test("toDomainArticleShould should remove unneeded attributes on embed-tags") {
     val content =
-      s"""<h1>hello</h1><embed ${TagAttributes.DataResource}="${ResourceType.Image}" ${TagAttributes.DataUrl}="http://some-url" data-random="hehe" />"""
-    val expectedContent = s"""<h1>hello</h1><embed ${TagAttributes.DataResource}="${ResourceType.Image}">"""
+      s"""<h1>hello</h1><$EmbedTagName ${TagAttributes.DataResource}="${ResourceType.Image}" ${TagAttributes.DataUrl}="http://some-url" data-random="hehe" />"""
+    val expectedContent = s"""<h1>hello</h1><$EmbedTagName ${TagAttributes.DataResource}="${ResourceType.Image}" />"""
     val visualElement =
-      s"""<embed ${TagAttributes.DataResource}="${ResourceType.Image}" ${TagAttributes.DataUrl}="http://some-url" data-random="hehe" />"""
-    val expectedVisualElement = s"""<embed ${TagAttributes.DataResource}="${ResourceType.Image}">"""
+      s"""<$EmbedTagName ${TagAttributes.DataResource}="${ResourceType.Image}" ${TagAttributes.DataUrl}="http://some-url" data-random="hehe" />"""
+    val expectedVisualElement = s"""<$EmbedTagName ${TagAttributes.DataResource}="${ResourceType.Image}" />"""
     val apiArticle            = TestData.newArticle.copy(content = Some(content), visualElement = Some(visualElement))
     val expectedTime          = TestData.today
 
@@ -765,7 +766,7 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
 
   test("toDomainArticle should clone files if existing files appear in new language") {
     val embed1 =
-      """<embed data-alt="Kul alt1" data-path="/files/resources/abc123.pdf" data-resource="file" data-title="Kul tittel1" data-type="pdf">"""
+      s"""<$EmbedTagName data-alt="Kul alt1" data-path="/files/resources/abc123.pdf" data-resource="file" data-title="Kul tittel1" data-type="pdf">"""
     val existingArticle = TestData.sampleDomainArticle.copy(
       content = Seq(ArticleContent(s"<section><h1>Hei</h1>$embed1</section>", "nb"))
     )
@@ -804,16 +805,16 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
     val expectedPaths = Seq(enPath1, enPath2, nbPath1, nbPath2, vePath1, vePath2).sorted
 
     val articleContentNb = ArticleContent(
-      s"""<section><h1>Heisann</h1><embed data-path="$nbPath1" data-resource="h5p" /></section><section><p>Joda<embed data-path="$nbPath2" data-resource="h5p" /></p><embed data-resource="concept" data-path="thisisinvalidbutletsdoit"/></section>""",
+      s"""<section><h1>Heisann</h1><$EmbedTagName data-path="$nbPath1" data-resource="h5p" /></section><section><p>Joda<$EmbedTagName data-path="$nbPath2" data-resource="h5p" /></p><$EmbedTagName data-resource="concept" data-path="thisisinvalidbutletsdoit"/></section>""",
       "nb"
     )
     val articleContentEn = ArticleContent(
-      s"""<section><h1>Hello</h1><embed data-path="$enPath1" data-resource="h5p" /></section><section><p>Joda<embed data-path="$enPath2" data-resource="h5p" /></p><embed data-resource="concept" data-path="thisisinvalidbutletsdoit"/></section>""",
+      s"""<section><h1>Hello</h1><$EmbedTagName data-path="$enPath1" data-resource="h5p" /></section><section><p>Joda<$EmbedTagName data-path="$enPath2" data-resource="h5p" /></p><$EmbedTagName data-resource="concept" data-path="thisisinvalidbutletsdoit"/></section>""",
       "en"
     )
 
-    val visualElementNb = VisualElement(s"""<embed data-path="$vePath1" data-resource="h5p" />""", "nb")
-    val visualElementEn = VisualElement(s"""<embed data-path="$vePath2" data-resource="h5p" />""", "en")
+    val visualElementNb = VisualElement(s"""<$EmbedTagName data-path="$vePath1" data-resource="h5p" />""", "nb")
+    val visualElementEn = VisualElement(s"""<$EmbedTagName data-path="$vePath2" data-resource="h5p" />""", "en")
 
     val article = TestData.sampleDomainArticle.copy(
       id = Some(1),

--- a/draft-api/src/test/scala/no/ndla/draftapi/service/ReadServiceTest.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/service/ReadServiceTest.scala
@@ -7,6 +7,7 @@
 
 package no.ndla.draftapi.service
 
+import no.ndla.common.configuration.Constants.EmbedTagName
 import no.ndla.common.errors.ValidationException
 import no.ndla.common.model.domain.{ArticleContent, VisualElement}
 import no.ndla.draftapi.{TestData, TestEnvironment, UnitSuite}
@@ -16,7 +17,7 @@ import scalikejdbc.DBSession
 import scala.util.{Failure, Success}
 
 class ReadServiceTest extends UnitSuite with TestEnvironment {
-  import props.{externalApiUrls, resourceHtmlEmbedTag}
+  import props.externalApiUrls
 
   val externalImageApiUrl = externalApiUrls("image")
   val resourceIdAttr      = s"${TagAttributes.DataResource_Id}"
@@ -26,14 +27,14 @@ class ReadServiceTest extends UnitSuite with TestEnvironment {
   val urlAttr             = s"${TagAttributes.DataUrl}"
 
   val content1 =
-    s"""<$resourceHtmlEmbedTag $resourceIdAttr="123" $resourceAttr="$imageType"><$resourceHtmlEmbedTag $resourceIdAttr=1234 $resourceAttr="$imageType">"""
+    s"""<$EmbedTagName $resourceIdAttr="123" $resourceAttr="$imageType" /><$EmbedTagName $resourceIdAttr=1234 $resourceAttr="$imageType" />"""
 
   val content2 =
-    s"""<$resourceHtmlEmbedTag $resourceIdAttr="321" $resourceAttr="$imageType"><$resourceHtmlEmbedTag $resourceIdAttr=4321 $resourceAttr="$imageType">"""
+    s"""<$EmbedTagName $resourceIdAttr="321" $resourceAttr="$imageType" /><$EmbedTagName $resourceIdAttr=4321 $resourceAttr="$imageType" />"""
   val articleContent1 = ArticleContent(content1, "und")
 
   val expectedArticleContent1 = articleContent1.copy(content =
-    s"""<$resourceHtmlEmbedTag $resourceIdAttr="123" $resourceAttr="$imageType" $urlAttr="$externalImageApiUrl/123"><$resourceHtmlEmbedTag $resourceIdAttr="1234" $resourceAttr="$imageType" $urlAttr="$externalImageApiUrl/1234">"""
+    s"""<$EmbedTagName $resourceIdAttr="123" $resourceAttr="$imageType" $urlAttr="$externalImageApiUrl/123" /><$EmbedTagName $resourceIdAttr="1234" $resourceAttr="$imageType" $urlAttr="$externalImageApiUrl/1234" />"""
   )
 
   val articleContent2 = ArticleContent(content2, "und")
@@ -43,9 +44,9 @@ class ReadServiceTest extends UnitSuite with TestEnvironment {
 
   test("withId adds urls and ids on embed resources") {
     val visualElementBefore =
-      s"""<$resourceHtmlEmbedTag data-align="" data-alt="" data-caption="" data-resource="image" data-resource_id="1" data-size="">"""
+      s"""<$EmbedTagName data-align="" data-alt="" data-caption="" data-resource="image" data-resource_id="1" data-size="" />"""
     val visualElementAfter =
-      s"""<$resourceHtmlEmbedTag data-align="" data-alt="" data-caption="" data-resource="image" data-resource_id="1" data-size="" data-url="http://api-gateway.ndla-local/image-api/v2/images/1">"""
+      s"""<$EmbedTagName data-align="" data-alt="" data-caption="" data-resource="image" data-resource_id="1" data-size="" data-url="http://api-gateway.ndla-local/image-api/v2/images/1" />"""
     val article = TestData.sampleArticleWithByNcSa.copy(
       content = Seq(articleContent1),
       visualElement = Seq(VisualElement(visualElementBefore, "nb"))
@@ -70,7 +71,7 @@ class ReadServiceTest extends UnitSuite with TestEnvironment {
 
   test("addIdAndUrlOnResource adds id but not url on embed resources without a data-resource_id attribute") {
     val articleContent3 = articleContent1.copy(
-      content = s"""<$resourceHtmlEmbedTag $resourceAttr="$h5pType" $urlAttr="http://some.h5p.org">"""
+      content = s"""<$EmbedTagName $resourceAttr="$h5pType" $urlAttr="http://some.h5p.org" />"""
     )
     readService.addUrlOnResource(articleContent3.content) should equal(articleContent3.content)
   }
@@ -78,10 +79,10 @@ class ReadServiceTest extends UnitSuite with TestEnvironment {
   test("addIdAndUrlOnResource adds urls on all content translations in an article") {
     val article = TestData.sampleArticleWithByNcSa.copy(content = Seq(articleContent1, articleContent2))
     val article1ExpectedResult = articleContent1.copy(content =
-      s"""<$resourceHtmlEmbedTag $resourceIdAttr="123" $resourceAttr="$imageType" $urlAttr="$externalImageApiUrl/123"><$resourceHtmlEmbedTag $resourceIdAttr="1234" $resourceAttr="$imageType" $urlAttr="$externalImageApiUrl/1234">"""
+      s"""<$EmbedTagName $resourceIdAttr="123" $resourceAttr="$imageType" $urlAttr="$externalImageApiUrl/123" /><$EmbedTagName $resourceIdAttr="1234" $resourceAttr="$imageType" $urlAttr="$externalImageApiUrl/1234" />"""
     )
     val article2ExpectedResult = articleContent1.copy(content =
-      s"""<$resourceHtmlEmbedTag $resourceIdAttr="321" $resourceAttr="$imageType" $urlAttr="$externalImageApiUrl/321"><$resourceHtmlEmbedTag $resourceIdAttr="4321" $resourceAttr="$imageType" $urlAttr="$externalImageApiUrl/4321">"""
+      s"""<$EmbedTagName $resourceIdAttr="321" $resourceAttr="$imageType" $urlAttr="$externalImageApiUrl/321" /><$EmbedTagName $resourceIdAttr="4321" $resourceAttr="$imageType" $urlAttr="$externalImageApiUrl/4321" />"""
     )
 
     val result = readService.addUrlsOnEmbedResources(article)
@@ -91,9 +92,9 @@ class ReadServiceTest extends UnitSuite with TestEnvironment {
   test("addUrlOnResource adds url attribute on file embeds") {
     val filePath = "files/lel/fileste.pdf"
     val content =
-      s"""<div data-type="file"><$resourceHtmlEmbedTag $resourceAttr="${ResourceType.File}" ${TagAttributes.DataPath}="$filePath" ${TagAttributes.Title}="This fancy pdf"><$resourceHtmlEmbedTag $resourceAttr="${ResourceType.File}" ${TagAttributes.DataPath}="$filePath" ${TagAttributes.Title}="This fancy pdf"></div>"""
+      s"""<div data-type="file"><$EmbedTagName $resourceAttr="${ResourceType.File}" ${TagAttributes.DataPath}="$filePath" ${TagAttributes.Title}="This fancy pdf" /><$EmbedTagName $resourceAttr="${ResourceType.File}" ${TagAttributes.DataPath}="$filePath" ${TagAttributes.Title}="This fancy pdf" /></div>"""
     val expectedResult =
-      s"""<div data-type="file"><$resourceHtmlEmbedTag $resourceAttr="${ResourceType.File}" ${TagAttributes.DataPath}="$filePath" ${TagAttributes.Title}="This fancy pdf" $urlAttr="http://api-gateway.ndla-local/$filePath"><$resourceHtmlEmbedTag $resourceAttr="${ResourceType.File}" ${TagAttributes.DataPath}="$filePath" ${TagAttributes.Title}="This fancy pdf" $urlAttr="http://api-gateway.ndla-local/$filePath"></div>"""
+      s"""<div data-type="file"><$EmbedTagName $resourceAttr="${ResourceType.File}" ${TagAttributes.DataPath}="$filePath" ${TagAttributes.Title}="This fancy pdf" $urlAttr="http://api-gateway.ndla-local/$filePath" /><$EmbedTagName $resourceAttr="${ResourceType.File}" ${TagAttributes.DataPath}="$filePath" ${TagAttributes.Title}="This fancy pdf" $urlAttr="http://api-gateway.ndla-local/$filePath" /></div>"""
     val result = readService.addUrlOnResource(content)
     result should equal(expectedResult)
   }
@@ -101,9 +102,9 @@ class ReadServiceTest extends UnitSuite with TestEnvironment {
   test("addUrlOnResource adds url attribute on h5p embeds") {
     val h5pPath = "/resource/89734643-4006-4c65-a5de-34989ba7b2c8"
     val content =
-      s"""<div><$resourceHtmlEmbedTag $resourceAttr="${ResourceType.H5P}" ${TagAttributes.DataPath}="$h5pPath" ${TagAttributes.Title}="This fancy h5p"><$resourceHtmlEmbedTag $resourceAttr="${ResourceType.H5P}" ${TagAttributes.DataPath}="$h5pPath" ${TagAttributes.Title}="This fancy h5p"></div>"""
+      s"""<div><$EmbedTagName $resourceAttr="${ResourceType.H5P}" ${TagAttributes.DataPath}="$h5pPath" ${TagAttributes.Title}="This fancy h5p" /><$EmbedTagName $resourceAttr="${ResourceType.H5P}" ${TagAttributes.DataPath}="$h5pPath" ${TagAttributes.Title}="This fancy h5p" /></div>"""
     val expectedResult =
-      s"""<div><$resourceHtmlEmbedTag $resourceAttr="${ResourceType.H5P}" ${TagAttributes.DataPath}="$h5pPath" ${TagAttributes.Title}="This fancy h5p" $urlAttr="https://h5p.ndla.no$h5pPath"><$resourceHtmlEmbedTag $resourceAttr="${ResourceType.H5P}" ${TagAttributes.DataPath}="$h5pPath" ${TagAttributes.Title}="This fancy h5p" $urlAttr="https://h5p.ndla.no$h5pPath"></div>"""
+      s"""<div><$EmbedTagName $resourceAttr="${ResourceType.H5P}" ${TagAttributes.DataPath}="$h5pPath" ${TagAttributes.Title}="This fancy h5p" $urlAttr="https://h5p.ndla.no$h5pPath" /><$EmbedTagName $resourceAttr="${ResourceType.H5P}" ${TagAttributes.DataPath}="$h5pPath" ${TagAttributes.Title}="This fancy h5p" $urlAttr="https://h5p.ndla.no$h5pPath" /></div>"""
     val result = readService.addUrlOnResource(content)
     result should equal(expectedResult)
   }

--- a/draft-api/src/test/scala/no/ndla/draftapi/service/WriteServiceTest.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/service/WriteServiceTest.scala
@@ -8,6 +8,7 @@
 package no.ndla.draftapi.service
 
 import cats.effect.unsafe.implicits.global
+import no.ndla.common.configuration.Constants.EmbedTagName
 import no.ndla.common.errors.ValidationMessage
 import no.ndla.common.model.domain.{
   ArticleContent,
@@ -217,7 +218,7 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
     val updatedMetaId          = "1234"
     val updatedMetaAlt         = "HeheAlt"
     val newImageMeta           = api.NewArticleMetaImage(updatedMetaId, updatedMetaAlt)
-    val updatedVisualElement   = "<embed something>"
+    val updatedVisualElement   = s"<$EmbedTagName something />"
     val updatedCopyright = api.Copyright(
       Some(api.License("a", Some("b"), None)),
       Some("c"),
@@ -909,22 +910,22 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
         Success("resources/new101112.pdf")
       )
     val embed1 =
-      """<embed data-alt="Kul alt1" data-path="/files/resources/abc123.pdf" data-resource="file" data-title="Kul tittel1" data-type="pdf">"""
+      s"""<$EmbedTagName data-alt="Kul alt1" data-path="/files/resources/abc123.pdf" data-resource="file" data-title="Kul tittel1" data-type="pdf" />"""
     val embed2 =
-      """<embed data-alt="Kul alt2" data-path="/files/resources/abc456.pdf" data-resource="file" data-title="Kul tittel2" data-type="pdf">"""
+      s"""<$EmbedTagName data-alt="Kul alt2" data-path="/files/resources/abc456.pdf" data-resource="file" data-title="Kul tittel2" data-type="pdf" />"""
     val embed3 =
-      """<embed data-alt="Kul alt3" data-path="/files/resources/abc789.pdf" data-resource="file" data-title="Kul tittel3" data-type="pdf">"""
+      s"""<$EmbedTagName data-alt="Kul alt3" data-path="/files/resources/abc789.pdf" data-resource="file" data-title="Kul tittel3" data-type="pdf" />"""
     val contentNb = ArticleContent(s"<section><h1>Hei</h1>$embed1$embed2</section>", "nb")
     val contentEn = ArticleContent(s"<section><h1>Hello</h1>$embed1$embed3</section>", "en")
 
     val expectedEmbed1 =
-      """<embed data-alt="Kul alt1" data-path="/files/resources/new123.pdf" data-resource="file" data-title="Kul tittel1" data-type="pdf">"""
+      s"""<$EmbedTagName data-alt="Kul alt1" data-path="/files/resources/new123.pdf" data-resource="file" data-title="Kul tittel1" data-type="pdf" />"""
     val expectedEmbed2 =
-      """<embed data-alt="Kul alt2" data-path="/files/resources/new456.pdf" data-resource="file" data-title="Kul tittel2" data-type="pdf">"""
+      s"""<$EmbedTagName data-alt="Kul alt2" data-path="/files/resources/new456.pdf" data-resource="file" data-title="Kul tittel2" data-type="pdf" />"""
     val expectedEmbed3 =
-      """<embed data-alt="Kul alt1" data-path="/files/resources/new789.pdf" data-resource="file" data-title="Kul tittel1" data-type="pdf">"""
+      s"""<$EmbedTagName data-alt="Kul alt1" data-path="/files/resources/new789.pdf" data-resource="file" data-title="Kul tittel1" data-type="pdf" />"""
     val expectedEmbed4 =
-      """<embed data-alt="Kul alt3" data-path="/files/resources/new101112.pdf" data-resource="file" data-title="Kul tittel3" data-type="pdf">"""
+      s"""<$EmbedTagName data-alt="Kul alt3" data-path="/files/resources/new101112.pdf" data-resource="file" data-title="Kul tittel3" data-type="pdf" />"""
 
     val expectedNb = ArticleContent(s"<section><h1>Hei</h1>$expectedEmbed1$expectedEmbed2</section>", "nb")
     val expectedEn = ArticleContent(s"<section><h1>Hello</h1>$expectedEmbed3$expectedEmbed4</section>", "en")
@@ -938,12 +939,12 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
   test("cloneEmbedAndUpdateElement updates file embeds") {
     import scala.jdk.CollectionConverters._
     val embed1 =
-      """<embed data-alt="Kul alt1" data-path="/files/resources/abc123.pdf" data-resource="file" data-title="Kul tittel1" data-type="pdf">"""
+      s"""<$EmbedTagName data-alt="Kul alt1" data-path="/files/resources/abc123.pdf" data-resource="file" data-title="Kul tittel1" data-type="pdf" />"""
     val embed2 =
-      """<embed data-alt="Kul alt2" data-path="/files/resources/abc456.pdf" data-resource="file" data-title="Kul tittel2" data-type="pdf">"""
+      s"""<$EmbedTagName data-alt="Kul alt2" data-path="/files/resources/abc456.pdf" data-resource="file" data-title="Kul tittel2" data-type="pdf" />"""
 
     val doc    = HtmlTagRules.stringToJsoupDocument(s"<section>$embed1</section><section>$embed2</section>")
-    val embeds = doc.select(s"embed[data-resource='file']").asScala
+    val embeds = doc.select(s"$EmbedTagName[data-resource='file']").asScala
     when(fileStorage.copyResource(anyString, anyString)).thenReturn(
       Success("resources/new123.pdf"),
       Success("resources/new456.pdf")
@@ -953,9 +954,9 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
     results.map(_.isSuccess should be(true))
 
     val expectedEmbed1 =
-      """<embed data-alt="Kul alt1" data-path="/files/resources/new123.pdf" data-resource="file" data-title="Kul tittel1" data-type="pdf">"""
+      s"""<$EmbedTagName data-alt="Kul alt1" data-path="/files/resources/new123.pdf" data-resource="file" data-title="Kul tittel1" data-type="pdf" />"""
     val expectedEmbed2 =
-      """<embed data-alt="Kul alt2" data-path="/files/resources/new456.pdf" data-resource="file" data-title="Kul tittel2" data-type="pdf">"""
+      s"""<$EmbedTagName data-alt="Kul alt2" data-path="/files/resources/new456.pdf" data-resource="file" data-title="Kul tittel2" data-type="pdf" />"""
 
     HtmlTagRules.jsoupDocumentToString(doc) should be(
       s"<section>$expectedEmbed1</section><section>$expectedEmbed2</section>"

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
@@ -10,6 +10,7 @@ package no.ndla.searchapi.service.search
 import cats.implicits._
 import com.sksamuel.elastic4s.requests.searches.SearchHit
 import com.typesafe.scalalogging.StrictLogging
+import no.ndla.common.configuration.Constants.EmbedTagName
 import no.ndla.common.model.domain.draft.{Draft, RevisionStatus}
 import no.ndla.common.model.domain.{ArticleContent, ArticleMetaImage, VisualElement}
 import no.ndla.language.Language.{UnknownLanguage, findByLanguageOrBestEffort, getSupportedLanguages}
@@ -65,7 +66,7 @@ trait SearchConverterService {
       contents.flatMap(content => {
         val traits = ListBuffer[String]()
         parseHtml(content.content)
-          .select("embed")
+          .select(EmbedTagName)
           .forEach(embed => {
             val dataResource = embed.attr("data-resource")
             dataResource match {
@@ -89,7 +90,7 @@ trait SearchConverterService {
 
     private[service] def getAttributes(html: String): List[String] = {
       parseHtml(html)
-        .select("embed")
+        .select(EmbedTagName)
         .asScala
         .flatMap(getAttributes)
         .toList
@@ -120,7 +121,7 @@ trait SearchConverterService {
 
     private[service] def getEmbedValues(html: String, language: String): List[EmbedValues] = {
       parseHtml(html)
-        .select("embed")
+        .select(EmbedTagName)
         .asScala
         .flatMap(embed => Some(getEmbedValuesFromEmbed(embed, language)))
         .toList

--- a/search-api/src/test/scala/no/ndla/searchapi/TestData.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/TestData.scala
@@ -7,6 +7,7 @@
 
 package no.ndla.searchapi
 
+import no.ndla.common.configuration.Constants.EmbedTagName
 import no.ndla.common.model.domain.{
   ArticleContent,
   ArticleIntroduction,
@@ -51,7 +52,7 @@ object TestData {
   val today: LocalDateTime = LocalDateTime.now().withNano(0)
 
   val sampleArticleTitle         = ArticleApiTitle("tittell", "nb")
-  val sampleArticleVisualElement = ArticleApiVisualElement("""<embed data-resource="image">""", "nb")
+  val sampleArticleVisualElement = ArticleApiVisualElement(s"""<$EmbedTagName data-resource="image">""", "nb")
   val sampleArticleIntro         = ArticleApiIntro("intro", "nb")
 
   val sampleArticleSearch = ArticleApiSearchResults(
@@ -390,7 +391,7 @@ object TestData {
     title = List(Title("Katter", "nb"), Title("Cats", "en"), Title("Chhattisgarhi", "hne")),
     content = List(
       ArticleContent(
-        "<p>Søkeord: delt?streng delt!streng delt&streng</p><embed data-resource=\"concept\" data-resource_id=\"222\" /><p>Noe om en katt</p>",
+        s"<p>Søkeord: delt?streng delt!streng delt&streng</p><$EmbedTagName data-resource=\"concept\" data-resource_id=\"222\" /><p>Noe om en katt</p>",
         "nb"
       ),
       ArticleContent("<p>Something about a cat</p>", "en"),
@@ -411,13 +412,16 @@ object TestData {
     title = List(Title("Ekstrastoff", "nb"), Title("extra", "en")),
     content = List(
       ArticleContent(
-        "Helsesøster H5P <p>delt-streng</p><embed data-title=\"Flubber\" data-resource=\"h5p\" data-path=\"/resource/id\"><embed data-resource=\"concept\" data-content-id=\"111\" data-title=\"Flubber\" /><embed data-videoid=\"77\" data-resource=\"video\"  /><embed data-resource=\"video\" data-resource_id=\"66\"  /><embed data-resource=\"video\" data-url=\"http://test\" data-resource_id=\"test-id1\"/>",
+        s"Helsesøster H5P <p>delt-streng</p><$EmbedTagName data-title=\"Flubber\" data-resource=\"h5p\" data-path=\"/resource/id\"><$EmbedTagName data-resource=\"concept\" data-content-id=\"111\" data-title=\"Flubber\" /><$EmbedTagName data-videoid=\"77\" data-resource=\"video\"  /><$EmbedTagName data-resource=\"video\" data-resource_id=\"66\"  /><$EmbedTagName data-resource=\"video\" data-url=\"http://test\" data-resource_id=\"test-id1\"/>",
         "nb"
       ),
-      ArticleContent("Header <embed data-resource_id=\"222\" /><embed data-resource=\"concept\" />", "en")
+      ArticleContent(
+        s"Header <$EmbedTagName data-resource_id=\"222\" /><$EmbedTagName data-resource=\"concept\" />",
+        "en"
+      )
     ),
     tags = List(Tag(List(""), "nb")),
-    visualElement = List(VisualElement("<embed data-resource_id=\"333\">", "nb")),
+    visualElement = List(VisualElement(s"<$EmbedTagName data-resource_id=\"333\">", "nb")),
     introduction = List(ArticleIntroduction("Ekstra", "nb")),
     metaDescription = List(MetaDescription("", "nb")),
     created = today.minusDays(10),
@@ -754,11 +758,11 @@ object TestData {
     metaDescription = List(ArticleMetaDescription("", "nb")),
     content = List(
       ArticleContent(
-        "<section><p>artikkeltekst med fire deler</p><embed data-resource=\"concept\" data-resource_id=\"222\" /><embed data-resource=\"image\" data-resource_id=\"test-image.id\"  data-url=\"test-image.url\"/><embed data-resource=\"image\" data-resource_id=\"55\"/><embed data-resource=\"concept\" data-content-id=\"111\" data-title=\"Flubber\" /><embed data-videoid=\"77\" data-resource=\"video\"  /><embed data-resource=\"video\" data-resource_id=\"66\"  /><embed data-resource=\"video\"  data-url=\"http://test.test\" />",
+        s"<section><p>artikkeltekst med fire deler</p><$EmbedTagName data-resource=\"concept\" data-resource_id=\"222\" /><$EmbedTagName data-resource=\"image\" data-resource_id=\"test-image.id\"  data-url=\"test-image.url\"/><$EmbedTagName data-resource=\"image\" data-resource_id=\"55\"/><$EmbedTagName data-resource=\"concept\" data-content-id=\"111\" data-title=\"Flubber\" /><$EmbedTagName data-videoid=\"77\" data-resource=\"video\"  /><$EmbedTagName data-resource=\"video\" data-resource_id=\"66\"  /><$EmbedTagName data-resource=\"video\"  data-url=\"http://test.test\" />",
         "nb"
       )
     ),
-    visualElement = List(VisualElement("<embed data-resource_id=\"333\">", "nb")),
+    visualElement = List(VisualElement(s"<$EmbedTagName data-resource_id=\"333\">", "nb")),
     tags = List(Tag(List(""), "nb")),
     created = today.minusDays(10),
     updated = today.minusDays(5),
@@ -772,9 +776,12 @@ object TestData {
     metaDescription = List(ArticleMetaDescription("", "nb")),
     content = List(
       ArticleContent("<section><p>Helsesøster</p><p>Søkeord: delt?streng delt!streng delt&streng</p></section>", "nb"),
-      ArticleContent("Header <embed data-resource_id=\"222\" /><embed data-resource=\"concept\" />", "en"),
       ArticleContent(
-        "Header in Chhattisgarhi <embed data-resource_id=\"222\" /><embed data-resource=\"concept\" />",
+        s"Header <$EmbedTagName data-resource_id=\"222\" /><$EmbedTagName data-resource=\"concept\" />",
+        "en"
+      ),
+      ArticleContent(
+        s"Header in Chhattisgarhi <$EmbedTagName data-resource_id=\"222\" /><$EmbedTagName data-resource=\"concept\" />",
         "hne"
       )
     ),

--- a/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceAtomicTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceAtomicTest.scala
@@ -7,6 +7,7 @@
 
 package no.ndla.searchapi.service.search
 
+import no.ndla.common.configuration.Constants.EmbedTagName
 import no.ndla.common.model.domain.draft.{DraftResponsible, DraftStatus, RevisionMeta, RevisionStatus}
 import no.ndla.common.model.domain.{ArticleContent, EditorNote, Status, Title}
 import no.ndla.scalatestsuite.IntegrationSuite
@@ -74,7 +75,7 @@ class MultiDraftSearchServiceAtomicTest
       id = Some(1),
       content = Seq(
         ArticleContent(
-          """<section><div data-type="related-content"><embed data-article-id="3" data-resource="related-content"></div></section>""",
+          s"""<section><div data-type="related-content"><$EmbedTagName data-article-id="3" data-resource="related-content"></div></section>""",
           "nb"
         )
       )
@@ -83,7 +84,7 @@ class MultiDraftSearchServiceAtomicTest
       id = Some(2),
       content = Seq(
         ArticleContent(
-          """<section><embed data-content-id="3" data-link-text="Test?" data-resource="content-link"></section>""",
+          s"""<section><$EmbedTagName data-content-id="3" data-link-text="Test?" data-resource="content-link"></section>""",
           "nb"
         )
       )

--- a/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceAtomicTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceAtomicTest.scala
@@ -7,6 +7,7 @@
 
 package no.ndla.searchapi.service.search
 
+import no.ndla.common.configuration.Constants.EmbedTagName
 import no.ndla.common.model.domain.ArticleContent
 import no.ndla.scalatestsuite.IntegrationSuite
 import no.ndla.search.Elastic4sClientFactory
@@ -67,7 +68,7 @@ class MultiSearchServiceAtomicTest extends IntegrationSuite(EnableElasticsearchC
       id = Some(1),
       content = Seq(
         ArticleContent(
-          """<section><div data-type="related-content"><embed data-article-id="3" data-resource="related-content"></div></section>""",
+          s"""<section><div data-type="related-content"><$EmbedTagName data-article-id="3" data-resource="related-content"></div></section>""",
           "nb"
         )
       )
@@ -76,7 +77,7 @@ class MultiSearchServiceAtomicTest extends IntegrationSuite(EnableElasticsearchC
       id = Some(2),
       content = Seq(
         ArticleContent(
-          """<section><embed data-content-id="3" data-link-text="Test?" data-resource="content-link"></section>""",
+          s"""<section><$EmbedTagName data-content-id="3" data-link-text="Test?" data-resource="content-link"></section>""",
           "nb"
         )
       )

--- a/search-api/src/test/scala/no/ndla/searchapi/service/search/SearchConverterServiceTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/service/search/SearchConverterServiceTest.scala
@@ -7,6 +7,7 @@
 
 package no.ndla.searchapi.service.search
 
+import no.ndla.common.configuration.Constants.EmbedTagName
 import no.ndla.common.model.domain.{ArticleContent, Tag, Title}
 import no.ndla.search.model.{LanguageValue, SearchableLanguageList, SearchableLanguageValues}
 import no.ndla.searchapi.caching.Memoize
@@ -477,8 +478,8 @@ class SearchConverterServiceTest extends UnitSuite with TestEnvironment {
       TestData.emptyDomainArticle.copy(
         id = Some(99),
         content = Seq(
-          ArticleContent("Sjekk denne h5p-en <embed data-resource=\"h5p\" data-path=\"/resource/id\">", "nb"),
-          ArticleContent("Fil <embed data-resource=\"file\" data-path=\"/file/path\">", "nn")
+          ArticleContent(s"Sjekk denne h5p-en <$EmbedTagName data-resource=\"h5p\" data-path=\"/resource/id\">", "nb"),
+          ArticleContent(s"Fil <$EmbedTagName data-resource=\"file\" data-path=\"/file/path\">", "nn")
         )
       )
 
@@ -490,10 +491,13 @@ class SearchConverterServiceTest extends UnitSuite with TestEnvironment {
       TestData.emptyDomainArticle.copy(
         id = Some(99),
         content = Seq(
-          ArticleContent("Skikkelig bra h5p: <embed data-resource=\"h5p\" data-path=\"/resource/id\">", "nb"),
-          ArticleContent("Fin video <embed data-resource=\"external\" data-url=\"https://youtu.be/id\">", "nn"),
+          ArticleContent(s"Skikkelig bra h5p: <$EmbedTagName data-resource=\"h5p\" data-path=\"/resource/id\">", "nb"),
           ArticleContent(
-            "Movie trailer <embed data-resource=\"iframe\" data-url=\"https://www.imdb.com/video/vi3074735641\">",
+            s"Fin video <$EmbedTagName data-resource=\"external\" data-url=\"https://youtu.be/id\">",
+            "nn"
+          ),
+          ArticleContent(
+            s"Movie trailer <$EmbedTagName data-resource=\"iframe\" data-url=\"https://www.imdb.com/video/vi3074735641\">",
             "en"
           )
         )
@@ -506,7 +510,7 @@ class SearchConverterServiceTest extends UnitSuite with TestEnvironment {
 
   test("That extracting attributes extracts data-title but not all attributes") {
     val html =
-      """<section>Hei<p align="center">Heihei</p><embed class="testklasse" tulleattributt data-resource_id="55" data-title="For ei tittel" />"""
+      s"""<section>Hei<p align="center">Heihei</p><$EmbedTagName class="testklasse" tulleattributt data-resource_id="55" data-title="For ei tittel" />"""
     val result = searchConverterService.getAttributes(html)
     result should be(List("For ei tittel"))
   }

--- a/validation/src/main/resources/html-rules.json
+++ b/validation/src/main/resources/html-rules.json
@@ -172,7 +172,7 @@
     "br",
     "article",
     "strong",
-    "embed",
+    "ndlaembed",
     "i",
     "u",
     "button",

--- a/validation/src/main/scala/no/ndla/validation/EmbedTagRules.scala
+++ b/validation/src/main/scala/no/ndla/validation/EmbedTagRules.scala
@@ -11,8 +11,6 @@ import scala.io.Source
 import scala.language.postfixOps
 
 object EmbedTagRules {
-  val ResourceHtmlEmbedTag = "embed"
-
   case class EmbedThings(attrsForResource: Map[ResourceType.Value, TagRules.TagAttributeRules])
 
   private[validation] lazy val attributeRules: Map[ResourceType.Value, TagRules.TagAttributeRules] = embedRulesToJson

--- a/validation/src/main/scala/no/ndla/validation/HtmlTagRules.scala
+++ b/validation/src/main/scala/no/ndla/validation/HtmlTagRules.scala
@@ -7,11 +7,12 @@
 
 package no.ndla.validation
 
-import no.ndla.validation.EmbedTagRules._
+import no.ndla.common.configuration.Constants.EmbedTagName
 import org.json4s.native.JsonMethods._
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Element
 import org.jsoup.nodes.Entities.EscapeMode
+
 import scala.io.Source
 import scala.language.postfixOps
 import scala.jdk.CollectionConverters._
@@ -75,7 +76,7 @@ object HtmlTagRules {
       }
       val mathMlAttrs = mathMlJson.get("attributes").map(_.asInstanceOf[Map[String, Seq[String]]])
       val embedAttrs  = EmbedTagRules.allEmbedTagAttributes.map(_.toString).toSeq
-      htmlAttrs ++ mathMlAttrs.getOrElse(Map.empty) ++ Map(ResourceHtmlEmbedTag -> embedAttrs)
+      htmlAttrs ++ mathMlAttrs.getOrElse(Map.empty) ++ Map(EmbedTagName -> embedAttrs)
     }
   }
 

--- a/validation/src/main/scala/no/ndla/validation/TagValidator.scala
+++ b/validation/src/main/scala/no/ndla/validation/TagValidator.scala
@@ -8,8 +8,8 @@
 package no.ndla.validation
 
 import io.lemonlabs.uri.typesafe.dsl._
+import no.ndla.common.configuration.Constants.EmbedTagName
 import no.ndla.common.errors.ValidationMessage
-import no.ndla.validation.EmbedTagRules.ResourceHtmlEmbedTag
 import no.ndla.validation.TagRules.TagAttributeRules
 import org.jsoup.nodes.{Element, Node}
 
@@ -29,7 +29,7 @@ class TagValidator {
       .select("*")
       .asScala
       .flatMap(tag => {
-        if (tag.tagName == ResourceHtmlEmbedTag) validateEmbedTag(fieldName, tag, requiredToOptional)
+        if (tag.tagName == EmbedTagName) validateEmbedTag(fieldName, tag, requiredToOptional)
         else validateHtmlTag(fieldName, tag)
       })
       .toList
@@ -72,13 +72,13 @@ class TagValidator {
       embed: Element,
       requiredToOptional: Map[String, Seq[String]]
   ): Seq[ValidationMessage] = {
-    if (embed.tagName != ResourceHtmlEmbedTag)
+    if (embed.tagName != EmbedTagName)
       return Seq()
 
     val allAttributesOnTag = embed.attributes().asScala.map(attr => attr.getKey -> attr.getValue).toMap
-    val legalAttributes    = getLegalAttributesUsed(allAttributesOnTag, ResourceHtmlEmbedTag)
+    val legalAttributes    = getLegalAttributesUsed(allAttributesOnTag, EmbedTagName)
 
-    val validationErrors = attributesAreLegal(fieldName, allAttributesOnTag, ResourceHtmlEmbedTag) ++
+    val validationErrors = attributesAreLegal(fieldName, allAttributesOnTag, EmbedTagName) ++
       attributesContainsNoHtml(fieldName, legalAttributes) ++
       verifyAttributeResource(fieldName, legalAttributes, requiredToOptional) ++
       verifyParent(fieldName, legalAttributes, embed) ++
@@ -287,7 +287,7 @@ class TagValidator {
       Some(
         ValidationMessage(
           fieldName,
-          s"HTML tag '$ResourceHtmlEmbedTag' contains attributes with HTML: ${attributesWithHtml.mkString(", ")}"
+          s"HTML tag '$EmbedTagName' contains attributes with HTML: ${attributesWithHtml.mkString(", ")}"
         )
       )
     } else {
@@ -304,7 +304,7 @@ class TagValidator {
     if (!attributeKeys.contains(TagAttributes.DataResource)) {
       return ValidationMessage(
         fieldName,
-        s"$ResourceHtmlEmbedTag tags must contain a ${TagAttributes.DataResource} attribute"
+        s"$EmbedTagName tags must contain a ${TagAttributes.DataResource} attribute"
       ) :: Nil
     }
 
@@ -323,7 +323,7 @@ class TagValidator {
       .attributesForResourceType(resourceType)
       .withOptionalRequired(requiredToOptional.get(resourceType.toString).getOrElse(Seq.empty))
 
-    val partialErrorMessage = s"An $ResourceHtmlEmbedTag HTML tag with ${TagAttributes.DataResource}=$resourceType"
+    val partialErrorMessage = s"An $EmbedTagName HTML tag with ${TagAttributes.DataResource}=$resourceType"
 
     verifyEmbedTagBasedOnResourceType(fieldName, attributeRulesForTag, attributes, resourceType) ++
       verifyOptionals(fieldName, attributeRulesForTag, attributeKeys, partialErrorMessage) ++
@@ -340,7 +340,7 @@ class TagValidator {
     val missingAttributes = getMissingAttributes(requiredAttrs, actualAttributes.keySet)
     val illegalAttributes = getMissingAttributes(actualAttributes.keySet, attrRules.all)
 
-    val partialErrorMessage = s"An $ResourceHtmlEmbedTag HTML tag with ${TagAttributes.DataResource}=$resourceType"
+    val partialErrorMessage = s"An $EmbedTagName HTML tag with ${TagAttributes.DataResource}=$resourceType"
 
     val missingErrors = missingAttributes
       .map(missingAttributes =>
@@ -428,7 +428,7 @@ class TagValidator {
         Seq(
           ValidationMessage(
             fieldName,
-            s"An $ResourceHtmlEmbedTag HTML tag with ${TagAttributes.DataResource}=$resourceType can only contain ${TagAttributes.DataUrl} urls from the following domains: ${attrs.validSrcDomains
+            s"An $EmbedTagName HTML tag with ${TagAttributes.DataResource}=$resourceType can only contain ${TagAttributes.DataUrl} urls from the following domains: ${attrs.validSrcDomains
                 .mkString(", ")}"
           )
         )

--- a/validation/src/main/scala/no/ndla/validation/TextValidator.scala
+++ b/validation/src/main/scala/no/ndla/validation/TextValidator.scala
@@ -7,8 +7,8 @@
 
 package no.ndla.validation
 
+import no.ndla.common.configuration.Constants.EmbedTagName
 import no.ndla.common.errors.ValidationMessage
-import no.ndla.validation.EmbedTagRules.ResourceHtmlEmbedTag
 import org.jsoup.Jsoup
 import org.jsoup.safety.Safelist
 
@@ -58,7 +58,7 @@ class TextValidator(allowHtml: Boolean) {
 
     elemList match {
       case onlyElement :: Nil =>
-        if (onlyElement.tagName() != ResourceHtmlEmbedTag) {
+        if (onlyElement.tagName() != EmbedTagName) {
           errorWith("The root html element for visual elements needs to be `embed`.")
         } else {
           validateOnlyBasicHtmlTags(fieldPath, text, requiredToOptional)

--- a/validation/src/test/scala/no/ndla/validation/EmbedTagRulesTest.scala
+++ b/validation/src/test/scala/no/ndla/validation/EmbedTagRulesTest.scala
@@ -7,6 +7,7 @@
 
 package no.ndla.validation
 
+import no.ndla.common.configuration.Constants.EmbedTagName
 import no.ndla.common.errors.ValidationMessage
 import no.ndla.mapping.UnitSuite
 import no.ndla.validation.TagRules.Condition
@@ -56,7 +57,7 @@ class EmbedTagRulesTest extends UnitSuite {
 
   test("RequiredNonEmpty fields should not be allowed to be empty-strings") {
     val embedString =
-      """<embed
+      s"""<$EmbedTagName
         | data-resource="image"
         | data-resource_id=""
         | data-size=""
@@ -71,7 +72,7 @@ class EmbedTagRulesTest extends UnitSuite {
       Seq(
         ValidationMessage(
           "test",
-          "An embed HTML tag with data-resource=image must contain non-empty attributes: data-resource_id."
+          s"An $EmbedTagName HTML tag with data-resource=image must contain non-empty attributes: data-resource_id."
         )
       )
     )

--- a/validation/src/test/scala/no/ndla/validation/EmbedTagValidatorTest.scala
+++ b/validation/src/test/scala/no/ndla/validation/EmbedTagValidatorTest.scala
@@ -7,9 +7,9 @@
 
 package no.ndla.validation
 
+import no.ndla.common.configuration.Constants.EmbedTagName
 import no.ndla.common.errors.ValidationMessage
 import no.ndla.mapping.UnitSuite
-import no.ndla.validation.EmbedTagRules.ResourceHtmlEmbedTag
 import no.ndla.validation.TagRules.Condition
 
 class EmbedTagValidatorTest extends UnitSuite {
@@ -30,7 +30,7 @@ class EmbedTagValidatorTest extends UnitSuite {
 
   private def generateTagWithAttrs(attrs: Map[TagAttributes.Value, String]): String = {
     val strAttrs = attrs map { case (k, v) => k.toString -> v }
-    s"""<$ResourceHtmlEmbedTag ${generateAttributes(strAttrs)} />"""
+    s"""<$EmbedTagName ${generateAttributes(strAttrs)} />"""
   }
 
   private def findErrorByMessage(validationMessages: Seq[ValidationMessage], partialMessage: String) =
@@ -54,7 +54,7 @@ class EmbedTagValidatorTest extends UnitSuite {
       )
     )
 
-    val res = embedTagValidator.validate("content", s"""<$ResourceHtmlEmbedTag $attrs />""")
+    val res = embedTagValidator.validate("content", s"""<$EmbedTagName $attrs />""")
     findErrorByMessage(res, "illegal attribute(s) 'illegalattr'").size should be(1)
   }
 
@@ -479,10 +479,10 @@ class EmbedTagValidatorTest extends UnitSuite {
 
   test("validate should return error if related content doesnt contain either ids or url and title") {
     val validRelatedExternalEmbed =
-      """<embed data-resource="related-content" data-url="http://example.com" data-title="Eksempel tittel right here, yo">"""
-    val validRelatedArticle   = """<embed data-resource="related-content" data-article-id="5">"""
-    val invalidRelatedArticle = """<embed data-resource="related-content" data-url="http://example.com">"""
-    val emptyAndInvalidEmbed  = """<embed data-resource="related-content">"""
+      s"""<$EmbedTagName data-resource="related-content" data-url="http://example.com" data-title="Eksempel tittel right here, yo" />"""
+    val validRelatedArticle   = s"""<$EmbedTagName data-resource="related-content" data-article-id="5" />"""
+    val invalidRelatedArticle = s"""<$EmbedTagName data-resource="related-content" data-url="http://example.com" />"""
+    val emptyAndInvalidEmbed  = s"""<$EmbedTagName data-resource="related-content" />"""
 
     val res = embedTagValidator.validate(
       "content",
@@ -499,7 +499,7 @@ class EmbedTagValidatorTest extends UnitSuite {
 
   test("validate should return error if related content is not wrapped in div with data-type='related-content'") {
     val validRelatedExternalEmbed =
-      """<embed data-resource="related-content" data-url="http://example.com" data-title="Eksempel tittel right here, yo">"""
+      s"""<$EmbedTagName data-resource="related-content" data-url="http://example.com" data-title="Eksempel tittel right here, yo" />"""
 
     val res = embedTagValidator.validate("content", s"""<div>$validRelatedExternalEmbed</div>""")
     res.size should be(1)
@@ -566,7 +566,7 @@ class EmbedTagValidatorTest extends UnitSuite {
 
   test("validate should should no longer allow single file embeds with multiple unrelated siblings") {
     val content =
-      """<section><embed data-alt="Øvingsark for teiknskriving for leksjon 1" data-path="files/147739/ovelsesark_for_tegnskriving_for_leksjon_1.pdf" data-resource="file" data-title="Øvelsesark for tegnskriving for leksjon 1" data-type="pdf"><p><span data-size="large">你</span></p><embed data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:163943"><p><span data-size="large">您</span></p><embed data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:163944"><p><span data-size="large">好</span></p><embed data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:163946"><p><span data-size="large">李</span></p><embed data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:163948"><p><span data-size="large">美</span></p><embed data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:163950"><p><span data-size="large">玉</span></p><embed data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:163952"><p><span data-size="large">马</span></p><embed data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:163953"><p><span data-size="large">红</span></p><embed data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:163956"><p><span data-size="large">老</span></p><embed data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:163959"><p><span data-size="large">师</span></p><embed data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:163960"><p><span data-size="large">贵</span></p><embed data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:164025"><p><span data-size="large">姓</span></p><embed data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:164029"><p><span data-size="large">王</span></p><embed data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:164031"><p><span data-size="large">们</span></p><embed data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:164032"><p><span data-size="large">我</span></p><embed data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:164034"><p><span data-size="large">叫</span></p><embed data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:164035"><p><span data-size="large">什</span></p><embed data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:164036"><p><span data-size="large">么</span></p><embed data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:164037"><p><span data-size="large">名</span></p><embed data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:164038"><p><span data-size="large">字</span></p><embed data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:164039"><p><span data-size="large">呢</span></p><embed data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:164067"><p><span data-size="large">认</span></p><embed data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:164069"><p><span data-size="large">识</span></p><embed data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:164072"><p><span data-size="large">很</span></p><embed data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:164077"><p><span data-size="large">高</span></p><embed data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:164078"><p><span data-size="large">兴</span></p><embed data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:164079"></section>"""
+      s"""<section><$EmbedTagName data-alt="Øvingsark for teiknskriving for leksjon 1" data-path="files/147739/ovelsesark_for_tegnskriving_for_leksjon_1.pdf" data-resource="file" data-title="Øvelsesark for tegnskriving for leksjon 1" data-type="pdf" /><p><span data-size="large">你</span></p><$EmbedTagName data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:163943" /><p><span data-size="large">您</span></p><$EmbedTagName data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:163944" /><p><span data-size="large">好</span></p><$EmbedTagName data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:163946" /><p><span data-size="large">李</span></p><$EmbedTagName data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:163948" /><p><span data-size="large">美</span></p><$EmbedTagName data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:163950" /><p><span data-size="large">玉</span></p><$EmbedTagName data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:163952" /><p><span data-size="large">马</span></p><$EmbedTagName data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:163953" /><p><span data-size="large">红</span></p><$EmbedTagName data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:163956" /><p><span data-size="large">老</span></p><$EmbedTagName data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:163959" /><p><span data-size="large">师</span></p><$EmbedTagName data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:163960" /><p><span data-size="large">贵</span></p><$EmbedTagName data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:164025" /><p><span data-size="large">姓</span></p><$EmbedTagName data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:164029" /><p><span data-size="large">王</span></p><$EmbedTagName data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:164031" /><p><span data-size="large">们</span></p><$EmbedTagName data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:164032" /><p><span data-size="large">我</span></p><$EmbedTagName data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:164034" /><p><span data-size="large">叫</span></p><$EmbedTagName data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:164035" /><p><span data-size="large">什</span></p><$EmbedTagName data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:164036" /><p><span data-size="large">么</span></p><$EmbedTagName data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:164037" /><p><span data-size="large">名</span></p><$EmbedTagName data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:164038" /><p><span data-size="large">字</span></p><$EmbedTagName data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:164039" /><p><span data-size="large">呢</span></p><$EmbedTagName data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:164067" /><p><span data-size="large">认</span></p><$EmbedTagName data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:164069" /><p><span data-size="large">识</span></p><$EmbedTagName data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:164072" /><p><span data-size="large">很</span></p><$EmbedTagName data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:164077" /><p><span data-size="large">高</span></p><$EmbedTagName data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:164078" /><p><span data-size="large">兴</span></p><$EmbedTagName data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:164079" /></section>"""
 
     val res = embedTagValidator.validate("content", content)
     res should be(
@@ -581,47 +581,47 @@ class EmbedTagValidatorTest extends UnitSuite {
 
   test("That getNumEqualSiblings returns number of direct equal siblings") {
     {
-      val content = """<section><p><embed type="a" data-resource="file"></p></section>"""
-      val embed   = HtmlTagRules.stringToJsoupDocument(content).select("embed").first()
+      val content = s"""<section><p><$EmbedTagName type="a" data-resource="file" /></p></section>"""
+      val embed   = HtmlTagRules.stringToJsoupDocument(content).select(EmbedTagName).first()
       embedTagValidator.numDirectEqualSiblings(embed) should be(1)
     }
     {
       val content =
-        """<section><p><embed type="a" data-resource="file"><embed type="b" data-resource="file"><embed type="c" data-resource="file"><embed type="d" data-resource="file"></p></section>"""
-      val embed = HtmlTagRules.stringToJsoupDocument(content).select("embed[type=b]").first()
+        s"""<section><p><$EmbedTagName type="a" data-resource="file" /><$EmbedTagName type="b" data-resource="file" /><$EmbedTagName type="c" data-resource="file" /><$EmbedTagName type="d" data-resource="file" /></p></section>"""
+      val embed = HtmlTagRules.stringToJsoupDocument(content).select(s"$EmbedTagName[type=b]").first()
       embedTagValidator.numDirectEqualSiblings(embed) should be(4)
     }
     {
       val content =
-        """<section><p><embed type="a" data-resource="file">, <embed type="b" data-resource="file">, <embed type="c" data-resource="file">, <embed type="d" data-resource="file"></p></section>"""
-      val embed = HtmlTagRules.stringToJsoupDocument(content).select("embed[type=d]").first()
+        s"""<section><p><$EmbedTagName type="a" data-resource="file" />, <$EmbedTagName type="b" data-resource="file" />, <$EmbedTagName type="c" data-resource="file" />, <$EmbedTagName type="d" data-resource="file" /></p></section>"""
+      val embed = HtmlTagRules.stringToJsoupDocument(content).select(s"$EmbedTagName[type=d]").first()
       embedTagValidator.numDirectEqualSiblings(embed) should be(1)
     }
     {
       val content =
-        """<section><p><embed type="a" data-resource="file">, <embed type="b" data-resource="file">, <embed type="c" data-resource="file"><embed type="d" data-resource="file"></p></section>"""
-      val embed = HtmlTagRules.stringToJsoupDocument(content).select("embed[type=c]").first()
+        s"""<section><p><$EmbedTagName type="a" data-resource="file" />, <$EmbedTagName type="b" data-resource="file" />, <$EmbedTagName type="c" data-resource="file" /><$EmbedTagName type="d" data-resource="file" /></p></section>"""
+      val embed = HtmlTagRules.stringToJsoupDocument(content).select(s"$EmbedTagName[type=c]").first()
       embedTagValidator.numDirectEqualSiblings(embed) should be(2)
     }
   }
 
   test("getNumEqualSiblings should ignore only-whitespace siblings, but not text siblings") {
     val content =
-      """<section>
+      s"""<section>
           |<p>
-          |<embed type="a" data-resource="file">awdk
-          |<embed type="b" data-resource="file">
+          |<$EmbedTagName type="a" data-resource="file" />awdk
+          |<$EmbedTagName type="b" data-resource="file" />
           |
-          |<embed type="c" data-resource="file">
-          |
-          |
+          |<$EmbedTagName type="c" data-resource="file" />
           |
           |
           |
-          |<embed type="d" data-resource="file">
+          |
+          |
+          |<$EmbedTagName type="d" data-resource="file" />
           |</p>
           |</section>""".stripMargin
-    val embed = HtmlTagRules.stringToJsoupDocument(content).select("embed[type=c]").first()
+    val embed = HtmlTagRules.stringToJsoupDocument(content).select(s"$EmbedTagName[type=c]").first()
     embedTagValidator.numDirectEqualSiblings(embed) should be(3)
   }
 

--- a/validation/src/test/scala/no/ndla/validation/HtmlTagRulesTest.scala
+++ b/validation/src/test/scala/no/ndla/validation/HtmlTagRulesTest.scala
@@ -7,6 +7,7 @@
 
 package no.ndla.validation
 
+import no.ndla.common.configuration.Constants.EmbedTagName
 import no.ndla.mapping.UnitSuite
 
 class HtmlTagRulesTest extends UnitSuite {
@@ -14,7 +15,7 @@ class HtmlTagRulesTest extends UnitSuite {
     HtmlTagRules.isTagValid("embed")
     val dataAttrs =
       TagAttributes.values.map(_.toString).filter(x => x.startsWith("data-") && x != TagAttributes.DataType.toString)
-    val legalEmbedAttrs = HtmlTagRules.legalAttributesForTag("embed")
+    val legalEmbedAttrs = HtmlTagRules.legalAttributesForTag(EmbedTagName)
     dataAttrs.foreach(x => legalEmbedAttrs should contain(x))
   }
 

--- a/validation/src/test/scala/no/ndla/validation/HtmlValidatorTest.scala
+++ b/validation/src/test/scala/no/ndla/validation/HtmlValidatorTest.scala
@@ -1,5 +1,6 @@
 package no.ndla.validation
 
+import no.ndla.common.configuration.Constants.EmbedTagName
 import no.ndla.common.errors.ValidationMessage
 import no.ndla.mapping.UnitSuite
 
@@ -7,7 +8,7 @@ class HtmlValidatorTest extends UnitSuite {
   val htmlValidator = new TextValidator(allowHtml = true)
 
   private val getValidImageEmbed = (id: String) => {
-    s"""<embed data-caption="some capt" data-align="" data-resource_id="$id" data-resource="image" data-alt="some alt" data-size="full" />"""
+    s"""<$EmbedTagName data-caption="some capt" data-align="" data-resource_id="$id" data-resource="image" data-alt="some alt" data-size="full" />"""
   }
 
   test("validate should allow math tags with styling") {


### PR DESCRIPTION
Oppdaterer all kode som refererer til `embed` til å bruke en konstant (som nå er satt til `ndlaembed`).
Legger også til migreringer i {draft,article,concept}-api for å migrere content og visualElement.