### PR TITLE
Index search-api synchronized

### DIFF
--- a/integration-tests/src/test/scala/no/ndla/integrationtests/searchapi/articleapi/ArticleApiClientTest.scala
+++ b/integration-tests/src/test/scala/no/ndla/integrationtests/searchapi/articleapi/ArticleApiClientTest.scala
@@ -25,8 +25,6 @@ import org.json4s.Formats
 import org.json4s.ext.{EnumNameSerializer, JavaTimeSerializers}
 import org.testcontainers.containers.PostgreSQLContainer
 
-import scala.concurrent.duration.Duration
-import scala.concurrent.{Await, ExecutionContext, ExecutionContextExecutor}
 import scala.util.{Failure, Success, Try}
 
 class ArticleApiClientTest
@@ -74,7 +72,7 @@ class ArticleApiClientTest
 
   val exampleToken =
     "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6Ik9FSTFNVVU0T0RrNU56TTVNekkyTXpaRE9EazFOMFl3UXpkRE1EUXlPRFZDUXpRM1FUSTBNQSJ9.eyJodHRwczovL25kbGEubm8vY2xpZW50X2lkIjogInh4eHl5eSIsICJpc3MiOiAiaHR0cHM6Ly9uZGxhLmV1LmF1dGgwLmNvbS8iLCAic3ViIjogInh4eHl5eUBjbGllbnRzIiwgImF1ZCI6ICJuZGxhX3N5c3RlbSIsICJpYXQiOiAxNTEwMzA1NzczLCAiZXhwIjogMTUxMDM5MjE3MywgInNjb3BlIjogImFydGljbGVzLXRlc3Q6cHVibGlzaCBkcmFmdHMtdGVzdDp3cml0ZSBkcmFmdHMtdGVzdDpzZXRfdG9fcHVibGlzaCBhcnRpY2xlcy10ZXN0OndyaXRlIiwgImd0eSI6ICJjbGllbnQtY3JlZGVudGlhbHMifQ.gsM-U84ykgaxMSbL55w6UYIIQUouPIB6YOmJuj1KhLFnrYctu5vwYBo80zyr1je9kO_6L-rI7SUnrHVao9DFBZJmfFfeojTxIT3CE58hoCdxZQZdPUGePjQzROWRWeDfG96iqhRcepjbVF9pMhKp6FNqEVOxkX00RZg9vFT8iMM"
-  val authHeaderMap = Map("Authorization" -> s"Bearer $exampleToken")
+  val authHeaderMap: Map[String, String] = Map("Authorization" -> s"Bearer $exampleToken")
 
   class LocalArticleApiTestData extends articleapi.Props with articleapi.TestData {
     override val props: ArticleApiProperties = articleApiProperties
@@ -106,9 +104,8 @@ class ArticleApiClientTest
     AuthUser.setHeader(s"Bearer $exampleToken")
     val articleApiClient = new ArticleApiClient(articleApiBaseUrl)
 
-    implicit val ec: ExecutionContextExecutor = ExecutionContext.global
-    val chunks                                = articleApiClient.getChunks[Article].toList
-    val fetchedArticle                        = Await.result(chunks.head, Duration.Inf).get.head
+    val chunks         = articleApiClient.getChunks[Article].toList
+    val fetchedArticle = chunks.head.get.head
     val searchable = searchConverterService
       .asSearchableArticle(fetchedArticle, Some(TestData.taxonomyTestBundle), Some(TestData.emptyGrepBundle))
 

--- a/integration-tests/src/test/scala/no/ndla/integrationtests/searchapi/draftapi/DraftApiClientTest.scala
+++ b/integration-tests/src/test/scala/no/ndla/integrationtests/searchapi/draftapi/DraftApiClientTest.scala
@@ -23,9 +23,6 @@ import org.json4s.Formats
 import org.json4s.ext.{EnumNameSerializer, JavaTimeSerializers}
 import org.testcontainers.containers.PostgreSQLContainer
 
-import scala.concurrent.duration.Duration
-import scala.concurrent.{Await, ExecutionContext}
-
 class DraftApiClientTest
     extends IntegrationSuite(EnablePostgresContainer = true, EnableElasticsearchContainer = true)
     with UnitSuite
@@ -82,7 +79,7 @@ class DraftApiClientTest
 
   val exampleToken =
     "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6Ik9FSTFNVVU0T0RrNU56TTVNekkyTXpaRE9EazFOMFl3UXpkRE1EUXlPRFZDUXpRM1FUSTBNQSJ9.eyJodHRwczovL25kbGEubm8vY2xpZW50X2lkIjogInh4eHl5eSIsICJpc3MiOiAiaHR0cHM6Ly9uZGxhLmV1LmF1dGgwLmNvbS8iLCAic3ViIjogInh4eHl5eUBjbGllbnRzIiwgImF1ZCI6ICJuZGxhX3N5c3RlbSIsICJpYXQiOiAxNTEwMzA1NzczLCAiZXhwIjogMTUxMDM5MjE3MywgInNjb3BlIjogImFydGljbGVzLXRlc3Q6cHVibGlzaCBkcmFmdHMtdGVzdDp3cml0ZSBkcmFmdHMtdGVzdDpzZXRfdG9fcHVibGlzaCBhcnRpY2xlcy10ZXN0OndyaXRlIiwgImd0eSI6ICJjbGllbnQtY3JlZGVudGlhbHMifQ.gsM-U84ykgaxMSbL55w6UYIIQUouPIB6YOmJuj1KhLFnrYctu5vwYBo80zyr1je9kO_6L-rI7SUnrHVao9DFBZJmfFfeojTxIT3CE58hoCdxZQZdPUGePjQzROWRWeDfG96iqhRcepjbVF9pMhKp6FNqEVOxkX00RZg9vFT8iMM"
-  val authHeaderMap = Map("Authorization" -> s"Bearer $exampleToken")
+  val authHeaderMap: Map[String, String] = Map("Authorization" -> s"Bearer $exampleToken")
 
   test("that dumping drafts returns drafts in serializable format") {
     setupArticles()
@@ -90,9 +87,8 @@ class DraftApiClientTest
     AuthUser.setHeader(s"Bearer $exampleToken")
     val draftApiClient = new DraftApiClient(draftApiBaseUrl)
 
-    implicit val ec  = ExecutionContext.global
     val chunks       = draftApiClient.getChunks[Draft].toList
-    val fetchedDraft = Await.result(chunks.head, Duration.Inf).get.head
+    val fetchedDraft = chunks.head.get.head
     val searchable = searchConverterService
       .asSearchableDraft(
         fetchedDraft,

--- a/integration-tests/src/test/scala/no/ndla/integrationtests/searchapi/learningpathapi/LearningpathApiClientTest.scala
+++ b/integration-tests/src/test/scala/no/ndla/integrationtests/searchapi/learningpathapi/LearningpathApiClientTest.scala
@@ -24,9 +24,6 @@ import org.json4s.Formats
 import org.json4s.ext.{EnumNameSerializer, JavaTimeSerializers}
 import org.testcontainers.containers.PostgreSQLContainer
 
-import scala.concurrent.duration.Duration
-import scala.concurrent.{Await, ExecutionContext, ExecutionContextExecutor}
-
 class LearningpathApiClientTest
     extends IntegrationSuite(EnableElasticsearchContainer = true, EnablePostgresContainer = true)
     with UnitSuite
@@ -80,7 +77,7 @@ class LearningpathApiClientTest
 
   val exampleToken =
     "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6Ik9FSTFNVVU0T0RrNU56TTVNekkyTXpaRE9EazFOMFl3UXpkRE1EUXlPRFZDUXpRM1FUSTBNQSJ9.eyJodHRwczovL25kbGEubm8vY2xpZW50X2lkIjogInh4eHl5eSIsICJpc3MiOiAiaHR0cHM6Ly9uZGxhLmV1LmF1dGgwLmNvbS8iLCAic3ViIjogInh4eHl5eUBjbGllbnRzIiwgImF1ZCI6ICJuZGxhX3N5c3RlbSIsICJpYXQiOiAxNTEwMzA1NzczLCAiZXhwIjogMTUxMDM5MjE3MywgInNjb3BlIjogImFydGljbGVzLXRlc3Q6cHVibGlzaCBkcmFmdHMtdGVzdDp3cml0ZSBkcmFmdHMtdGVzdDpzZXRfdG9fcHVibGlzaCBhcnRpY2xlcy10ZXN0OndyaXRlIiwgImd0eSI6ICJjbGllbnQtY3JlZGVudGlhbHMifQ.gsM-U84ykgaxMSbL55w6UYIIQUouPIB6YOmJuj1KhLFnrYctu5vwYBo80zyr1je9kO_6L-rI7SUnrHVao9DFBZJmfFfeojTxIT3CE58hoCdxZQZdPUGePjQzROWRWeDfG96iqhRcepjbVF9pMhKp6FNqEVOxkX00RZg9vFT8iMM"
-  val authHeaderMap = Map("Authorization" -> s"Bearer $exampleToken")
+  val authHeaderMap: Map[String, String] = Map("Authorization" -> s"Bearer $exampleToken")
 
   test("that dumping learningpaths returns learningpaths in serializable format") {
     setupLearningPaths()
@@ -88,9 +85,8 @@ class LearningpathApiClientTest
     AuthUser.setHeader(s"Bearer $exampleToken")
     val learningPathApiClient = new LearningPathApiClient(learningpathApiBaseUrl)
 
-    implicit val ec: ExecutionContextExecutor = ExecutionContext.global
-    val chunks                                = learningPathApiClient.getChunks[domain.learningpath.LearningPath].toList
-    val fetchedLearningPath                   = Await.result(chunks.head, Duration.Inf).get.head
+    val chunks              = learningPathApiClient.getChunks[domain.learningpath.LearningPath].toList
+    val fetchedLearningPath = chunks.head.get.head
 
     val searchable =
       searchConverterService.asSearchableLearningPath(fetchedLearningPath, Some(searchapi.TestData.taxonomyTestBundle))

--- a/search-api/src/main/scala/no/ndla/searchapi/integration/SearchApiClient.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/integration/SearchApiClient.scala
@@ -10,21 +10,19 @@ package no.ndla.searchapi.integration
 import com.typesafe.scalalogging.StrictLogging
 import enumeratum.Json4s
 import io.lemonlabs.uri.typesafe.dsl._
-import no.ndla.common.model.domain.{ArticleType, Availability}
 import no.ndla.common.model.domain.draft.{DraftStatus, RevisionStatus}
 import no.ndla.common.model.domain.learningpath.EmbedType
+import no.ndla.common.model.domain.{ArticleType, Availability}
 import no.ndla.network.NdlaClient
 import no.ndla.network.model.RequestInfo
 import no.ndla.searchapi.Props
 import no.ndla.searchapi.model.api.ApiSearchException
-import no.ndla.searchapi.model.domain.LearningResourceType
 import no.ndla.searchapi.model.domain.learningpath._
-import no.ndla.searchapi.model.domain.{ApiSearchResults, DomainDumpResults, SearchParams}
+import no.ndla.searchapi.model.domain.{ApiSearchResults, DomainDumpResults, LearningResourceType, SearchParams}
 import org.json4s.Formats
 import org.json4s.ext.{EnumNameSerializer, JavaTimeSerializers, JavaTypesSerializers}
 import sttp.client3.quick._
 
-import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.math.ceil
@@ -51,9 +49,8 @@ trait SearchApiClient {
       }
     }
 
-    def getChunks[T](implicit mf: Manifest[T], ec: ExecutionContext): Iterator[Future[Try[Seq[T]]]] = {
-      val fut     = getChunk(0, 0)
-      val initial = Await.result(fut, 10.minutes)
+    def getChunks[T](implicit mf: Manifest[T]): Iterator[Try[Seq[T]]] = {
+      val initial = getChunk(0, 0)
 
       initial match {
         case Success(initSearch) =>
@@ -62,38 +59,33 @@ trait SearchApiClient {
           val numPages = ceil(dbCount.toDouble / pageSize.toDouble).toInt
           val pages    = Seq.range(1, numPages + 1)
 
-          val iterator: Iterator[Future[Try[Seq[T]]]] = pages.iterator.map(p => {
-            getChunk[T](p, pageSize).map(_.map(_.results))
+          val iterator: Iterator[Try[Seq[T]]] = pages.iterator.map(p => {
+            getChunk[T](p, pageSize).map(_.results)
           })
 
           iterator
         case Failure(ex) =>
           logger.error(s"Could not fetch initial chunk from $baseUrl/$dumpDomainPath")
-          Iterator(Future(Failure(ex)))
+          Iterator(Failure(ex))
       }
     }
 
-    private def getChunk[T](page: Int, pageSize: Int)(implicit
-        mf: Manifest[T],
-        ec: ExecutionContext
-    ): Future[Try[DomainDumpResults[T]]] = {
+    private def getChunk[T](page: Int, pageSize: Int)(implicit mf: Manifest[T]): Try[DomainDumpResults[T]] = {
       val params = Map(
         "page"      -> page.toString,
         "page-size" -> pageSize.toString
       )
       val reqs = RequestInfo()
-      Future {
-        reqs.setRequestInfo()
-        get[DomainDumpResults[T]](dumpDomainPath, params, timeout = 120000) match {
-          case Success(result) =>
-            logger.info(s"Fetched chunk of ${result.results.size} $name from ${baseUrl.addParams(params)}")
-            Success(result)
-          case Failure(ex) =>
-            logger.error(
-              s"Could not fetch chunk on page: '$page', with pageSize: '$pageSize' from '$baseUrl/$dumpDomainPath'"
-            )
-            Failure(ex)
-        }
+      reqs.setRequestInfo()
+      get[DomainDumpResults[T]](dumpDomainPath, params, timeout = 120000) match {
+        case Success(result) =>
+          logger.info(s"Fetched chunk of ${result.results.size} $name from ${baseUrl.addParams(params)}")
+          Success(result)
+        case Failure(ex) =>
+          logger.error(
+            s"Could not fetch chunk on page: '$page', with pageSize: '$pageSize' from '$baseUrl/$dumpDomainPath'"
+          )
+          Failure(ex)
       }
     }
 


### PR DESCRIPTION
Fjerner bruk av futures ved indeksering av search-api.

Problemet var at håndtering av futures ikkje fungerte i gammel løsning, men det var det som gjorde at det faktisk virka.
Så tester å fjerne dette slik at indeksering skjer synkront.

Deployer dette til test.