### PR TITLE
Map urls to embeds

### DIFF
--- a/article-api/src/main/scala/no/ndla/articleapi/service/ReadService.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/service/ReadService.scala
@@ -81,7 +81,7 @@ trait ReadService {
     }
 
     def getArticleBySlug(slug: String, language: String, fallback: Boolean = false): Try[Cachable[api.ArticleV2]] = {
-      articleRepository.withSlug(slug) match {
+      articleRepository.withSlug(slug).mapArticle(addUrlsOnEmbedResources) match {
         case None => Failure(NotFoundException(s"The article with slug '$slug' was not found"))
         case Some(ArticleRow(_, _, _, _, None)) => Failure(ArticleGoneException())
         case Some(ArticleRow(_, _, _, _, Some(article))) if article.availability == Availability.everyone =>


### PR DESCRIPTION
Prøvde å hente ut artikler i frontend, ser at `data-url` mangler når artikkelen blir fetcha. 
Har ikke backend satt opp/aner ikke hvordan man kan teste med lokal swagger men ser at det blir mappa over artikkelen for å legge til URLer når man henter på ID. 