### PR TITLE
Move link-text to `ndlaembed` children

### DIFF
--- a/article-api/README.md
+++ b/article-api/README.md
@@ -61,7 +61,7 @@ The embed tag contains a set of attributes which define what content should be i
 * **data-caption** - a caption to display along with the resource. Present in brightcove and image
 * **data-account** - the brightcove account id. Present in brightcove
 * **data-videoid** - a video identifier. Present in brightcove
-* **data-link-text** - the text to display in a link. Present in content-link and concept
+* **data-link-text** - the text to display in a link. Present in concept
 * **data-content-id** - the id to the article content to be inserted. Present in content-link and concept
 * **data-content-type** - the type of the content-link to be inserted. Internal or external
 * **data-nrk-video-id** - an ID to nrk videos. Present in nrk

--- a/article-api/src/main/scala/no/ndla/articleapi/db/migration/V40__ContentLinkEmbedChildren.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/db/migration/V40__ContentLinkEmbedChildren.scala
@@ -31,9 +31,9 @@ class V40__ContentLinkEmbedChildren extends BaseJavaMigration {
   }
 
   def migrateArticles(implicit session: DBSession): Unit = {
-    val count = countAllArticles.get
+    val count        = countAllArticles.get
     var numPagesLeft = (count / 1000) + 1
-    var offset = 0L
+    var offset       = 0L
 
     while (numPagesLeft > 0) {
       allArticles(offset * 1000).map { case (id, document) =>
@@ -96,7 +96,7 @@ class V40__ContentLinkEmbedChildren extends BaseJavaMigration {
     contents.map(content =>
       content.mapField {
         case (`contentType`, JString(html)) => (`contentType`, JString(moveContentLinkTextToChildren(html)))
-        case z => z
+        case z                              => z
       }
     )
   }

--- a/article-api/src/main/scala/no/ndla/articleapi/db/migration/V40__ContentLinkEmbedChildren.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/db/migration/V40__ContentLinkEmbedChildren.scala
@@ -1,0 +1,119 @@
+/*
+ * Part of NDLA draft-api.
+ * Copyright (C) 2022 NDLA
+ *
+ * See LICENSE
+ */
+
+package no.ndla.articleapi.db.migration
+
+import org.flywaydb.core.api.migration.{BaseJavaMigration, Context}
+import org.json4s
+import org.json4s.DefaultFormats
+import org.json4s.JsonAST.{JArray, JString}
+import org.json4s.native.JsonMethods.{compact, parse, render}
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Element
+import org.jsoup.nodes.Entities.EscapeMode
+import org.postgresql.util.PGobject
+import scalikejdbc.{DB, DBSession, _}
+
+class V40__ContentLinkEmbedChildren extends BaseJavaMigration {
+  implicit val formats: DefaultFormats.type = org.json4s.DefaultFormats
+
+  override def migrate(context: Context): Unit = {
+    val db = DB(context.getConnection)
+    db.autoClose(false)
+
+    db.withinTx { implicit session =>
+      migrateArticles
+    }
+  }
+
+  def migrateArticles(implicit session: DBSession): Unit = {
+    val count = countAllArticles.get
+    var numPagesLeft = (count / 1000) + 1
+    var offset = 0L
+
+    while (numPagesLeft > 0) {
+      allArticles(offset * 1000).map { case (id, document) =>
+        updateArticle(convertArticleUpdate(document), id)
+      }
+      numPagesLeft -= 1
+      offset += 1
+    }
+  }
+
+  def countAllArticles(implicit session: DBSession): Option[Long] = {
+    sql"select count(*) from contentdata where document is not NULL"
+      .map(rs => rs.long("count"))
+      .single()
+  }
+
+  def allArticles(offset: Long)(implicit session: DBSession): Seq[(Long, String)] = {
+    sql"select id, document, article_id from contentdata where document is not null order by id limit 1000 offset $offset"
+      .map(rs => {
+        (rs.long("id"), rs.string("document"))
+      })
+      .list()
+  }
+
+  def updateArticle(document: String, id: Long)(implicit session: DBSession): Int = {
+    val dataObject = new PGobject()
+    dataObject.setType("jsonb")
+    dataObject.setValue(document)
+
+    sql"update contentdata set document = $dataObject where id = $id"
+      .update()
+  }
+
+  private def stringToJsoupDocument(htmlString: String): Element = {
+    val document = Jsoup.parseBodyFragment(htmlString)
+    document.outputSettings().escapeMode(EscapeMode.xhtml).prettyPrint(false)
+    document.select("body").first()
+  }
+
+  private def jsoupDocumentToString(element: Element): String = {
+    element.select("body").html()
+  }
+
+  def moveContentLinkTextToChildren(html: String): String = {
+    val doc = stringToJsoupDocument(html)
+    doc
+      .select("ndlaembed[data-resource='content-link']")
+      .forEach(embed => {
+        Option(embed.attr("data-link-text")).filter(_.nonEmpty) match {
+          case None =>
+          case Some(nonEmptyAttr) =>
+            embed.text(nonEmptyAttr)
+            embed.removeAttr("data-link-text")
+        }
+      })
+    jsoupDocumentToString(doc)
+  }
+
+  def updateContent(contents: JArray, contentType: String): json4s.JValue = {
+    contents.map(content =>
+      content.mapField {
+        case (`contentType`, JString(html)) => (`contentType`, JString(moveContentLinkTextToChildren(html)))
+        case z => z
+      }
+    )
+  }
+
+  private[migration] def convertArticleUpdate(document: String): String = {
+    val oldArticle = parse(document)
+
+    val newArticle = oldArticle.mapField {
+      case ("content", contents: JArray) =>
+        val updatedContent = updateContent(contents, "content")
+        ("content", updatedContent)
+      case ("visualElement", visualElements: JArray) =>
+        val updatedVisualElement = updateContent(visualElements, "resource")
+        ("visualElement", updatedVisualElement)
+      case x => x
+    }
+
+    compact(render(newArticle))
+  }
+}

--- a/article-api/src/test/scala/no/ndla/articleapi/db/migration/V40__ContentLinkEmbedChildrenTest.scala
+++ b/article-api/src/test/scala/no/ndla/articleapi/db/migration/V40__ContentLinkEmbedChildrenTest.scala
@@ -1,0 +1,16 @@
+package no.ndla.articleapi.db.migration
+
+import no.ndla.articleapi.{TestEnvironment, UnitSuite}
+
+class V40__ContentLinkEmbedChildrenTest extends UnitSuite with TestEnvironment {
+
+  test("That converting content-links works as expected") {
+    val testHtml =
+      """<section><ndlaembed data-content-id="13690" data-link-text="Fastset blodtypen ved hjelp av Blodtypar og blodoverføring" data-open-in="new-context" data-resource="content-link" data-content-type="article"></ndlaembed>.</section>"""
+    val expectedResult =
+      """<section><ndlaembed data-content-id="13690" data-open-in="new-context" data-resource="content-link" data-content-type="article">Fastset blodtypen ved hjelp av Blodtypar og blodoverføring</ndlaembed>.</section>"""
+    val migration = new V40__ContentLinkEmbedChildren
+    val result    = migration.moveContentLinkTextToChildren(testHtml)
+    result should be(expectedResult)
+  }
+}

--- a/common/src/main/scala/no/ndla/common/errors/ValidationMessage.scala
+++ b/common/src/main/scala/no/ndla/common/errors/ValidationMessage.scala
@@ -18,3 +18,9 @@ case class ValidationMessage(
     @(ApiModelProperty @field)(description = "The field the error occured in") field: String,
     @(ApiModelProperty @field)(description = "The validation message") message: String
 )
+
+object ValidationMessage {
+  def seq(fieldName: String, message: String): Seq[ValidationMessage] = {
+    Seq(ValidationMessage(fieldName, message))
+  }
+}

--- a/draft-api/src/main/scala/no/ndla/draftapi/db/migration/V41__ContentLinkEmbedChildren.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/db/migration/V41__ContentLinkEmbedChildren.scala
@@ -1,0 +1,119 @@
+/*
+ * Part of NDLA draft-api.
+ * Copyright (C) 2022 NDLA
+ *
+ * See LICENSE
+ */
+
+package no.ndla.draftapi.db.migration
+
+import org.flywaydb.core.api.migration.{BaseJavaMigration, Context}
+import org.json4s
+import org.json4s.DefaultFormats
+import org.json4s.JsonAST.{JArray, JString}
+import org.json4s.native.JsonMethods.{compact, parse, render}
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Element
+import org.jsoup.nodes.Entities.EscapeMode
+import org.postgresql.util.PGobject
+import scalikejdbc.{DB, DBSession, _}
+
+class V41__ContentLinkEmbedChildren extends BaseJavaMigration {
+  implicit val formats: DefaultFormats.type = org.json4s.DefaultFormats
+
+  override def migrate(context: Context): Unit = {
+    val db = DB(context.getConnection)
+    db.autoClose(false)
+
+    db.withinTx { implicit session =>
+      migrateArticles
+    }
+  }
+
+  def migrateArticles(implicit session: DBSession): Unit = {
+    val count        = countAllArticles.get
+    var numPagesLeft = (count / 1000) + 1
+    var offset       = 0L
+
+    while (numPagesLeft > 0) {
+      allArticles(offset * 1000).map { case (id, document) =>
+        updateArticle(convertArticleUpdate(document), id)
+      }
+      numPagesLeft -= 1
+      offset += 1
+    }
+  }
+
+  def countAllArticles(implicit session: DBSession): Option[Long] = {
+    sql"select count(*) from articledata where document is not NULL"
+      .map(rs => rs.long("count"))
+      .single()
+  }
+
+  def allArticles(offset: Long)(implicit session: DBSession): Seq[(Long, String)] = {
+    sql"select id, document, article_id from articledata where document is not null order by id limit 1000 offset $offset"
+      .map(rs => {
+        (rs.long("id"), rs.string("document"))
+      })
+      .list()
+  }
+
+  def updateArticle(document: String, id: Long)(implicit session: DBSession): Int = {
+    val dataObject = new PGobject()
+    dataObject.setType("jsonb")
+    dataObject.setValue(document)
+
+    sql"update articledata set document = $dataObject where id = $id"
+      .update()
+  }
+
+  private def stringToJsoupDocument(htmlString: String): Element = {
+    val document = Jsoup.parseBodyFragment(htmlString)
+    document.outputSettings().escapeMode(EscapeMode.xhtml).prettyPrint(false)
+    document.select("body").first()
+  }
+
+  private def jsoupDocumentToString(element: Element): String = {
+    element.select("body").html()
+  }
+
+  def moveContentLinkTextToChildren(html: String): String = {
+    val doc = stringToJsoupDocument(html)
+    doc
+      .select("ndlaembed[data-resource='content-link']")
+      .forEach(embed => {
+        Option(embed.attr("data-link-text")).filter(_.nonEmpty) match {
+          case None =>
+          case Some(nonEmptyAttr) =>
+            embed.text(nonEmptyAttr)
+            embed.removeAttr("data-link-text")
+        }
+      })
+    jsoupDocumentToString(doc)
+  }
+
+  def updateContent(contents: JArray, contentType: String): json4s.JValue = {
+    contents.map(content =>
+      content.mapField {
+        case (`contentType`, JString(html)) => (`contentType`, JString(moveContentLinkTextToChildren(html)))
+        case z                              => z
+      }
+    )
+  }
+
+  private[migration] def convertArticleUpdate(document: String): String = {
+    val oldArticle = parse(document)
+
+    val newArticle = oldArticle.mapField {
+      case ("content", contents: JArray) =>
+        val updatedContent = updateContent(contents, "content")
+        ("content", updatedContent)
+      case ("visualElement", visualElements: JArray) =>
+        val updatedVisualElement = updateContent(visualElements, "resource")
+        ("visualElement", updatedVisualElement)
+      case x => x
+    }
+
+    compact(render(newArticle))
+  }
+}

--- a/draft-api/src/test/scala/no/ndla/draftapi/db/migration/V41__ContentLinkEmbedChildrenTest.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/db/migration/V41__ContentLinkEmbedChildrenTest.scala
@@ -1,0 +1,16 @@
+package no.ndla.draftapi.db.migration
+
+import no.ndla.draftapi.{TestEnvironment, UnitSuite}
+
+class V41__ContentLinkEmbedChildrenTest extends UnitSuite with TestEnvironment {
+
+  test("That converting content-links works as expected") {
+    val testHtml =
+      """<section><ndlaembed data-content-id="13690" data-link-text="Fastset blodtypen ved hjelp av Blodtypar og blodoverføring" data-open-in="new-context" data-resource="content-link" data-content-type="article"></ndlaembed>.</section>"""
+    val expectedResult =
+      """<section><ndlaembed data-content-id="13690" data-open-in="new-context" data-resource="content-link" data-content-type="article">Fastset blodtypen ved hjelp av Blodtypar og blodoverføring</ndlaembed>.</section>"""
+    val migration = new V41__ContentLinkEmbedChildren
+    val result    = migration.moveContentLinkTextToChildren(testHtml)
+    result should be(expectedResult)
+  }
+}

--- a/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceAtomicTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceAtomicTest.scala
@@ -84,7 +84,7 @@ class MultiDraftSearchServiceAtomicTest
       id = Some(2),
       content = Seq(
         ArticleContent(
-          s"""<section><$EmbedTagName data-content-id="3" data-link-text="Test?" data-resource="content-link"></section>""",
+          s"""<section><$EmbedTagName data-content-id="3" data-resource="content-link">Test?</$EmbedTagName></section>""",
           "nb"
         )
       )

--- a/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceAtomicTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceAtomicTest.scala
@@ -77,7 +77,7 @@ class MultiSearchServiceAtomicTest extends IntegrationSuite(EnableElasticsearchC
       id = Some(2),
       content = Seq(
         ArticleContent(
-          s"""<section><$EmbedTagName data-content-id="3" data-link-text="Test?" data-resource="content-link"></section>""",
+          s"""<section><$EmbedTagName data-content-id="3" data-resource="content-link">Test?</$EmbedTagName></section>""",
           "nb"
         )
       )

--- a/validation/src/main/resources/embed-tag-rules.json
+++ b/validation/src/main/resources/embed-tag-rules.json
@@ -51,13 +51,24 @@
     "content-link": {
       "required": [
         "data-resource",
-        "data-content-id",
-        "data-link-text"
+        "data-content-id"
       ],
       "optional": [
         [ "data-open-in" ],
         [ "data-content-type" ]
-      ]
+      ],
+      "children": {
+        "required": true,
+        "allowedChildren": [
+          "b",
+          "i",
+          "s",
+          "strong",
+          "sub",
+          "sup",
+          "u"
+        ]
+      }
     },
     "brightcove": {
       "required": [

--- a/validation/src/main/scala/no/ndla/validation/HtmlTagRules.scala
+++ b/validation/src/main/scala/no/ndla/validation/HtmlTagRules.scala
@@ -96,7 +96,7 @@ object HtmlTagRules {
   def legalAttributesForTag(tagName: String): Set[String] = attributesForTagType(tagName).toSet
 
   def tagMustContainAtLeastOneOptionalAttribute(tagName: String): Boolean =
-    tagAttributesForTagType(tagName).exists(_.mustContainAtLeastOneOptionalAttribute)
+    tagAttributesForTagType(tagName).exists(_.mustContainAtLeastOneOptionalAttribute.getOrElse(false))
 
   def removeIllegalAttributes(el: Element, legalAttributes: Set[String]): Seq[String] = {
     el.attributes()

--- a/validation/src/main/scala/no/ndla/validation/TagRules.scala
+++ b/validation/src/main/scala/no/ndla/validation/TagRules.scala
@@ -12,9 +12,12 @@ object TagRules {
       optional: Seq[Set[TagAttributes.Value]],
       validSrcDomains: Option[Seq[String]],
       mustBeDirectChildOf: Option[ParentTag],
-      mustContainAtLeastOneOptionalAttribute: Boolean = false
+      children: Option[ChildrenRule],
+      mustContainAtLeastOneOptionalAttribute: Option[Boolean]
   ) {
     lazy val all: Set[TagAttributes.Value] = required ++ requiredNonEmpty ++ optional.flatten
+
+    def mustContainOptionalAttribute: Boolean = this.mustContainAtLeastOneOptionalAttribute.getOrElse(false)
 
     def withOptionalRequired(toBeOptional: Seq[String]): TagAttributeRules = {
       val toBeOptionalEnums = toBeOptional.flatMap(TagAttributes.valueOf)
@@ -29,10 +32,14 @@ object TagRules {
   }
 
   case class ParentTag(name: String, requiredAttr: List[(String, String)], conditions: Option[Condition])
+  case class ChildrenRule(required: Boolean, allowedChildren: List[String])
+  object ChildrenRule {
+    def default: ChildrenRule = ChildrenRule(required = false, allowedChildren = List.empty)
+  }
   case class Condition(childCount: String)
 
   object TagAttributeRules {
-    def empty: TagAttributeRules = TagAttributeRules(Set.empty, Set.empty, Seq.empty, None, None)
+    def empty: TagAttributeRules = TagAttributeRules(Set.empty, Set.empty, Seq.empty, None, None, None, None)
   }
 
   def convertJsonStrToAttributeRules(jsonStr: String): Map[String, TagAttributeRules] = {

--- a/validation/src/test/scala/no/ndla/validation/EmbedTagValidatorTest.scala
+++ b/validation/src/test/scala/no/ndla/validation/EmbedTagValidatorTest.scala
@@ -30,12 +30,12 @@ class EmbedTagValidatorTest extends UnitSuite {
 
   private def generateTagWithAttrs(attrs: Map[TagAttributes.Value, String]): String = {
     val strAttrs = attrs map { case (k, v) => k.toString -> v }
-    s"""<$EmbedTagName ${generateAttributes(strAttrs)}></ndlaembed>"""
+    s"""<$EmbedTagName ${generateAttributes(strAttrs)}></$EmbedTagName>"""
   }
 
   private def generateTagWithAttrsAndChildren(attrs: Map[TagAttributes.Value, String], children: String): String = {
     val strAttrs = attrs map { case (k, v) => k.toString -> v }
-    s"""<$EmbedTagName ${generateAttributes(strAttrs)}>$children</ndlaembed>"""
+    s"""<$EmbedTagName ${generateAttributes(strAttrs)}>$children</$EmbedTagName>"""
   }
 
   private def findErrorByMessage(validationMessages: Seq[ValidationMessage], partialMessage: String) =


### PR DESCRIPTION
Gjør om lenke-tekst til `ndlaembed`-barn istedetfor å ha en attributt.
Dette gjør at vi kan ha (forhåpentligvis enkel) html som tekst for en link.