### PR TITLE
Only set responsible if responsibleId actually changes

### DIFF
--- a/draft-api/src/main/scala/no/ndla/draftapi/service/ConverterService.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/service/ConverterService.scala
@@ -642,10 +642,12 @@ trait ConverterService {
         newContent <- cloneFilesForOtherLanguages(article.content, toMergeInto.content, isNewLanguage)
       } yield (newNotes, newContent)
 
-      val responsible = article.responsibleId match {
-        case Left(_)                    => None
-        case Right(Some(responsibleId)) => Some(Responsible(responsibleId, clock.now()))
-        case Right(None)                => toMergeInto.responsible
+      val responsible = (article.responsibleId, toMergeInto.responsible) match {
+        case (Left(_), _)                       => None
+        case (Right(Some(responsibleId)), None) => Some(Responsible(responsibleId, clock.now()))
+        case (Right(Some(responsibleId)), existing) if (existing.get.responsibleId != responsibleId) =>
+          Some(Responsible(responsibleId, clock.now()))
+        case (Right(_), existing) => existing
       }
 
       failableFields match {

--- a/draft-api/src/main/scala/no/ndla/draftapi/service/ConverterService.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/service/ConverterService.scala
@@ -645,7 +645,7 @@ trait ConverterService {
       val responsible = (article.responsibleId, toMergeInto.responsible) match {
         case (Left(_), _)                       => None
         case (Right(Some(responsibleId)), None) => Some(Responsible(responsibleId, clock.now()))
-        case (Right(Some(responsibleId)), existing) if (existing.get.responsibleId != responsibleId) =>
+        case (Right(Some(responsibleId)), Some(existing)) if existing.responsibleId != responsibleId =>
           Some(Responsible(responsibleId, clock.now()))
         case (Right(_), existing) => existing
       }


### PR DESCRIPTION
Sjekker at innsendt verdi er forskjellig fra eksisterende før ny timestamp settes.