### PR TITLE
Add custom `BAD REQUEST` json response body for request decoding

### DIFF
--- a/frontpage-api/src/main/scala/no/ndla/frontpageapi/ComponentRegistry.scala
+++ b/frontpage-api/src/main/scala/no/ndla/frontpageapi/ComponentRegistry.scala
@@ -10,6 +10,7 @@ package no.ndla.frontpageapi
 import cats.data.Kleisli
 import cats.effect.IO
 import com.zaxxer.hikari.HikariDataSource
+import no.ndla.common.Clock
 import no.ndla.frontpageapi.controller._
 import no.ndla.frontpageapi.integration.DataSource
 import no.ndla.frontpageapi.model.api.ErrorHelpers
@@ -33,6 +34,7 @@ class ComponentRegistry(properties: FrontpageApiProperties)
     with DBSubjectFrontPageData
     with DBFrontPageData
     with ErrorHelpers
+    with Clock
     with Props
     with DBMigrator
     with ConverterService
@@ -45,6 +47,8 @@ class ComponentRegistry(properties: FrontpageApiProperties)
   override val migrator                      = new DBMigrator
   override val dataSource: HikariDataSource  = DataSource.getHikariDataSource
   DataSource.connectToDatabase()
+
+  override val clock = new SystemClock
 
   override val subjectPageRepository   = new SubjectPageRepository
   override val frontPageRepository     = new FrontPageRepository

--- a/frontpage-api/src/main/scala/no/ndla/frontpageapi/model/api/Error.scala
+++ b/frontpage-api/src/main/scala/no/ndla/frontpageapi/model/api/Error.scala
@@ -7,6 +7,8 @@
 
 package no.ndla.frontpageapi.model.api
 
+import no.ndla.common.Clock
+
 import java.time.LocalDateTime
 import no.ndla.frontpageapi.Props
 
@@ -23,7 +25,7 @@ case class UnauthorizedError(code: String, description: String, occuredAt: Local
 case class ForbiddenError(code: String, description: String, occuredAt: LocalDateTime)
 
 trait ErrorHelpers {
-  this: Props =>
+  this: Props with Clock =>
 
   object ErrorHelpers {
     val GENERIC              = "GENERIC"
@@ -40,12 +42,12 @@ trait ErrorHelpers {
     val UNAUTHORIZED_DESCRIPTION = "Missing user/client-id or role"
     val FORBIDDEN_DESCRIPTION    = "You do not have the required permissions to access that resource"
 
-    def generic: GenericError                    = GenericError(GENERIC, GENERIC_DESCRIPTION, LocalDateTime.now)
-    def notFound: NotFoundError                  = NotFoundError(NOT_FOUND, NOT_FOUND_DESCRIPTION, LocalDateTime.now)
-    def badRequest(msg: String): BadRequestError = BadRequestError(BAD_REQUEST, msg, LocalDateTime.now)
+    def generic: GenericError                    = GenericError(GENERIC, GENERIC_DESCRIPTION, clock.now())
+    def notFound: NotFoundError                  = NotFoundError(NOT_FOUND, NOT_FOUND_DESCRIPTION, clock.now())
+    def badRequest(msg: String): BadRequestError = BadRequestError(BAD_REQUEST, msg, clock.now())
     def unprocessableEntity(msg: String): UnprocessableEntityError =
-      UnprocessableEntityError(UNPROCESSABLE_ENTITY, msg, LocalDateTime.now)
-    def unauthorized: UnauthorizedError = UnauthorizedError(UNAUTHORIZED, UNAUTHORIZED_DESCRIPTION, LocalDateTime.now)
-    def forbidden: ForbiddenError       = ForbiddenError(FORBIDDEN, FORBIDDEN_DESCRIPTION, LocalDateTime.now)
+      UnprocessableEntityError(UNPROCESSABLE_ENTITY, msg, clock.now())
+    def unauthorized: UnauthorizedError = UnauthorizedError(UNAUTHORIZED, UNAUTHORIZED_DESCRIPTION, clock.now())
+    def forbidden: ForbiddenError       = ForbiddenError(FORBIDDEN, FORBIDDEN_DESCRIPTION, clock.now())
   }
 }

--- a/frontpage-api/src/test/scala/no/ndla/frontpageapi/FilmPageControllerTest.scala
+++ b/frontpage-api/src/test/scala/no/ndla/frontpageapi/FilmPageControllerTest.scala
@@ -47,6 +47,7 @@ class FilmPageControllerTest extends UnitSuite with TestEnvironment {
   }
 
   test("Should return 404 when no frontpage found") {
+    when(clock.now()).thenCallRealMethod()
     when(readService.filmFrontPage(None)).thenReturn(None)
     val response =
       simpleHttpClient.send(quickRequest.get(uri"http://localhost:$serverPort/frontpage-api/v1/filmfrontpage"))

--- a/frontpage-api/src/test/scala/no/ndla/frontpageapi/SubjectPageControllerTest.scala
+++ b/frontpage-api/src/test/scala/no/ndla/frontpageapi/SubjectPageControllerTest.scala
@@ -1,0 +1,58 @@
+/*
+ * Part of NDLA frontpage-api
+ * Copyright (C) 2023 NDLA
+ *
+ * See LICENSE
+ */
+
+package no.ndla.frontpageapi
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import com.comcast.ip4s.{Host, Port}
+import io.circe.syntax.EncoderOps
+import io.circe.generic.auto._
+import org.http4s.ember.server.EmberServerBuilder
+import sttp.client3.quick._
+
+import java.time.LocalDateTime
+
+class SubjectPageControllerTest extends UnitSuite with TestEnvironment {
+
+  val serverPort: Int = findFreePort
+
+  override val subjectPageController = new SubjectPageController()
+
+  override def beforeAll(): Unit = {
+    val app = Routes.build(List(subjectPageController))
+
+    var serverReady = false
+
+    EmberServerBuilder
+      .default[IO]
+      .withHost(Host.fromString("0.0.0.0").get)
+      .withPort(Port.fromInt(serverPort).get)
+      .withHttpApp(app)
+      .build
+      .use(server => {
+        IO {
+          println(s"${this.getClass.toString} is running server on ${server.address}")
+          serverReady = true
+        }.flatMap(_ => IO.never)
+      })
+      .unsafeToFuture()
+    blockUntil(() => serverReady)
+  }
+
+  test("Should return 400 with cool custom message if bad request") {
+    when(clock.now()).thenReturn(LocalDateTime.now())
+    val response =
+      simpleHttpClient.send(
+        quickRequest.get(uri"http://localhost:$serverPort/frontpage-api/v1/subjectpage/1?fallback=noefeil")
+      )
+    response.code.code should equal(400)
+    val expectedBody = ErrorHelpers.badRequest("Invalid value for: query parameter fallback").asJson.noSpaces
+    response.body should be(expectedBody)
+  }
+
+}

--- a/frontpage-api/src/test/scala/no/ndla/frontpageapi/TestEnvironment.scala
+++ b/frontpage-api/src/test/scala/no/ndla/frontpageapi/TestEnvironment.scala
@@ -8,7 +8,8 @@
 package no.ndla.frontpageapi
 
 import com.zaxxer.hikari.HikariDataSource
-import no.ndla.frontpageapi.controller.{FilmPageController, NdlaMiddleware, Service}
+import no.ndla.common.Clock
+import no.ndla.frontpageapi.controller.{FilmPageController, NdlaMiddleware, Service, SubjectPageController}
 import no.ndla.frontpageapi.integration.DataSource
 import no.ndla.frontpageapi.model.api.ErrorHelpers
 import no.ndla.frontpageapi.model.domain.{DBFilmFrontPageData, DBFrontPageData, DBSubjectFrontPageData}
@@ -23,6 +24,7 @@ trait TestEnvironment
     with FrontPageRepository
     with FilmFrontPageRepository
     with FilmPageController
+    with SubjectPageController
     with Service
     with NdlaMiddleware
     with ReadService
@@ -33,14 +35,17 @@ trait TestEnvironment
     with DBSubjectFrontPageData
     with DBFrontPageData
     with ErrorHelpers
+    with Clock
     with DBMigrator
     with Routes {
   override val props = new FrontpageApiProperties
 
+  override val clock      = mock[SystemClock]
   override val migrator   = mock[DBMigrator]
   override val dataSource = mock[HikariDataSource]
 
   override val filmPageController      = mock[FilmPageController]
+  override val subjectPageController   = mock[SubjectPageController]
   override val subjectPageRepository   = mock[SubjectPageRepository]
   override val frontPageRepository     = mock[FrontPageRepository]
   override val filmFrontPageRepository = mock[FilmFrontPageRepository]


### PR DESCRIPTION
La merke til at vi tidligere bare fallbacka til `GENERIC` responsbody for 400 requests så la til en `BAD REQUEST` greie som ligner litt mer på det vi gjør i andre apier.