### PR TITLE
article-api: Return 410 GONE when article has been unpublished

### DIFF
--- a/article-api/src/main/scala/no/ndla/articleapi/controller/ArticleControllerV2.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/controller/ArticleControllerV2.scala
@@ -52,6 +52,7 @@ trait ArticleControllerV2 {
     val response400 = ResponseMessage(400, "Validation Error", Some("ValidationError"))
     val response403 = ResponseMessage(403, "Access Denied", Some("Error"))
     val response404 = ResponseMessage(404, "Not found", Some("Error"))
+    val response410 = ResponseMessage(410, "Gone", Some("Error"))
     val response500 = ResponseMessage(500, "Unknown error", Some("Error"))
 
     private val correlationId =
@@ -342,7 +343,7 @@ trait ArticleControllerV2 {
             asQueryParam(fallback),
             asQueryParam(revision)
           )
-          .responseMessages(response404, response500)
+          .responseMessages(response404, response410, response500)
       )
     ) {
       parseArticleIdAndRevision(params(this.articleId.paramName)) match {

--- a/article-api/src/main/scala/no/ndla/articleapi/controller/NdlaController.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/controller/NdlaController.scala
@@ -58,6 +58,7 @@ trait NdlaController {
           if rf.error.rootCause
             .exists(x => x.`type` == "search_context_missing_exception" || x.reason == "Cannot parse scroll id") =>
         BadRequest(body = InvalidSearchContext)
+      case age: ArticleGoneException => Gone(body = Error(ARTICLE_GONE, age.getMessage))
       case t: Throwable =>
         logger.error(GenericError.toString, t)
         InternalServerError(body = ErrorHelpers.GenericError)

--- a/article-api/src/main/scala/no/ndla/articleapi/db/migrationwithdependencies/R__SetArticleLanguageFromTaxonomy.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/db/migrationwithdependencies/R__SetArticleLanguageFromTaxonomy.scala
@@ -151,7 +151,7 @@ class R__SetArticleLanguageFromTaxonomy(properties: ArticleApiProperties)
     sql"select ${ar.result.*} from ${Article.as(ar)} where ar.document is not NULL and $withId"
       .map(Article.fromResultSet(ar))
       .single()
-      .flatten
+      .toArticle
   }
 
   def convertArticleLanguage(oldArticle: Option[Article], externalTags: Seq[Tag]): Option[Article] = {

--- a/article-api/src/main/scala/no/ndla/articleapi/model/api/NDLAErrors.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/model/api/NDLAErrors.scala
@@ -35,6 +35,7 @@ trait ErrorHelpers {
     val ACCESS_DENIED        = "ACCESS DENIED"
     val WINDOW_TOO_LARGE     = "RESULT_WINDOW_TOO_LARGE"
     val DATABASE_UNAVAILABLE = "DATABASE_UNAVAILABLE"
+    val ARTICLE_GONE         = "ARTICLE_GONE"
 
     val VALIDATION_DESCRIPTION = "Validation Error"
     val INVALID_SEARCH_CONTEXT = "INVALID_SEARCH_CONTEXT"
@@ -54,12 +55,15 @@ trait ErrorHelpers {
     val INVALID_SEARCH_CONTEXT_DESCRIPTION =
       "The search-context specified was not expected. Please create one by searching from page 1."
 
+    val ARTICLE_GONE_DESCRIPTION = "The article you are searching for seems to have vanished 👻"
+
     val GenericError: Error         = Error(GENERIC, GENERIC_DESCRIPTION)
     val IndexMissingError: Error    = Error(INDEX_MISSING, INDEX_MISSING_DESCRIPTION)
     val InvalidSearchContext: Error = Error(INVALID_SEARCH_CONTEXT, INVALID_SEARCH_CONTEXT_DESCRIPTION)
 
     case class ResultWindowTooLargeException(message: String = WINDOW_TOO_LARGE_DESCRIPTION)
         extends RuntimeException(message)
+    case class ArticleGoneException(message: String = ARTICLE_GONE_DESCRIPTION) extends RuntimeException(message)
   }
 
 }

--- a/article-api/src/main/scala/no/ndla/articleapi/model/domain/ArticleRow.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/model/domain/ArticleRow.scala
@@ -12,6 +12,7 @@ import no.ndla.common.model.domain.article.Article
 
 case class ArticleRow(
     rowId: Long,
+    revision: Int,
     articleId: Long,
     article: Option[Article]
 )

--- a/article-api/src/main/scala/no/ndla/articleapi/model/domain/ArticleRow.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/model/domain/ArticleRow.scala
@@ -1,0 +1,38 @@
+/*
+ * Part of NDLA article-api.
+ * Copyright (C) 2022 NDLA
+ *
+ * See LICENSE
+ *
+ */
+
+package no.ndla.articleapi.model.domain
+
+import no.ndla.common.model.domain.article.Article
+
+case class ArticleRow(
+    rowId: Long,
+    articleId: Long,
+    article: Option[Article]
+)
+
+object ArticleRow {
+
+  /** Implicit class to add helper methods to `Option[ArticleRow]` */
+  implicit class OptionalArticleRow(articleRow: Option[ArticleRow]) {
+    def toArticle: Option[Article] = articleRow.flatMap(_.article)
+
+    def mapArticle(func: Article => Article): Option[ArticleRow] = {
+      articleRow.map(ar =>
+        ar.copy(
+          article = ar.article.map(func)
+        )
+      )
+    }
+  }
+
+  /** Implicit class to add helper methods to `List[ArticleRow]` */
+  implicit class ArticleRows(articleRows: Seq[ArticleRow]) {
+    def toArticles: Seq[Article] = articleRows.flatMap(_.article)
+  }
+}

--- a/article-api/src/main/scala/no/ndla/articleapi/model/domain/DBArticle.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/model/domain/DBArticle.scala
@@ -33,17 +33,19 @@ trait DBArticle {
       val articleId = rs.long(lp.c("article_id"))
       val rowId     = rs.long(lp.c("id"))
       val document  = rs.stringOpt(lp.c("document"))
+      val revision  = rs.int(lp.c("revision"))
 
       val article = document.map(jsonStr => {
         val meta = read[Article](jsonStr)
         meta.copy(
           id = Some(articleId),
-          revision = Some(rs.int(lp.c("revision")))
+          revision = Some(revision)
         )
       })
 
       ArticleRow(
         rowId = rowId,
+        revision = revision,
         articleId = articleId,
         article = article
       )

--- a/article-api/src/main/scala/no/ndla/articleapi/model/domain/DBArticle.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/model/domain/DBArticle.scala
@@ -24,20 +24,29 @@ trait DBArticle {
     override val tableName   = "contentdata"
     override lazy val schemaName: Option[String] = Some(props.MetaSchema)
 
-    def fromResultSet(lp: SyntaxProvider[Article])(rs: WrappedResultSet): Option[Article] =
+    def fromResultSet(lp: SyntaxProvider[Article])(rs: WrappedResultSet): ArticleRow =
       fromResultSet(lp.resultName)(rs)
 
-    def fromResultSet(lp: ResultName[Article])(rs: WrappedResultSet): Option[Article] = {
+    def fromResultSet(lp: ResultName[Article])(rs: WrappedResultSet): ArticleRow = {
       implicit val formats: Formats = repositorySerializer
 
-      rs.stringOpt(lp.c("document"))
-        .map(jsonStr => {
-          val meta = read[Article](jsonStr)
-          meta.copy(
-            id = Some(rs.long(lp.c("article_id"))),
-            revision = Some(rs.int(lp.c("revision")))
-          )
-        })
+      val articleId = rs.long(lp.c("article_id"))
+      val rowId     = rs.long(lp.c("id"))
+      val document  = rs.stringOpt(lp.c("document"))
+
+      val article = document.map(jsonStr => {
+        val meta = read[Article](jsonStr)
+        meta.copy(
+          id = Some(articleId),
+          revision = Some(rs.int(lp.c("revision")))
+        )
+      })
+
+      ArticleRow(
+        rowId = rowId,
+        articleId = articleId,
+        article = article
+      )
     }
 
     val repositorySerializer: Formats = jsonEncoder +

--- a/article-api/src/main/scala/no/ndla/articleapi/service/ReadService.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/service/ReadService.scala
@@ -14,7 +14,7 @@ import io.lemonlabs.uri.{Path, Url}
 import no.ndla.articleapi.Props
 import no.ndla.articleapi.caching.MemoizeHelpers
 import no.ndla.articleapi.model.api
-import no.ndla.articleapi.model.api.{ArticleSummaryV2, NotFoundException}
+import no.ndla.articleapi.model.api.{ArticleSummaryV2, ErrorHelpers, NotFoundException}
 import no.ndla.articleapi.model.domain._
 import no.ndla.articleapi.model.search.SearchResult
 import no.ndla.articleapi.repository.ArticleRepository
@@ -22,7 +22,7 @@ import no.ndla.articleapi.service.search.{ArticleSearchService, SearchConverterS
 import no.ndla.common.configuration.Constants.EmbedTagName
 import no.ndla.common.errors.{AccessDeniedException, ValidationException}
 import no.ndla.common.model.domain.article.Article
-import no.ndla.common.model.domain.{ArticleType, Availability, Content}
+import no.ndla.common.model.domain.{ArticleType, Availability}
 import no.ndla.network.clients.FeideApiClient
 import no.ndla.validation.HtmlTagRules.{jsoupDocumentToString, stringToJsoupDocument}
 import no.ndla.validation.{ResourceType, TagAttributes}
@@ -39,10 +39,12 @@ trait ReadService {
     with ArticleSearchService
     with SearchConverterService
     with MemoizeHelpers
-    with Props =>
+    with Props
+    with ErrorHelpers =>
   val readService: ReadService
 
   class ReadService extends StrictLogging {
+    import ErrorHelpers.ArticleGoneException
 
     def getInternalIdByExternalId(externalId: Long): Option[api.ArticleIdV2] =
       articleRepository.getIdFromExternalId(externalId.toString).map(api.ArticleIdV2)
@@ -50,22 +52,21 @@ trait ReadService {
     def withIdV2(
         id: Long,
         language: String,
-        fallback: Boolean = false,
-        revision: Option[Int] = None,
-        feideAccessToken: Option[String] = None
+        fallback: Boolean,
+        revision: Option[Int],
+        feideAccessToken: Option[String]
     ): Try[Cachable[api.ArticleV2]] = {
       val article = revision match {
         case Some(rev) => articleRepository.withIdAndRevision(id, rev)
         case None      => articleRepository.withId(id)
       }
 
-      lazy val notFound = Failure(NotFoundException(s"The article with id $id was not found"))
-
-      article.map(addUrlsOnEmbedResources) match {
-        case None => notFound
-        case Some(article) if article.availability == Availability.everyone =>
+      article.mapArticle(addUrlsOnEmbedResources) match {
+        case None                         => Failure(NotFoundException(s"The article with id $id was not found"))
+        case Some(ArticleRow(_, _, None)) => Failure(ArticleGoneException())
+        case Some(ArticleRow(_, _, Some(article))) if article.availability == Availability.everyone =>
           Cachable.yes(converterService.toApiArticleV2(article, language, fallback))
-        case Some(article) =>
+        case Some(ArticleRow(_, _, Some(article))) =>
           feideApiClient
             .getFeideExtendedUser(feideAccessToken)
             .flatMap(feideUser =>
@@ -152,12 +153,6 @@ trait ReadService {
         case revisions => Success(revisions)
       }
     }
-
-    def getContentByExternalId(externalId: String): Option[Content] =
-      articleRepository.withExternalId(externalId)
-
-    def getArticleIdByExternalId(externalId: String): Option[Long] =
-      articleRepository.getIdFromExternalId(externalId)
 
     def getArticleIdsByExternalId(externalId: String): Option[api.ArticleIds] =
       articleRepository.getArticleIdsFromExternalId(externalId).map(converterService.toApiArticleIds)
@@ -251,7 +246,7 @@ trait ReadService {
       if (articleIds.isEmpty) Failure(ValidationException("ids", "Query parameter 'ids' is missing"))
       else {
         val offset         = (page - 1) * pageSize
-        val domainArticles = articleRepository.withIds(articleIds, offset, pageSize)
+        val domainArticles = articleRepository.withIds(articleIds, offset, pageSize).toArticles
         val isFeideNeeded  = domainArticles.exists(article => article.availability == Availability.teacher)
         val filtered = if (isFeideNeeded) applyAvailabilityFilter(feideAccessToken, domainArticles) else domainArticles
         filtered.traverse(article => converterService.toApiArticleV2(article, language, fallback))

--- a/article-api/src/main/scala/no/ndla/articleapi/service/ReadService.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/service/ReadService.scala
@@ -62,11 +62,11 @@ trait ReadService {
       }
 
       article.mapArticle(addUrlsOnEmbedResources) match {
-        case None                         => Failure(NotFoundException(s"The article with id $id was not found"))
-        case Some(ArticleRow(_, _, None)) => Failure(ArticleGoneException())
-        case Some(ArticleRow(_, _, Some(article))) if article.availability == Availability.everyone =>
+        case None                            => Failure(NotFoundException(s"The article with id $id was not found"))
+        case Some(ArticleRow(_, _, _, None)) => Failure(ArticleGoneException())
+        case Some(ArticleRow(_, _, _, Some(article))) if article.availability == Availability.everyone =>
           Cachable.yes(converterService.toApiArticleV2(article, language, fallback))
-        case Some(ArticleRow(_, _, Some(article))) =>
+        case Some(ArticleRow(_, _, _, Some(article))) =>
           feideApiClient
             .getFeideExtendedUser(feideAccessToken)
             .flatMap(feideUser =>

--- a/article-api/src/main/scala/no/ndla/articleapi/service/WriteService.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/service/WriteService.scala
@@ -79,7 +79,7 @@ trait WriteService {
         language: String,
         fallback: Boolean
     ): Try[api.ArticleV2] = {
-      articleRepository.withId(articleId) match {
+      articleRepository.withId(articleId).toArticle match {
         case None => Failure(NotFoundException(s"Could not find article with id '$articleId' to partial publish"))
         case Some(existingArticle) =>
           val newArticle  = converterService.updateArticleFields(existingArticle, partialArticle)

--- a/article-api/src/test/scala/no/ndla/articleapi/UnitSuite.scala
+++ b/article-api/src/test/scala/no/ndla/articleapi/UnitSuite.scala
@@ -8,6 +8,8 @@
 
 package no.ndla.articleapi
 
+import no.ndla.articleapi.model.domain.ArticleRow
+import no.ndla.common.model.domain.article.Article
 import no.ndla.scalatestsuite.UnitTestSuite
 
 import scala.util.Properties.setProp
@@ -29,4 +31,13 @@ trait UnitSuite extends UnitTestSuite {
   setProp("BRIGHTCOVE_API_CLIENT_ID", "some-client-id")
   setProp("BRIGHTCOVE_API_CLIENT_SECRET", "some-secret")
   setProp("SEARCH_INDEX_NAME", "article-integration-test-index")
+
+  def toArticleRow(article: Article): ArticleRow = {
+    ArticleRow(
+      rowId = article.id.get,
+      articleId = article.id.get,
+      article = Some(article)
+    )
+  }
+
 }

--- a/article-api/src/test/scala/no/ndla/articleapi/UnitSuite.scala
+++ b/article-api/src/test/scala/no/ndla/articleapi/UnitSuite.scala
@@ -35,6 +35,7 @@ trait UnitSuite extends UnitTestSuite {
   def toArticleRow(article: Article): ArticleRow = {
     ArticleRow(
       rowId = article.id.get,
+      revision = article.revision.get,
       articleId = article.id.get,
       article = Some(article)
     )

--- a/article-api/src/test/scala/no/ndla/articleapi/controller/ArticleControllerV2Test.scala
+++ b/article-api/src/test/scala/no/ndla/articleapi/controller/ArticleControllerV2Test.scala
@@ -51,7 +51,8 @@ class ArticleControllerV2Test extends UnitSuite with TestEnvironment with Scalat
   val articleId       = 1
 
   test("/<article_id> should return 200 if the cover was found withIdV2") {
-    when(readService.withIdV2(articleId, lang)).thenReturn(Success(domain.Cachable.yes(TestData.sampleArticleV2)))
+    when(readService.withIdV2(articleId, lang, fallback = false, None, None))
+      .thenReturn(Success(domain.Cachable.yes(TestData.sampleArticleV2)))
 
     get(s"/test/$articleId?language=$lang") {
       status should equal(200)
@@ -59,7 +60,8 @@ class ArticleControllerV2Test extends UnitSuite with TestEnvironment with Scalat
   }
 
   test("/<article_id> should return 404 if the article was not found withIdV2") {
-    when(readService.withIdV2(articleId, lang)).thenReturn(Failure(api.NotFoundException("Not found")))
+    when(readService.withIdV2(articleId, lang, fallback = false, None, None))
+      .thenReturn(Failure(api.NotFoundException("Not found")))
 
     get(s"/test/$articleId?language=$lang") {
       status should equal(404)

--- a/article-api/src/test/scala/no/ndla/articleapi/repository/ArticleRepositoryTest.scala
+++ b/article-api/src/test/scala/no/ndla/articleapi/repository/ArticleRepositoryTest.scala
@@ -101,7 +101,7 @@ class ArticleRepositoryTest
     val Success(res: Article) = repository.updateArticleFromDraftApi(sampleArticle, externalIds)
 
     res.id.isDefined should be(true)
-    repository.withId(res.id.get).get should be(sampleArticle)
+    repository.withId(res.id.get).get.article.get should be(sampleArticle)
   }
 
   test("Fetching external ids works as expected") {
@@ -162,9 +162,9 @@ class ArticleRepositoryTest
     val art3 =
       repository.updateArticleFromDraftApi(TestData.sampleArticleWithCopyrighted.copy(id = Some(3)), List.empty).get
 
-    repository.withId(1) should be(Some(art1))
-    repository.withId(2) should be(Some(art2))
-    repository.withId(3) should be(Some(art3))
+    repository.withId(1).get.article should be(Some(art1))
+    repository.withId(2).get.article should be(Some(art2))
+    repository.withId(3).get.article should be(Some(art3))
   }
 
   test("getTags returns non-duplicate tags and correct number of them") {
@@ -247,7 +247,7 @@ class ArticleRepositoryTest
       List("6000", "10")
     )
 
-    val Right(relatedId) = repository.withId(1).get.relatedContent.head
+    val Right(relatedId) = repository.withId(1).toArticle.get.relatedContent.head
     relatedId.toLong should be(2L)
   }
 

--- a/article-api/src/test/scala/no/ndla/articleapi/service/ReadServiceTest.scala
+++ b/article-api/src/test/scala/no/ndla/articleapi/service/ReadServiceTest.scala
@@ -61,7 +61,7 @@ class ReadServiceTest extends UnitSuite with TestEnvironment {
       visualElement = Seq(VisualElement(visualElementBefore, "nb"))
     )
 
-    when(articleRepository.withId(1)).thenReturn(Option(article))
+    when(articleRepository.withId(1)).thenReturn(Some(toArticleRow(article)))
     when(articleRepository.getExternalIdsFromId(any[Long])(any[DBSession])).thenReturn(List("54321"))
 
     val expectedResult: Try[Cachable[api.ArticleV2]] = Cachable.yes(
@@ -71,7 +71,7 @@ class ReadServiceTest extends UnitSuite with TestEnvironment {
         "nb"
       )
     )
-    readService.withIdV2(1, "nb") should equal(expectedResult)
+    readService.withIdV2(1, "nb", fallback = false, None, None) should equal(expectedResult)
   }
 
   test("addIdAndUrlOnResource adds an id and url attribute on embed-resoures with a data-resource_id attribute") {
@@ -164,7 +164,8 @@ class ReadServiceTest extends UnitSuite with TestEnvironment {
     val article2 = TestData.sampleDomainArticle.copy(id = Some(2), availability = Availability.everyone)
     val article3 = TestData.sampleDomainArticle.copy(id = Some(3), availability = Availability.everyone)
 
-    when(articleRepository.withIds(any, any, any)(any)).thenReturn(Seq(article1, article2, article3))
+    when(articleRepository.withIds(any, any, any)(any))
+      .thenReturn(Seq(toArticleRow(article1), toArticleRow(article2), toArticleRow(article3)))
     when(articleRepository.getExternalIdsFromId(any)(any)).thenReturn(List(""), List(""), List(""))
 
     val Success(result) =
@@ -190,7 +191,8 @@ class ReadServiceTest extends UnitSuite with TestEnvironment {
     val teacherUser = FeideExtendedUserInfo("", eduPersonAffiliation = Seq("employee"), "")
 
     when(feideApiClient.getFeideExtendedUser(any)).thenReturn(Success(teacherUser))
-    when(articleRepository.withIds(any, any, any)(any)).thenReturn(Seq(article1, article2, article3))
+    when(articleRepository.withIds(any, any, any)(any))
+      .thenReturn(Seq(toArticleRow(article1), toArticleRow(article2), toArticleRow(article3)))
     when(articleRepository.getExternalIdsFromId(any)(any)).thenReturn(List(""), List(""), List(""))
 
     val Success(result) =
@@ -216,7 +218,8 @@ class ReadServiceTest extends UnitSuite with TestEnvironment {
     val teacherUser = FeideExtendedUserInfo("", eduPersonAffiliation = Seq("student"), "")
 
     when(feideApiClient.getFeideExtendedUser(any)).thenReturn(Success(teacherUser))
-    when(articleRepository.withIds(any, any, any)(any)).thenReturn(Seq(article1, article2, article3))
+    when(articleRepository.withIds(any, any, any)(any))
+      .thenReturn(Seq(toArticleRow(article1), toArticleRow(article2), toArticleRow(article3)))
     when(articleRepository.getExternalIdsFromId(any)(any)).thenReturn(List(""), List(""), List(""))
 
     val Success(result) =
@@ -241,7 +244,8 @@ class ReadServiceTest extends UnitSuite with TestEnvironment {
     val article2 = TestData.sampleDomainArticle.copy(id = Some(2), availability = Availability.everyone)
     val article3 = TestData.sampleDomainArticle.copy(id = Some(3), availability = Availability.teacher)
 
-    when(articleRepository.withIds(any, any, any)(any)).thenReturn(Seq(article1, article2, article3))
+    when(articleRepository.withIds(any, any, any)(any))
+      .thenReturn(Seq(toArticleRow(article1), toArticleRow(article2), toArticleRow(article3)))
     when(articleRepository.getExternalIdsFromId(any)(any)).thenReturn(List(""), List(""), List(""))
     when(feideApiClient.getFeideExtendedUser(any)).thenReturn(Failure(new RuntimeException))
 

--- a/article-api/src/test/scala/no/ndla/articleapi/service/WriteServiceTest.scala
+++ b/article-api/src/test/scala/no/ndla/articleapi/service/WriteServiceTest.scala
@@ -32,7 +32,7 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
   override def beforeEach(): Unit = {
     Mockito.reset(articleIndexService, articleRepository)
 
-    when(articleRepository.withId(articleId)).thenReturn(Option(article))
+    when(articleRepository.withId(articleId)).thenReturn(Option(toArticleRow(article)))
     when(articleIndexService.indexDocument(any[Article])).thenAnswer((invocation: InvocationOnMock) =>
       Try(invocation.getArgument[Article](0))
     )
@@ -53,7 +53,7 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
     val updatedAndInserted = articleToUpdate
       .copy(revision = articleToUpdate.revision.map(_ + 1), updated = today)
 
-    when(articleRepository.withId(10)).thenReturn(Some(articleToUpdate))
+    when(articleRepository.withId(10)).thenReturn(Some(toArticleRow(articleToUpdate)))
     when(articleRepository.updateArticleFromDraftApi(any[Article], anyList)(any[DBSession]))
       .thenReturn(Success(updatedAndInserted))
 


### PR DESCRIPTION
Relates to https://github.com/NDLANO/Issues/issues/3386

Lager en wrapper klasse for å ha kontroll på forskjellen på document=`NULL` og en manglende rad.