### PR TITLE
#3385: Make taxonomy-api clients use internal url rather than api-gateway

### DIFF
--- a/draft-api/src/main/scala/no/ndla/draftapi/DraftApiProperties.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/DraftApiProperties.scala
@@ -62,6 +62,7 @@ class DraftApiProperties extends BaseProps with StrictLogging {
   def ImageApiHost: String        = propOrElse("IMAGE_API_HOST", "image-api.ndla-local")
   def SearchApiHost: String       = propOrElse("SEARCH_API_HOST", "search-api.ndla-local")
   def ApiGatewayHost: String      = propOrElse("API_GATEWAY_HOST", "api-gateway.ndla-local")
+  def TaxonomyUrl: String         = s"http://${propOrElse("TAXONOMY_API_HOST", "taxonomy-api.ndla-local:5000")}"
 
   def internalApiUrls: Map[String, String] = Map(
     "article-api" -> s"http://$ArticleApiHost/intern",

--- a/draft-api/src/main/scala/no/ndla/draftapi/integration/TaxonomyApiClient.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/integration/TaxonomyApiClient.scala
@@ -25,10 +25,10 @@ import scala.util.{Failure, Success, Try}
 trait TaxonomyApiClient {
   this: NdlaClient with Props =>
   val taxonomyApiClient: TaxonomyApiClient
-  import props.{ApiGatewayHost, DefaultLanguage, TaxonomyVersionHeader, TaxonomyVersionIdKey}
+  import props.{TaxonomyUrl, DefaultLanguage, TaxonomyVersionHeader, TaxonomyVersionIdKey}
 
   class TaxonomyApiClient extends StrictLogging {
-    private val TaxonomyApiEndpoint           = s"http://$ApiGatewayHost/taxonomy/v1"
+    private val TaxonomyApiEndpoint           = s"$TaxonomyUrl/v1"
     private val taxonomyTimeout               = 20 * 1000 // 20 Seconds
     implicit val formats: DefaultFormats.type = DefaultFormats
 

--- a/draft-api/src/test/scala/no/ndla/draftapi/integration/TaxonomyApiClientTest.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/integration/TaxonomyApiClientTest.scala
@@ -385,7 +385,7 @@ class TaxonomyApiClientTest extends UnitSuite with TestEnvironment {
 
     verify(taxonomyApiClient, times(0)).updateTopic(any[Topic])(any[Formats])
     verify(taxonomyApiClient, times(0)).updateTopicTranslation(anyString, anyString, anyString)
-    verify(taxonomyApiClient, times(1)).delete(eqTo(s"${props.Domain}/taxonomy/v1/resources/urn:resource:1:12312/translations/nn"), any[(String, String)])
+    verify(taxonomyApiClient, times(1)).delete(eqTo(s"${props.TaxonomyUrl}/v1/resources/urn:resource:1:12312/translations/nn"), any[(String, String)])
     // format: on
   }
 }

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/LearningpathApiProperties.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/LearningpathApiProperties.scala
@@ -48,6 +48,7 @@ class LearningpathApiProperties extends BaseProps with StrictLogging {
   def ImageApiHost: String   = propOrElse("IMAGE_API_HOST", "image-api.ndla-local")
   def InternalImageApiUrl    = s"$ImageApiHost/image-api/v2/images"
   def SearchApiHost: String  = propOrElse("SEARCH_API_HOST", "search-api.ndla-local")
+  def TaxonomyUrl: String    = s"http://${propOrElse("TAXONOMY_API_HOST", "taxonomy-api.ndla-local:5000")}"
 
   def RedisHost: String = propOrElse("REDIS_HOST", "redis")
   def RedisPort: Int    = propOrElse("REDIS_PORT", "6379").toInt

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/integration/TaxonomyApiClient.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/integration/TaxonomyApiClient.scala
@@ -25,10 +25,10 @@ trait TaxonomyApiClient {
   val taxononyApiClient: TaxonomyApiClient
 
   class TaxonomyApiClient extends StrictLogging {
-    import props.{ApiGatewayHost, DefaultLanguage}
+    import props.{TaxonomyUrl, DefaultLanguage}
     implicit val formats                   = org.json4s.DefaultFormats
     private val taxonomyTimeout            = 20 * 1000 // 20 Seconds
-    private val TaxonomyApiEndpoint        = s"http://$ApiGatewayHost/taxonomy/v1"
+    private val TaxonomyApiEndpoint        = s"$TaxonomyUrl/v1"
     private val LearningPathResourceTypeId = "urn:resourcetype:learningPath"
 
     def updateTaxonomyForLearningPath(

--- a/search-api/src/main/scala/no/ndla/searchapi/SearchApiProperties.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/SearchApiProperties.scala
@@ -39,6 +39,7 @@ class SearchApiProperties extends BaseProps with StrictLogging {
   def AudioApiUrl: String        = s"http://${propOrElse("AUDIO_API_HOST", "audio-api.ndla-local")}"
   def ApiGatewayUrl: String      = s"http://${propOrElse("API_GATEWAY_HOST", "api-gateway.ndla-local")}"
   def GrepApiUrl: String         = s"https://${propOrElse("GREP_API_HOST", "data.udir.no")}"
+  def TaxonomyUrl: String        = s"http://${propOrElse("TAXONOMY_API_HOST", "taxonomy-api.ndla-local:5000")}"
 
   def SearchServer: String                 = propOrElse("SEARCH_SERVER", "http://search-search-api.ndla-local")
   def RunWithSignedSearchRequests: Boolean = propOrElse("RUN_WITH_SIGNED_SEARCH_REQUESTS", "true").toBoolean

--- a/search-api/src/main/scala/no/ndla/searchapi/integration/TaxonomyApiClient.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/integration/TaxonomyApiClient.scala
@@ -28,9 +28,9 @@ trait TaxonomyApiClient {
   val taxonomyApiClient: TaxonomyApiClient
 
   class TaxonomyApiClient extends StrictLogging {
-    import props.ApiGatewayUrl
+    import props.TaxonomyUrl
     implicit val formats: DefaultFormats.type = org.json4s.DefaultFormats
-    private val TaxonomyApiEndpoint           = s"$ApiGatewayUrl/taxonomy/v1"
+    private val TaxonomyApiEndpoint           = s"$TaxonomyUrl/v1"
     private val timeoutSeconds                = 600
 
     def getAllResources: Try[List[Resource]] =


### PR DESCRIPTION
Fixes NDLANO/Issues#3385
Depends on https://github.com/NDLANO/deploy/pull/452
Jeg syns vi burde unngå 1minutter lange requests uansett, men dette kan være en plasterlapp enn så lenge :smile: