### PR TITLE
article-api: Support fetching article by slug if more than one revision

### DIFF
--- a/article-api/src/main/scala/no/ndla/articleapi/repository/ArticleRepository.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/repository/ArticleRepository.scala
@@ -118,14 +118,14 @@ trait ArticleRepository {
       }
     }
 
-    def withSlug(slug: String): Option[ArticleRow] = articleWhere(sqls"ar.slug=$slug")
+    def withSlug(slug: String): Option[ArticleRow] = articleWhere(sqls"ar.slug=$slug ORDER BY revision DESC LIMIT 1")
 
     def withId(articleId: Long): Option[ArticleRow] =
       articleWhere(
         sqls"""
               ar.article_id=${articleId.toInt}
-              ORDER BY revision
-              DESC LIMIT 1
+              ORDER BY revision DESC
+              LIMIT 1
               """
       )
 

--- a/article-api/src/test/scala/no/ndla/articleapi/repository/ArticleRepositoryTest.scala
+++ b/article-api/src/test/scala/no/ndla/articleapi/repository/ArticleRepositoryTest.scala
@@ -269,4 +269,20 @@ class ArticleRepositoryTest
     resultAfter.size should be(0)
   }
 
+  test("That fetching with slugs works as expected with revisions") {
+    assume(databaseIsAvailable, "Database is unavailable")
+    val articleId = 110
+    val article   = TestData.sampleDomainArticle.copy(id = Some(articleId), slug = Some("Detti-er-ein-slug"))
+
+    val article1 = article.copy(revision = 1.some)
+    val article2 = article.copy(revision = 2.some)
+    val article3 = article.copy(revision = 3.some)
+
+    repository.updateArticleFromDraftApi(article1, List.empty).get
+    repository.updateArticleFromDraftApi(article2, List.empty).get
+    repository.updateArticleFromDraftApi(article3, List.empty).get
+
+    repository.withSlug("Detti-er-ein-slug").get.article.get should be(article3)
+  }
+
 }


### PR DESCRIPTION
Small bug by not filtering out older revisions in the SQL :^)