### PR TITLE
Move every thread-local variable into `RequestInfo`

### DIFF
--- a/article-api/src/main/scala/no/ndla/articleapi/ComponentRegistry.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/ComponentRegistry.scala
@@ -23,9 +23,9 @@ import no.ndla.articleapi.model.api.ErrorHelpers
 import no.ndla.articleapi.model.domain.DBArticle
 import no.ndla.common.Clock
 import no.ndla.common.configuration.BaseComponentRegistry
-import no.ndla.common.scalatra.{NdlaControllerBase, NdlaSwaggerSupport}
 import no.ndla.network.NdlaClient
 import no.ndla.network.clients.{FeideApiClient, RedisClient}
+import no.ndla.network.scalatra.{NdlaControllerBase, NdlaSwaggerSupport}
 import no.ndla.search.{BaseIndexService, Elastic4sClient, Elastic4sClientFactory, NdlaE4sClient}
 
 class ComponentRegistry(properties: ArticleApiProperties)

--- a/article-api/src/main/scala/no/ndla/articleapi/MainClass.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/MainClass.scala
@@ -9,7 +9,7 @@
 package no.ndla.articleapi
 
 import com.typesafe.scalalogging.StrictLogging
-import no.ndla.common.scalatra.NdlaScalatraServer
+import no.ndla.network.scalatra.NdlaScalatraServer
 import org.eclipse.jetty.server.Server
 
 class MainClass(props: ArticleApiProperties) extends StrictLogging {

--- a/article-api/src/main/scala/no/ndla/articleapi/ScalatraBootstrap.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/ScalatraBootstrap.scala
@@ -8,8 +8,7 @@
 
 package no.ndla.articleapi
 
-import no.ndla.common.scalatra.NdlaScalatraBootstrapBase
-
+import no.ndla.network.scalatra.NdlaScalatraBootstrapBase
 import javax.servlet.ServletContext
 
 class ScalatraBootstrap extends NdlaScalatraBootstrapBase[ComponentRegistry] {

--- a/article-api/src/main/scala/no/ndla/articleapi/controller/ArticleControllerV2.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/controller/ArticleControllerV2.scala
@@ -16,8 +16,8 @@ import no.ndla.articleapi.service.search.{ArticleSearchService, SearchConverterS
 import no.ndla.articleapi.service.{ConverterService, ReadService, WriteService}
 import no.ndla.articleapi.validation.ContentValidator
 import no.ndla.common.ContentURIUtil.parseArticleIdAndRevision
-import no.ndla.common.scalatra.NdlaSwaggerSupport
 import no.ndla.language.Language.AllLanguages
+import no.ndla.network.scalatra.NdlaSwaggerSupport
 import org.json4s.ext.JavaTimeSerializers
 import org.json4s.{DefaultFormats, Formats}
 import org.scalatra.swagger.{ResponseMessage, Swagger}

--- a/article-api/src/main/scala/no/ndla/articleapi/controller/HealthController.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/controller/HealthController.scala
@@ -8,7 +8,7 @@
 
 package no.ndla.articleapi.controller
 
-import no.ndla.common.scalatra.BaseHealthController
+import no.ndla.network.scalatra.BaseHealthController
 
 trait HealthController {
   val healthController: HealthController

--- a/article-api/src/main/scala/no/ndla/articleapi/controller/NdlaController.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/controller/NdlaController.scala
@@ -12,8 +12,7 @@ import no.ndla.articleapi.Props
 import no.ndla.articleapi.integration.DataSource
 import no.ndla.articleapi.model.api.{Error, ErrorHelpers, NotFoundException, ValidationError}
 import no.ndla.common.errors.{AccessDeniedException, ValidationException}
-import no.ndla.common.scalatra.NdlaControllerBase
-import no.ndla.network.{ApplicationUrl, AuthUser}
+import no.ndla.network.scalatra.NdlaControllerBase
 import no.ndla.search.{IndexNotFoundException, NdlaSearchException}
 import org.json4s.ext.JavaTimeSerializers
 import org.json4s.{DefaultFormats, Formats}
@@ -30,13 +29,6 @@ trait NdlaController {
 
     before() {
       contentType = formats("json")
-      ApplicationUrl.set(request)
-      AuthUser.set(request)
-    }
-
-    after() {
-      AuthUser.clear()
-      ApplicationUrl.clear()
     }
 
     override def ndlaErrorHandler: NdlaErrorHandler = {

--- a/article-api/src/test/scala/no/ndla/articleapi/TestEnvironment.scala
+++ b/article-api/src/test/scala/no/ndla/articleapi/TestEnvironment.scala
@@ -22,9 +22,9 @@ import no.ndla.articleapi.integration.SearchApiClient
 import no.ndla.articleapi.model.api.ErrorHelpers
 import no.ndla.articleapi.model.domain.DBArticle
 import no.ndla.common.Clock
-import no.ndla.common.scalatra.{NdlaControllerBase, NdlaSwaggerSupport}
 import no.ndla.network.NdlaClient
 import no.ndla.network.clients.{FeideApiClient, RedisClient}
+import no.ndla.network.scalatra.{NdlaControllerBase, NdlaSwaggerSupport}
 import no.ndla.search.{BaseIndexService, Elastic4sClient, NdlaE4sClient}
 import org.mockito.scalatest.MockitoSugar
 

--- a/audio-api/src/main/scala/no/ndla/audioapi/ComponentRegistry.scala
+++ b/audio-api/src/main/scala/no/ndla/audioapi/ComponentRegistry.scala
@@ -23,12 +23,12 @@ import no.ndla.audioapi.integration._
 import no.ndla.audioapi.model.api.ErrorHelpers
 import no.ndla.audioapi.model.domain.{DBAudioMetaInformation, DBSeries}
 import no.ndla.audioapi.repository.{AudioRepository, SeriesRepository}
-import no.ndla.audioapi.service.search.{AudioIndexService, _}
+import no.ndla.audioapi.service.search._
 import no.ndla.audioapi.service._
 import no.ndla.common.Clock
 import no.ndla.common.configuration.BaseComponentRegistry
-import no.ndla.common.scalatra.{NdlaControllerBase, NdlaSwaggerSupport}
 import no.ndla.network.NdlaClient
+import no.ndla.network.scalatra.{NdlaControllerBase, NdlaSwaggerSupport}
 import no.ndla.search.{BaseIndexService, Elastic4sClient, Elastic4sClientFactory, NdlaE4sClient}
 
 class ComponentRegistry(properties: AudioApiProperties)

--- a/audio-api/src/main/scala/no/ndla/audioapi/MainClass.scala
+++ b/audio-api/src/main/scala/no/ndla/audioapi/MainClass.scala
@@ -9,7 +9,7 @@
 package no.ndla.audioapi
 
 import com.typesafe.scalalogging.StrictLogging
-import no.ndla.common.scalatra.NdlaScalatraServer
+import no.ndla.network.scalatra.NdlaScalatraServer
 import org.eclipse.jetty.server.Server
 
 class MainClass(props: AudioApiProperties) extends StrictLogging {

--- a/audio-api/src/main/scala/no/ndla/audioapi/ScalatraBootstrap.scala
+++ b/audio-api/src/main/scala/no/ndla/audioapi/ScalatraBootstrap.scala
@@ -7,7 +7,7 @@
  */
 package no.ndla.audioapi
 
-import no.ndla.common.scalatra.NdlaScalatraBootstrapBase
+import no.ndla.network.scalatra.NdlaScalatraBootstrapBase
 import javax.servlet.ServletContext
 
 class ScalatraBootstrap extends NdlaScalatraBootstrapBase[ComponentRegistry] {

--- a/audio-api/src/main/scala/no/ndla/audioapi/controller/AudioController.scala
+++ b/audio-api/src/main/scala/no/ndla/audioapi/controller/AudioController.scala
@@ -28,8 +28,8 @@ import no.ndla.audioapi.model.domain.{AudioType, SearchSettings}
 import no.ndla.audioapi.repository.AudioRepository
 import no.ndla.audioapi.service.search.{AudioSearchService, SearchConverterService}
 import no.ndla.audioapi.service.{ConverterService, ReadService, WriteService}
-import no.ndla.common.scalatra.NdlaSwaggerSupport
 import no.ndla.language.Language
+import no.ndla.network.scalatra.NdlaSwaggerSupport
 import org.json4s.ext.EnumNameSerializer
 import org.json4s.{DefaultFormats, Formats}
 import org.scalatra._

--- a/audio-api/src/main/scala/no/ndla/audioapi/controller/HealthController.scala
+++ b/audio-api/src/main/scala/no/ndla/audioapi/controller/HealthController.scala
@@ -10,8 +10,7 @@ package no.ndla.audioapi.controller
 
 import no.ndla.audioapi.Props
 import no.ndla.audioapi.repository.AudioRepository
-import no.ndla.common.scalatra.BaseHealthController
-import no.ndla.network.ApplicationUrl
+import no.ndla.network.scalatra.BaseHealthController
 import org.scalatra.{ActionResult, InternalServerError, Ok}
 import sttp.client3.Response
 import sttp.client3.quick._
@@ -21,14 +20,6 @@ trait HealthController {
   val healthController: HealthController
 
   class HealthController extends BaseHealthController {
-
-    before() {
-      ApplicationUrl.set(request)
-    }
-
-    after() {
-      ApplicationUrl.clear()
-    }
 
     def getApiResponse(url: String): Response[String] = {
       simpleHttpClient.send(quickRequest.get(uri"$url"))

--- a/audio-api/src/main/scala/no/ndla/audioapi/controller/NdlaController.scala
+++ b/audio-api/src/main/scala/no/ndla/audioapi/controller/NdlaController.scala
@@ -12,9 +12,8 @@ import no.ndla.audioapi.Props
 import no.ndla.audioapi.integration.DataSource
 import no.ndla.audioapi.model.api._
 import no.ndla.common.errors.AccessDeniedException
-import no.ndla.common.scalatra.NdlaControllerBase
 import no.ndla.network.model.HttpRequestException
-import no.ndla.network.{ApplicationUrl, AuthUser}
+import no.ndla.network.scalatra.NdlaControllerBase
 import no.ndla.search.NdlaSearchException
 import org.postgresql.util.PSQLException
 import org.scalatra._
@@ -26,13 +25,6 @@ trait NdlaController {
   abstract class NdlaController extends NdlaControllerBase {
     before() {
       contentType = formats("json")
-      ApplicationUrl.set(request)
-      AuthUser.set(request)
-    }
-
-    after() {
-      ApplicationUrl.clear()
-      AuthUser.clear()
     }
 
     import ErrorHelpers._

--- a/audio-api/src/main/scala/no/ndla/audioapi/controller/SeriesController.scala
+++ b/audio-api/src/main/scala/no/ndla/audioapi/controller/SeriesController.scala
@@ -25,8 +25,8 @@ import no.ndla.audioapi.model.domain.SeriesSearchSettings
 import no.ndla.audioapi.model.Sort
 import no.ndla.audioapi.service.search.{SearchConverterService, SeriesSearchService}
 import no.ndla.audioapi.service.{ConverterService, ReadService, WriteService}
-import no.ndla.common.scalatra.NdlaSwaggerSupport
 import no.ndla.language.Language
+import no.ndla.network.scalatra.NdlaSwaggerSupport
 import org.json4s.ext.JavaTimeSerializers
 import org.json4s.{DefaultFormats, Formats}
 import org.scalatra._

--- a/audio-api/src/test/scala/no/ndla/audioapi/TestEnvironment.scala
+++ b/audio-api/src/test/scala/no/ndla/audioapi/TestEnvironment.scala
@@ -25,8 +25,8 @@ import no.ndla.audioapi.repository.{AudioRepository, SeriesRepository}
 import no.ndla.audioapi.service._
 import no.ndla.audioapi.service.search._
 import no.ndla.common.Clock
-import no.ndla.common.scalatra.{NdlaControllerBase, NdlaSwaggerSupport}
 import no.ndla.network.NdlaClient
+import no.ndla.network.scalatra.{NdlaControllerBase, NdlaSwaggerSupport}
 import no.ndla.search.{BaseIndexService, Elastic4sClient, NdlaE4sClient}
 import org.mockito.scalatest.MockitoSugar
 

--- a/common/src/main/scala/no/ndla/common/CorrelationID.scala
+++ b/common/src/main/scala/no/ndla/common/CorrelationID.scala
@@ -18,8 +18,12 @@ object CorrelationID {
   private val correlationID = new ThreadLocal[String]
 
   def set(request: HttpServletRequest): Unit = {
-    val maybeHeaderValue = Option(request.getHeader(Constants.CorrelationIdHeader))
+    val maybeHeaderValue = fromRequest(request)
     this.set(maybeHeaderValue)
+  }
+
+  def fromRequest(request: HttpServletRequest): Option[String] = {
+    Option(request.getHeader(Constants.CorrelationIdHeader))
   }
 
   def set(correlationId: Option[String]): Unit = {

--- a/concept-api/src/main/scala/no/ndla/conceptapi/ComponentRegistry.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/ComponentRegistry.scala
@@ -23,7 +23,7 @@ import no.ndla.network.NdlaClient
 import no.ndla.search.{BaseIndexService, Elastic4sClient, Elastic4sClientFactory, NdlaE4sClient}
 import no.ndla.common.Clock
 import no.ndla.common.configuration.BaseComponentRegistry
-import no.ndla.common.scalatra.{NdlaControllerBase, NdlaSwaggerSupport}
+import no.ndla.network.scalatra.{NdlaControllerBase, NdlaSwaggerSupport}
 
 class ComponentRegistry(properties: ConceptApiProperties)
     extends BaseComponentRegistry[ConceptApiProperties]

--- a/concept-api/src/main/scala/no/ndla/conceptapi/MainClass.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/MainClass.scala
@@ -8,7 +8,7 @@
 package no.ndla.conceptapi
 
 import com.typesafe.scalalogging.StrictLogging
-import no.ndla.common.scalatra.NdlaScalatraServer
+import no.ndla.network.scalatra.NdlaScalatraServer
 import org.eclipse.jetty.server.Server
 
 class MainClass(props: ConceptApiProperties) extends StrictLogging {

--- a/concept-api/src/main/scala/no/ndla/conceptapi/ScalatraBootstrap.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/ScalatraBootstrap.scala
@@ -6,7 +6,7 @@
  */
 package no.ndla.conceptapi
 
-import no.ndla.common.scalatra.NdlaScalatraBootstrapBase
+import no.ndla.network.scalatra.NdlaScalatraBootstrapBase
 import javax.servlet.ServletContext
 
 class ScalatraBootstrap extends NdlaScalatraBootstrapBase[ComponentRegistry] {

--- a/concept-api/src/main/scala/no/ndla/conceptapi/controller/DraftConceptController.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/controller/DraftConceptController.scala
@@ -8,7 +8,6 @@
 package no.ndla.conceptapi.controller
 
 import com.typesafe.scalalogging.StrictLogging
-import no.ndla.common.scalatra.NdlaSwaggerSupport
 import no.ndla.conceptapi.Props
 import no.ndla.conceptapi.auth.User
 import no.ndla.conceptapi.model.api._
@@ -18,6 +17,7 @@ import no.ndla.conceptapi.service.search.{DraftConceptSearchService, SearchConve
 import no.ndla.conceptapi.service.{ConverterService, ReadService, WriteService}
 import no.ndla.language.Language
 import no.ndla.language.Language.AllLanguages
+import no.ndla.network.scalatra.NdlaSwaggerSupport
 import org.json4s.ext.JavaTimeSerializers
 import org.json4s.{DefaultFormats, Formats}
 import org.scalatra.Ok

--- a/concept-api/src/main/scala/no/ndla/conceptapi/controller/HealthController.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/controller/HealthController.scala
@@ -7,7 +7,7 @@
 
 package no.ndla.conceptapi.controller
 
-import no.ndla.common.scalatra.BaseHealthController
+import no.ndla.network.scalatra.BaseHealthController
 
 trait HealthController {
   val healthController: HealthController

--- a/concept-api/src/main/scala/no/ndla/conceptapi/controller/NdlaController.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/controller/NdlaController.scala
@@ -8,7 +8,6 @@
 package no.ndla.conceptapi.controller
 
 import no.ndla.common.errors.ValidationException
-import no.ndla.common.scalatra.{NdlaControllerBase, NdlaSwaggerSupport}
 import no.ndla.conceptapi.Props
 import no.ndla.conceptapi.integration.DataSource
 import no.ndla.conceptapi.model.api.{
@@ -19,7 +18,7 @@ import no.ndla.conceptapi.model.api.{
   ValidationError
 }
 import no.ndla.network.model.HttpRequestException
-import no.ndla.network.{ApplicationUrl, AuthUser}
+import no.ndla.network.scalatra.{NdlaControllerBase, NdlaSwaggerSupport}
 import no.ndla.search.{IndexNotFoundException, NdlaSearchException}
 import org.json4s.ext.JavaTimeSerializers
 import org.json4s.{DefaultFormats, Formats}
@@ -38,13 +37,6 @@ trait NdlaController {
 
     before() {
       contentType = formats("json")
-      ApplicationUrl.set(request)
-      AuthUser.set(request)
-    }
-
-    after() {
-      AuthUser.clear()
-      ApplicationUrl.clear()
     }
 
     import ErrorHelpers._

--- a/concept-api/src/main/scala/no/ndla/conceptapi/service/StateTransitionRules.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/service/StateTransitionRules.scala
@@ -131,7 +131,7 @@ trait StateTransitionRules {
         user: UserInfo
     ): IO[Try[domain.Concept]] = {
       val (convertedArticle, sideEffect) = doTransitionWithoutSideEffect(current, to, user)
-      val requestInfo                    = RequestInfo()
+      val requestInfo                    = RequestInfo.fromThreadContext()
       IO {
         requestInfo.setRequestInfo()
         convertedArticle.flatMap(concept => sideEffect(concept))

--- a/concept-api/src/test/scala/no/ndla/conceptapi/TestEnvironment.scala
+++ b/concept-api/src/test/scala/no/ndla/conceptapi/TestEnvironment.scala
@@ -35,7 +35,7 @@ import no.ndla.conceptapi.validation.ContentValidator
 import no.ndla.network.NdlaClient
 import no.ndla.search.{BaseIndexService, Elastic4sClient, NdlaE4sClient}
 import no.ndla.common.Clock
-import no.ndla.common.scalatra.{NdlaControllerBase, NdlaSwaggerSupport}
+import no.ndla.network.scalatra.{NdlaControllerBase, NdlaSwaggerSupport}
 import org.mockito.scalatest.MockitoSugar
 
 trait TestEnvironment

--- a/draft-api/src/main/scala/no/ndla/draftapi/ComponentRegistry.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/ComponentRegistry.scala
@@ -13,7 +13,6 @@ import com.typesafe.scalalogging.StrictLogging
 import com.zaxxer.hikari.HikariDataSource
 import no.ndla.common.Clock
 import no.ndla.common.configuration.BaseComponentRegistry
-import no.ndla.common.scalatra.{NdlaControllerBase, NdlaSwaggerSupport}
 import no.ndla.draftapi.auth.User
 import no.ndla.draftapi.caching.MemoizeHelpers
 import no.ndla.draftapi.controller._
@@ -25,6 +24,7 @@ import no.ndla.draftapi.service._
 import no.ndla.draftapi.service.search._
 import no.ndla.draftapi.validation.ContentValidator
 import no.ndla.network.NdlaClient
+import no.ndla.network.scalatra.{NdlaControllerBase, NdlaSwaggerSupport}
 import no.ndla.search.{BaseIndexService, Elastic4sClient, Elastic4sClientFactory, NdlaE4sClient}
 
 class ComponentRegistry(properties: DraftApiProperties)

--- a/draft-api/src/main/scala/no/ndla/draftapi/DraftApiProperties.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/DraftApiProperties.scala
@@ -82,7 +82,6 @@ class DraftApiProperties extends BaseProps with StrictLogging {
   def ElasticSearchScrollKeepAlive         = "1m"
   def InitialScrollContextKeywords         = List("0", "initial", "start", "first")
 
-  def TaxonomyVersionIdKey  = "versionHash"
   def TaxonomyVersionHeader = "VersionHash"
 
   def AttachmentStorageName: String =

--- a/draft-api/src/main/scala/no/ndla/draftapi/MainClass.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/MainClass.scala
@@ -8,7 +8,7 @@
 package no.ndla.draftapi
 
 import com.typesafe.scalalogging.StrictLogging
-import no.ndla.common.scalatra.NdlaScalatraServer
+import no.ndla.network.scalatra.NdlaScalatraServer
 import org.eclipse.jetty.server.Server
 
 class MainClass(props: DraftApiProperties) extends StrictLogging {

--- a/draft-api/src/main/scala/no/ndla/draftapi/ScalatraBootstrap.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/ScalatraBootstrap.scala
@@ -7,7 +7,7 @@ package no.ndla.draftapi
  * See LICENSE
  */
 
-import no.ndla.common.scalatra.NdlaScalatraBootstrapBase
+import no.ndla.network.scalatra.NdlaScalatraBootstrapBase
 import javax.servlet.ServletContext
 
 class ScalatraBootstrap extends NdlaScalatraBootstrapBase[ComponentRegistry] {

--- a/draft-api/src/main/scala/no/ndla/draftapi/controller/HealthController.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/controller/HealthController.scala
@@ -7,7 +7,7 @@
 
 package no.ndla.draftapi.controller
 
-import no.ndla.common.scalatra.BaseHealthController
+import no.ndla.network.scalatra.BaseHealthController
 
 trait HealthController {
   val healthController: HealthController

--- a/draft-api/src/main/scala/no/ndla/draftapi/controller/NdlaController.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/controller/NdlaController.scala
@@ -8,7 +8,6 @@
 package no.ndla.draftapi.controller
 
 import no.ndla.common.errors.{AccessDeniedException, ValidationException}
-import no.ndla.common.scalatra.{NdlaControllerBase, NdlaSwaggerSupport}
 import no.ndla.draftapi.Props
 import no.ndla.draftapi.integration.DataSource
 import no.ndla.draftapi.model.api.{
@@ -20,9 +19,8 @@ import no.ndla.draftapi.model.api.{
   ValidationError
 }
 import no.ndla.network.model.HttpRequestException
-import no.ndla.network.{ApplicationUrl, AuthUser}
+import no.ndla.network.scalatra.{NdlaControllerBase, NdlaSwaggerSupport}
 import no.ndla.search.{IndexNotFoundException, NdlaSearchException}
-import org.apache.logging.log4j.ThreadContext
 import org.json4s.ext.JavaTimeSerializers
 import org.json4s.{DefaultFormats, Formats}
 import org.postgresql.util.PSQLException
@@ -37,15 +35,6 @@ trait NdlaController {
 
     before() {
       contentType = formats("json")
-      ThreadContext.put(TaxonomyVersionIdKey, Option(request.getHeader(TaxonomyVersionHeader)).getOrElse("default"))
-      ApplicationUrl.set(request)
-      AuthUser.set(request)
-    }
-
-    after() {
-      ThreadContext.remove(TaxonomyVersionIdKey)
-      AuthUser.clear()
-      ApplicationUrl.clear()
     }
 
     import ErrorHelpers._

--- a/draft-api/src/main/scala/no/ndla/draftapi/integration/H5PApiClient.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/integration/H5PApiClient.scala
@@ -80,7 +80,7 @@ trait H5PApiClient {
     private[integration] def putNothing(url: String, params: (String, String)*)(implicit
         ec: ExecutionContext
     ): Future[Try[Unit]] = {
-      val threadInfo = RequestInfo()
+      val threadInfo = RequestInfo.fromThreadContext()
       Future {
         logger.info(s"Doing call to $url")
         threadInfo.setRequestInfo()

--- a/draft-api/src/main/scala/no/ndla/draftapi/service/StateTransitionRules.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/service/StateTransitionRules.scala
@@ -234,7 +234,7 @@ trait StateTransitionRules {
         isImported: Boolean
     ): IO[Try[Draft]] = {
       val (convertedArticle, sideEffects) = doTransitionWithoutSideEffect(current, to, user, isImported)
-      val requestInfo                     = RequestInfo()
+      val requestInfo                     = RequestInfo.fromThreadContext()
       IO {
         requestInfo.setRequestInfo()
         convertedArticle.flatMap(articleBeforeSideEffect => {

--- a/draft-api/src/main/scala/no/ndla/draftapi/service/WriteService.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/service/WriteService.scala
@@ -865,7 +865,7 @@ trait WriteService {
           implicit val executionContext: ExecutionContextExecutorService =
             ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(1))
           val partialArticle = partialArticleFieldsUpdate(article, fieldsToPublish, language)
-          val requestInfo    = RequestInfo()
+          val requestInfo    = RequestInfo.fromThreadContext()
           val fut = Future {
             requestInfo.setRequestInfo()
             articleApiClient.partialPublishArticle(id, partialArticle)
@@ -889,7 +889,7 @@ trait WriteService {
         partialBulk: api.PartialBulkArticles
     ): Try[api.MultiPartialPublishResult] = {
       implicit val ec = ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(100))
-      val requestInfo = RequestInfo()
+      val requestInfo = RequestInfo.fromThreadContext()
 
       val futures = partialBulk.articleIds.map(id =>
         Future {

--- a/draft-api/src/test/scala/no/ndla/draftapi/TestEnvironment.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/TestEnvironment.scala
@@ -11,7 +11,6 @@ import com.amazonaws.services.s3.AmazonS3
 import com.typesafe.scalalogging.StrictLogging
 import com.zaxxer.hikari.HikariDataSource
 import no.ndla.common.Clock
-import no.ndla.common.scalatra.{NdlaControllerBase, NdlaSwaggerSupport}
 import no.ndla.draftapi.auth.User
 import no.ndla.draftapi.caching.MemoizeHelpers
 import no.ndla.draftapi.controller._
@@ -23,6 +22,7 @@ import no.ndla.draftapi.service._
 import no.ndla.draftapi.service.search._
 import no.ndla.draftapi.validation.ContentValidator
 import no.ndla.network.NdlaClient
+import no.ndla.network.scalatra.{NdlaControllerBase, NdlaSwaggerSupport}
 import no.ndla.search.{BaseIndexService, Elastic4sClient, NdlaE4sClient}
 import org.mockito.scalatest.MockitoSugar
 

--- a/image-api/src/main/scala/no/ndla/imageapi/ComponentRegistry.scala
+++ b/image-api/src/main/scala/no/ndla/imageapi/ComponentRegistry.scala
@@ -12,7 +12,6 @@ import com.amazonaws.regions.Regions
 import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
 import no.ndla.common.Clock
 import no.ndla.common.configuration.BaseComponentRegistry
-import no.ndla.common.scalatra.{NdlaControllerBase, NdlaSwaggerSupport}
 import no.ndla.imageapi.auth.{Role, User}
 import no.ndla.imageapi.controller._
 import no.ndla.imageapi.integration._
@@ -30,6 +29,7 @@ import no.ndla.imageapi.service.search.{
   TagSearchService
 }
 import no.ndla.network.NdlaClient
+import no.ndla.network.scalatra.{NdlaControllerBase, NdlaSwaggerSupport}
 import no.ndla.search.{BaseIndexService, Elastic4sClient, Elastic4sClientFactory, NdlaE4sClient}
 
 class ComponentRegistry(properties: ImageApiProperties)

--- a/image-api/src/main/scala/no/ndla/imageapi/MainClass.scala
+++ b/image-api/src/main/scala/no/ndla/imageapi/MainClass.scala
@@ -9,7 +9,7 @@
 package no.ndla.imageapi
 
 import com.typesafe.scalalogging.StrictLogging
-import no.ndla.common.scalatra.NdlaScalatraServer
+import no.ndla.network.scalatra.NdlaScalatraServer
 import org.eclipse.jetty.server.Server
 
 class MainClass(props: ImageApiProperties) extends StrictLogging {

--- a/image-api/src/main/scala/no/ndla/imageapi/ScalatraBootstrap.scala
+++ b/image-api/src/main/scala/no/ndla/imageapi/ScalatraBootstrap.scala
@@ -7,7 +7,7 @@
  */
 package no.ndla.imageapi
 
-import no.ndla.common.scalatra.NdlaScalatraBootstrapBase
+import no.ndla.network.scalatra.NdlaScalatraBootstrapBase
 import javax.servlet.ServletContext
 
 class ScalatraBootstrap extends NdlaScalatraBootstrapBase[ComponentRegistry] {

--- a/image-api/src/main/scala/no/ndla/imageapi/controller/BaseImageController.scala
+++ b/image-api/src/main/scala/no/ndla/imageapi/controller/BaseImageController.scala
@@ -8,10 +8,10 @@
 
 package no.ndla.imageapi.controller
 
-import no.ndla.common.scalatra.NdlaSwaggerSupport
 import no.ndla.imageapi.Props
 import no.ndla.imageapi.model.api.{Error, NewImageMetaInformationV2, UpdateImageMetaInformation, ValidationError}
 import no.ndla.imageapi.model.domain.{DBImageMetaInformation, ModelReleasedStatus, Sort}
+import no.ndla.network.scalatra.NdlaSwaggerSupport
 import org.json4s.{DefaultFormats, Formats}
 import org.scalatra.servlet.{FileUploadSupport, MultipartConfig}
 import org.scalatra.swagger._

--- a/image-api/src/main/scala/no/ndla/imageapi/controller/HealthController.scala
+++ b/image-api/src/main/scala/no/ndla/imageapi/controller/HealthController.scala
@@ -8,24 +8,14 @@
 
 package no.ndla.imageapi.controller
 
-import no.ndla.common.scalatra.BaseHealthController
 import no.ndla.imageapi.Props
 import no.ndla.imageapi.repository.ImageRepository
-import no.ndla.network.ApplicationUrl
+import no.ndla.network.scalatra.BaseHealthController
 
 trait HealthController {
   this: ImageRepository with Props =>
   val healthController: HealthController
 
-  class HealthController extends BaseHealthController {
-
-    before() {
-      ApplicationUrl.set(request)
-    }
-
-    after() {
-      ApplicationUrl.clear()
-    }
-  }
+  class HealthController extends BaseHealthController {}
 
 }

--- a/image-api/src/main/scala/no/ndla/imageapi/controller/NdlaController.scala
+++ b/image-api/src/main/scala/no/ndla/imageapi/controller/NdlaController.scala
@@ -9,13 +9,12 @@
 package no.ndla.imageapi.controller
 
 import no.ndla.common.errors.{AccessDeniedException, ValidationException}
-import no.ndla.common.scalatra.NdlaSwaggerSupport
 import no.ndla.imageapi.Props
 import no.ndla.imageapi.integration.DataSource
 import no.ndla.imageapi.model._
 import no.ndla.imageapi.model.api.{Error, ErrorHelpers, ValidationError}
 import no.ndla.imageapi.model.domain.ImageStream
-import no.ndla.network.{ApplicationUrl, AuthUser}
+import no.ndla.network.scalatra.NdlaSwaggerSupport
 import no.ndla.search.{IndexNotFoundException, NdlaSearchException}
 import org.postgresql.util.PSQLException
 import org.scalatra._
@@ -27,13 +26,6 @@ trait NdlaController {
   abstract class NdlaController extends NdlaSwaggerSupport {
     before() {
       contentType = formats("json")
-      ApplicationUrl.set(request)
-      AuthUser.set(request)
-    }
-
-    after() {
-      ApplicationUrl.clear()
-      AuthUser.clear()
     }
 
     import ErrorHelpers._

--- a/image-api/src/main/scala/no/ndla/imageapi/controller/RawController.scala
+++ b/image-api/src/main/scala/no/ndla/imageapi/controller/RawController.scala
@@ -7,12 +7,12 @@
 
 package no.ndla.imageapi.controller
 
-import no.ndla.common.scalatra.NdlaSwaggerSupport
 import no.ndla.imageapi.Props
 import no.ndla.imageapi.model.api.{Error, ErrorHelpers}
 import no.ndla.imageapi.model.domain.ImageStream
 import no.ndla.imageapi.repository.ImageRepository
 import no.ndla.imageapi.service.{ImageConverter, ImageStorageService, ReadService}
+import no.ndla.network.scalatra.NdlaSwaggerSupport
 import org.json4s.ext.JavaTimeSerializers
 import org.json4s.{DefaultFormats, Formats}
 import org.scalatra.servlet.FileUploadSupport

--- a/image-api/src/test/scala/no/ndla/imageapi/TestEnvironment.scala
+++ b/image-api/src/test/scala/no/ndla/imageapi/TestEnvironment.scala
@@ -11,7 +11,6 @@ package no.ndla.imageapi
 import com.amazonaws.services.s3.AmazonS3
 import com.zaxxer.hikari.HikariDataSource
 import no.ndla.common.Clock
-import no.ndla.common.scalatra.{NdlaControllerBase, NdlaSwaggerSupport}
 import no.ndla.imageapi.auth.{Role, User}
 import no.ndla.imageapi.controller.{
   BaseImageController,
@@ -37,6 +36,7 @@ import no.ndla.imageapi.service.search.{
   TagSearchService
 }
 import no.ndla.network.NdlaClient
+import no.ndla.network.scalatra.{NdlaControllerBase, NdlaSwaggerSupport}
 import no.ndla.search.{BaseIndexService, Elastic4sClient, NdlaE4sClient}
 import org.mockito.scalatest.MockitoSugar
 

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/ComponentRegistry.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/ComponentRegistry.scala
@@ -11,7 +11,6 @@ package no.ndla.learningpathapi
 import com.zaxxer.hikari.HikariDataSource
 import no.ndla.common.Clock
 import no.ndla.common.configuration.BaseComponentRegistry
-import no.ndla.common.scalatra.{NdlaControllerBase, NdlaSwaggerSupport}
 import no.ndla.learningpathapi.controller.{
   ConfigController,
   FolderController,
@@ -51,6 +50,7 @@ import no.ndla.learningpathapi.validation.{
 }
 import no.ndla.network.NdlaClient
 import no.ndla.network.clients.{FeideApiClient, RedisClient}
+import no.ndla.network.scalatra.{NdlaControllerBase, NdlaSwaggerSupport}
 import no.ndla.search.{BaseIndexService, Elastic4sClient, Elastic4sClientFactory, NdlaE4sClient}
 
 class ComponentRegistry(properties: LearningpathApiProperties)

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/MainClass.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/MainClass.scala
@@ -9,7 +9,7 @@
 package no.ndla.learningpathapi
 
 import com.typesafe.scalalogging.StrictLogging
-import no.ndla.common.scalatra.NdlaScalatraServer
+import no.ndla.network.scalatra.NdlaScalatraServer
 import org.eclipse.jetty.server.Server
 
 class MainClass(props: LearningpathApiProperties) extends StrictLogging {

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/ScalatraBootstrap.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/ScalatraBootstrap.scala
@@ -8,7 +8,7 @@
 
 package no.ndla.learningpathapi
 
-import no.ndla.common.scalatra.NdlaScalatraBootstrapBase
+import no.ndla.network.scalatra.NdlaScalatraBootstrapBase
 import javax.servlet.ServletContext
 
 class ScalatraBootstrap extends NdlaScalatraBootstrapBase[ComponentRegistry] {

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/controller/ConfigController.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/controller/ConfigController.scala
@@ -7,13 +7,13 @@
 
 package no.ndla.learningpathapi.controller
 
-import no.ndla.common.scalatra.NdlaSwaggerSupport
 import no.ndla.learningpathapi.Props
 import no.ndla.learningpathapi.model.api.{ValidationError, Error}
 import no.ndla.learningpathapi.model.api.config.{ConfigMeta, ConfigMetaRestricted, UpdateConfigValue}
 import no.ndla.learningpathapi.model.domain.UserInfo
 import no.ndla.learningpathapi.model.domain.config.ConfigKey
 import no.ndla.learningpathapi.service.{ReadService, UpdateService}
+import no.ndla.network.scalatra.NdlaSwaggerSupport
 import org.json4s.{DefaultFormats, Formats}
 import org.scalatra.swagger.ResponseMessage
 

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/controller/FolderController.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/controller/FolderController.scala
@@ -8,7 +8,6 @@
 
 package no.ndla.learningpathapi.controller
 
-import no.ndla.common.scalatra.NdlaSwaggerSupport
 import no.ndla.learningpathapi.model.api.{
   Error,
   Folder,
@@ -22,6 +21,7 @@ import no.ndla.learningpathapi.model.api.{
 }
 import no.ndla.learningpathapi.model.domain.FolderSortObject.{FolderSorting, ResourceSorting, RootFolderSorting}
 import no.ndla.learningpathapi.service.{ConverterService, ReadService, UpdateService}
+import no.ndla.network.scalatra.NdlaSwaggerSupport
 import org.json4s.ext.{JavaTimeSerializers, JavaTypesSerializers}
 import org.json4s.{DefaultFormats, Formats}
 import org.scalatra.swagger._

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/controller/HealthController.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/controller/HealthController.scala
@@ -8,7 +8,7 @@
 
 package no.ndla.learningpathapi.controller
 
-import no.ndla.common.scalatra.BaseHealthController
+import no.ndla.network.scalatra.BaseHealthController
 
 trait HealthController {
   val healthController: HealthController

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/controller/LearningpathControllerV2.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/controller/LearningpathControllerV2.scala
@@ -9,7 +9,6 @@
 package no.ndla.learningpathapi.controller
 
 import no.ndla.common.errors.AccessDeniedException
-import no.ndla.common.scalatra.NdlaSwaggerSupport
 import no.ndla.language.Language.AllLanguages
 import no.ndla.learningpathapi.Props
 import no.ndla.learningpathapi.integration.TaxonomyApiClient
@@ -21,6 +20,7 @@ import no.ndla.learningpathapi.service.{ConverterService, ReadService, UpdateSer
 import no.ndla.learningpathapi.validation.LanguageValidator
 import no.ndla.mapping
 import no.ndla.mapping.LicenseDefinition
+import no.ndla.network.scalatra.NdlaSwaggerSupport
 import org.json4s.ext.JavaTimeSerializers
 import org.json4s.{DefaultFormats, Formats}
 import org.scalatra.swagger._

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/controller/NdlaController.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/controller/NdlaController.scala
@@ -10,13 +10,13 @@ package no.ndla.learningpathapi.controller
 
 import cats.implicits._
 import no.ndla.common.errors.{AccessDeniedException, ValidationException}
-import no.ndla.common.scalatra.NdlaSwaggerSupport
 import no.ndla.learningpathapi.integration.DataSource
 import no.ndla.learningpathapi.model.api.{Error, ErrorHelpers, ImportReport, ValidationError}
 import no.ndla.learningpathapi.model.domain._
 import no.ndla.learningpathapi.service.ConverterService
+import no.ndla.network.AuthUser
 import no.ndla.network.model.HttpRequestException
-import no.ndla.network.{ApplicationUrl, AuthUser}
+import no.ndla.network.scalatra.NdlaSwaggerSupport
 import no.ndla.search.{IndexNotFoundException, NdlaSearchException}
 import org.json4s.{DefaultFormats, Formats}
 import org.postgresql.util.PSQLException
@@ -34,13 +34,6 @@ trait NdlaController {
 
     before() {
       contentType = formats("json")
-      ApplicationUrl.set(request)
-      AuthUser.set(request)
-    }
-
-    after() {
-      ApplicationUrl.clear()
-      AuthUser.clear()
     }
 
     // This lets us return Try[T] and handle errors automatically, otherwise return 200 OK :^)

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/controller/StatsController.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/controller/StatsController.scala
@@ -7,10 +7,10 @@
 
 package no.ndla.learningpathapi.controller
 
-import no.ndla.common.scalatra.NdlaSwaggerSupport
 import no.ndla.learningpathapi.Props
 import no.ndla.learningpathapi.model.api.{Error, Stats}
 import no.ndla.learningpathapi.service.ReadService
+import no.ndla.network.scalatra.NdlaSwaggerSupport
 import org.json4s.{DefaultFormats, Formats}
 import org.scalatra.swagger.{ResponseMessage, Swagger}
 import org.scalatra.{NotFound, Ok}

--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/TestEnvironment.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/TestEnvironment.scala
@@ -10,7 +10,6 @@ package no.ndla.learningpathapi
 
 import com.zaxxer.hikari.HikariDataSource
 import no.ndla.common.Clock
-import no.ndla.common.scalatra.{NdlaControllerBase, NdlaSwaggerSupport}
 import no.ndla.learningpathapi.controller.{
   ConfigController,
   HealthController,
@@ -41,6 +40,7 @@ import no.ndla.learningpathapi.service.search.{SearchConverterServiceComponent, 
 import no.ndla.learningpathapi.validation._
 import no.ndla.network.NdlaClient
 import no.ndla.network.clients.{FeideApiClient, RedisClient}
+import no.ndla.network.scalatra.{NdlaControllerBase, NdlaSwaggerSupport}
 import no.ndla.search.{BaseIndexService, Elastic4sClient, NdlaE4sClient}
 import org.mockito.scalatest.MockitoSugar
 

--- a/network/src/main/scala/no/ndla/network/AuthUser.scala
+++ b/network/src/main/scala/no/ndla/network/AuthUser.scala
@@ -11,6 +11,22 @@ import javax.servlet.http.HttpServletRequest
 import no.ndla.network.jwt.JWTExtractor
 import no.ndla.network.model.NdlaHttpRequest
 
+case class AuthUser(
+    userId: Option[String],
+    userRoles: List[String],
+    userName: Option[String],
+    clientId: Option[String],
+    authHeader: Option[String]
+) {
+  def setThreadContext(): Unit = {
+    userId.foreach(AuthUser.setId)
+    AuthUser.setRoles(userRoles)
+    userName.foreach(AuthUser.setName)
+    clientId.foreach(AuthUser.setClientId)
+    authHeader.foreach(AuthUser.setHeader)
+  }
+}
+
 object AuthUser {
 
   def getAuth0HostForEnv(env: String): String = {
@@ -29,22 +45,35 @@ object AuthUser {
   private val clientId   = ThreadLocal.withInitial[Option[String]](() => None)
   private val authHeader = ThreadLocal.withInitial[Option[String]](() => None)
 
-  def set(request: HttpServletRequest): Unit = set(NdlaHttpRequest(request))
-
-  def set(request: NdlaHttpRequest): Unit = {
+  def fromRequest(request: HttpServletRequest): AuthUser = fromRequest(NdlaHttpRequest(request))
+  def fromRequest(request: NdlaHttpRequest): AuthUser = {
     val jWTExtractor = JWTExtractor(request)
-    jWTExtractor.extractUserId().foreach(setId)
-    setRoles(jWTExtractor.extractUserRoles())
-    jWTExtractor.extractUserName().foreach(setName)
-    jWTExtractor.extractClientId().foreach(setClientId)
-    request.getHeader("Authorization").foreach(setHeader)
+    new AuthUser(
+      userId = jWTExtractor.extractUserId(),
+      userRoles = jWTExtractor.extractUserRoles(),
+      userName = jWTExtractor.extractUserName(),
+      clientId = jWTExtractor.extractClientId(),
+      authHeader = request.getHeader("Authorization")
+    )
+  }
+  def fromThreadContext(): AuthUser = {
+    new AuthUser(
+      userId = AuthUser.get,
+      userRoles = AuthUser.getRoles,
+      userName = AuthUser.getName,
+      clientId = AuthUser.getClientId,
+      authHeader = AuthUser.getHeader
+    )
   }
 
-  def setId(user: String): Unit           = userId.set(Option(user))
-  def setRoles(roles: List[String]): Unit = userRoles.set(roles)
-  def setName(name: String): Unit         = userName.set(Option(name))
-  def setClientId(client: String): Unit   = clientId.set(Option(client))
-  def setHeader(header: String): Unit     = authHeader.set(Option(header))
+  def set(request: HttpServletRequest): Unit = set(NdlaHttpRequest(request))
+  def set(request: NdlaHttpRequest): Unit    = fromRequest(request).setThreadContext()
+
+  private def setId(user: String): Unit           = userId.set(Option(user))
+  private def setRoles(roles: List[String]): Unit = userRoles.set(roles)
+  private def setName(name: String): Unit         = userName.set(Option(name))
+  private def setClientId(client: String): Unit   = clientId.set(Option(client))
+  def setHeader(header: String): Unit             = authHeader.set(Option(header))
 
   def get: Option[String]         = userId.get
   def getRoles: List[String]      = userRoles.get

--- a/network/src/main/scala/no/ndla/network/TaxonomyData.scala
+++ b/network/src/main/scala/no/ndla/network/TaxonomyData.scala
@@ -1,0 +1,31 @@
+/*
+ * Part of NDLA network.
+ * Copyright (C) 2023 NDLA
+ *
+ * See LICENSE
+ *
+ */
+
+package no.ndla.network
+
+import javax.servlet.http.HttpServletRequest
+
+object TaxonomyData {
+  private val TAXONOMY_VERSION_HEADER = "VersionHash"
+  private val taxonomyVersion         = new ThreadLocal[String]
+  private val defaultVersion          = "default"
+
+  def set(value: String): Unit = {
+    val taxonomyVersionValue = Option(value).getOrElse(defaultVersion)
+    taxonomyVersion.set(taxonomyVersionValue)
+  }
+
+  def getFromRequest(request: HttpServletRequest): String = {
+    Option(request.getHeader(TAXONOMY_VERSION_HEADER)).getOrElse(defaultVersion)
+  }
+
+  def get: String = Option(taxonomyVersion.get()).getOrElse(defaultVersion)
+
+  def clear(): Unit = taxonomyVersion.remove()
+
+}

--- a/network/src/main/scala/no/ndla/network/scalatra/BaseHealthController.scala
+++ b/network/src/main/scala/no/ndla/network/scalatra/BaseHealthController.scala
@@ -1,16 +1,21 @@
 /*
- * Part of NDLA common
+ * Part of NDLA network
  * Copyright (C) 2022 NDLA
  *
  * See LICENSE
  *
  */
-package no.ndla.common.scalatra
+package no.ndla.network.scalatra
 
 import no.ndla.common.Warmup
+import no.ndla.network.model.RequestInfo
 import org.scalatra._
 
 class BaseHealthController extends ScalatraServlet with Warmup {
+
+  before() {
+    RequestInfo.fromRequest(request).setRequestInfo()
+  }
 
   protected def doIfWarmedUp(func: => Any): Any = {
     if (isWarmedUp) {

--- a/network/src/main/scala/no/ndla/network/scalatra/NdlaControllerBase.scala
+++ b/network/src/main/scala/no/ndla/network/scalatra/NdlaControllerBase.scala
@@ -1,18 +1,18 @@
 /*
- * Part of NDLA common.
+ * Part of NDLA network.
  * Copyright (C) 2022 NDLA
  *
  * See LICENSE
  *
  */
 
-package no.ndla.common.scalatra
+package no.ndla.network.scalatra
 
 import com.typesafe.scalalogging.StrictLogging
-import no.ndla.common.CorrelationID
 import no.ndla.common.RequestLogger.beforeRequestLogString
 import no.ndla.common.configuration.HasBaseProps
 import no.ndla.common.errors.{ValidationException, ValidationMessage}
+import no.ndla.network.model.RequestInfo
 import org.json4s.ext.JavaTimeSerializers
 import org.json4s.native.Serialization.read
 import org.json4s.{DefaultFormats, Formats}
@@ -34,7 +34,7 @@ trait NdlaControllerBase {
     def ndlaErrorHandler: NdlaErrorHandler
 
     before() {
-      CorrelationID.set(request)
+      RequestInfo.fromRequest(request).setRequestInfo()
 
       logger.info(
         beforeRequestLogString(request.getMethod, request.getRequestURI, request.queryString)

--- a/network/src/main/scala/no/ndla/network/scalatra/NdlaRequestLogger.scala
+++ b/network/src/main/scala/no/ndla/network/scalatra/NdlaRequestLogger.scala
@@ -1,17 +1,17 @@
 /*
- * Part of NDLA common.
+ * Part of NDLA network.
  * Copyright (C) 2022 NDLA
  *
  * See LICENSE
  *
  */
 
-package no.ndla.common.scalatra
+package no.ndla.network.scalatra
 
 import com.typesafe.scalalogging.StrictLogging
-import no.ndla.common.CorrelationID
 import no.ndla.common.RequestLogger.afterRequestLogString
 import no.ndla.common.configuration.BaseProps
+import no.ndla.network.model.RequestInfo
 import org.eclipse.jetty.server.{Request, RequestLog, Response}
 
 class NdlaRequestLogger[PROPS <: BaseProps](props: PROPS) extends RequestLog with StrictLogging {
@@ -31,6 +31,6 @@ class NdlaRequestLogger[PROPS <: BaseProps](props: PROPS) extends RequestLog wit
       )
     )
 
-    CorrelationID.clear()
+    RequestInfo.clear()
   }
 }

--- a/network/src/main/scala/no/ndla/network/scalatra/NdlaScalatraBootstrapBase.scala
+++ b/network/src/main/scala/no/ndla/network/scalatra/NdlaScalatraBootstrapBase.scala
@@ -1,12 +1,12 @@
 /*
- * Part of NDLA common.
+ * Part of NDLA network.
  * Copyright (C) 2022 NDLA
  *
  * See LICENSE
  *
  */
 
-package no.ndla.common.scalatra
+package no.ndla.network.scalatra
 
 import org.scalatra.LifeCycle
 import javax.servlet.ServletContext

--- a/network/src/main/scala/no/ndla/network/scalatra/NdlaScalatraServer.scala
+++ b/network/src/main/scala/no/ndla/network/scalatra/NdlaScalatraServer.scala
@@ -1,12 +1,12 @@
 /*
- * Part of NDLA common.
+ * Part of NDLA network.
  * Copyright (C) 2022 NDLA
  *
  * See LICENSE
  *
  */
 
-package no.ndla.common.scalatra
+package no.ndla.network.scalatra
 
 import com.typesafe.scalalogging.StrictLogging
 import net.bull.javamelody.{MonitoringFilter, Parameter, ReportServlet, SessionListener}

--- a/network/src/main/scala/no/ndla/network/scalatra/NdlaSwaggerSupport.scala
+++ b/network/src/main/scala/no/ndla/network/scalatra/NdlaSwaggerSupport.scala
@@ -1,12 +1,12 @@
 /*
- * Part of NDLA common.
+ * Part of NDLA network.
  * Copyright (C) 2022 NDLA
  *
  * See LICENSE
  *
  */
 
-package no.ndla.common.scalatra
+package no.ndla.network.scalatra
 
 import com.typesafe.scalalogging.StrictLogging
 import no.ndla.common.configuration.HasBaseProps

--- a/oembed-proxy/src/main/scala/no/ndla/oembedproxy/ComponentRegistry.scala
+++ b/oembed-proxy/src/main/scala/no/ndla/oembedproxy/ComponentRegistry.scala
@@ -9,8 +9,8 @@
 package no.ndla.oembedproxy
 
 import no.ndla.common.configuration.BaseComponentRegistry
-import no.ndla.common.scalatra.{NdlaControllerBase, NdlaSwaggerSupport}
 import no.ndla.network.NdlaClient
+import no.ndla.network.scalatra.{NdlaControllerBase, NdlaSwaggerSupport}
 import no.ndla.oembedproxy.caching.MemoizeHelpers
 import no.ndla.oembedproxy.controller.{HealthController, OEmbedProxyController}
 import no.ndla.oembedproxy.model.ErrorHelpers

--- a/oembed-proxy/src/main/scala/no/ndla/oembedproxy/MainClass.scala
+++ b/oembed-proxy/src/main/scala/no/ndla/oembedproxy/MainClass.scala
@@ -9,7 +9,7 @@
 package no.ndla.oembedproxy
 
 import com.typesafe.scalalogging.StrictLogging
-import no.ndla.common.scalatra.NdlaScalatraServer
+import no.ndla.network.scalatra.NdlaScalatraServer
 import org.eclipse.jetty.server.Server
 
 class MainClass(props: OEmbedProxyProperties) extends StrictLogging {

--- a/oembed-proxy/src/main/scala/no/ndla/oembedproxy/ScalatraBootstrap.scala
+++ b/oembed-proxy/src/main/scala/no/ndla/oembedproxy/ScalatraBootstrap.scala
@@ -7,7 +7,7 @@
  */
 package no.ndla.oembedproxy
 
-import no.ndla.common.scalatra.NdlaScalatraBootstrapBase
+import no.ndla.network.scalatra.NdlaScalatraBootstrapBase
 import javax.servlet.ServletContext
 
 class ScalatraBootstrap extends NdlaScalatraBootstrapBase[ComponentRegistry] {

--- a/oembed-proxy/src/main/scala/no/ndla/oembedproxy/controller/HealthController.scala
+++ b/oembed-proxy/src/main/scala/no/ndla/oembedproxy/controller/HealthController.scala
@@ -8,7 +8,7 @@
 
 package no.ndla.oembedproxy.controller
 
-import no.ndla.common.scalatra.BaseHealthController
+import no.ndla.network.scalatra.BaseHealthController
 
 trait HealthController {
   val healthController: HealthController

--- a/oembed-proxy/src/main/scala/no/ndla/oembedproxy/controller/OEmbedProxyController.scala
+++ b/oembed-proxy/src/main/scala/no/ndla/oembedproxy/controller/OEmbedProxyController.scala
@@ -8,9 +8,8 @@
 
 package no.ndla.oembedproxy.controller
 
-import no.ndla.common.scalatra.{NdlaControllerBase, NdlaSwaggerSupport}
-import no.ndla.network.ApplicationUrl
 import no.ndla.network.model.HttpRequestException
+import no.ndla.network.scalatra.{NdlaControllerBase, NdlaSwaggerSupport}
 import no.ndla.oembedproxy.model._
 import no.ndla.oembedproxy.service.OEmbedServiceComponent
 import org.json4s.{DefaultFormats, Formats}
@@ -51,11 +50,6 @@ trait OEmbedProxyController {
 
     before() {
       contentType = formats("json")
-      ApplicationUrl.set(request)
-    }
-
-    after() {
-      ApplicationUrl.clear()
     }
 
     import ErrorHelpers._

--- a/oembed-proxy/src/test/scala/no/ndla/oembedproxy/TestEnvironment.scala
+++ b/oembed-proxy/src/test/scala/no/ndla/oembedproxy/TestEnvironment.scala
@@ -8,8 +8,8 @@
 
 package no.ndla.oembedproxy
 
-import no.ndla.common.scalatra.{NdlaControllerBase, NdlaSwaggerSupport}
 import no.ndla.network.NdlaClient
+import no.ndla.network.scalatra.{NdlaControllerBase, NdlaSwaggerSupport}
 import no.ndla.oembedproxy.caching.MemoizeHelpers
 import no.ndla.oembedproxy.controller.{HealthController, OEmbedProxyController}
 import no.ndla.oembedproxy.model.ErrorHelpers

--- a/project/networklib.scala
+++ b/project/networklib.scala
@@ -16,7 +16,7 @@ object networklib extends Module {
       "javax.servlet"         % "javax.servlet-api"       % "4.0.1"    % "provided;test",
       "com.github.jwt-scala" %% "jwt-json4s-native"       % "9.0.2",
       "redis.clients"         % "jedis"                   % "4.2.3"
-    ) ++ vulnerabilityOverrides
+    ) ++ vulnerabilityOverrides ++ scalatra
   )
 
   override lazy val settings: Seq[Def.Setting[_]] = Seq(

--- a/search-api/src/main/scala/no/ndla/searchapi/ComponentRegistry.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/ComponentRegistry.scala
@@ -10,9 +10,9 @@ package no.ndla.searchapi
 
 import com.typesafe.scalalogging.StrictLogging
 import no.ndla.common.configuration.BaseComponentRegistry
-import no.ndla.common.scalatra.{NdlaControllerBase, NdlaSwaggerSupport}
 import no.ndla.network.NdlaClient
 import no.ndla.network.clients.{FeideApiClient, RedisClient}
+import no.ndla.network.scalatra.{NdlaControllerBase, NdlaSwaggerSupport}
 import no.ndla.search.{BaseIndexService, Elastic4sClient, Elastic4sClientFactory, NdlaE4sClient}
 import no.ndla.searchapi.auth.User
 import no.ndla.searchapi.controller.{HealthController, InternController, NdlaController, SearchController}

--- a/search-api/src/main/scala/no/ndla/searchapi/MainClass.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/MainClass.scala
@@ -10,7 +10,7 @@ package no.ndla.searchapi
 
 import com.typesafe.scalalogging.StrictLogging
 import no.ndla.common.Environment.booleanPropOrFalse
-import no.ndla.common.scalatra.NdlaScalatraServer
+import no.ndla.network.scalatra.NdlaScalatraServer
 import no.ndla.searchapi.service.StandaloneIndexing
 import org.eclipse.jetty.server.Server
 

--- a/search-api/src/main/scala/no/ndla/searchapi/ScalatraBootstrap.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/ScalatraBootstrap.scala
@@ -8,7 +8,7 @@
 
 package no.ndla.searchapi
 
-import no.ndla.common.scalatra.NdlaScalatraBootstrapBase
+import no.ndla.network.scalatra.NdlaScalatraBootstrapBase
 import javax.servlet.ServletContext
 
 class ScalatraBootstrap extends NdlaScalatraBootstrapBase[ComponentRegistry] {

--- a/search-api/src/main/scala/no/ndla/searchapi/controller/HealthController.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/controller/HealthController.scala
@@ -8,7 +8,7 @@
 
 package no.ndla.searchapi.controller
 
-import no.ndla.common.scalatra.BaseHealthController
+import no.ndla.network.scalatra.BaseHealthController
 
 trait HealthController {
   val healthController: HealthController

--- a/search-api/src/main/scala/no/ndla/searchapi/controller/InternController.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/controller/InternController.scala
@@ -136,7 +136,7 @@ trait InternController {
     }
 
     post("/index/draft") {
-      val requestInfo = RequestInfo()
+      val requestInfo = RequestInfo.fromThreadContext()
       val draftIndex = Future {
         requestInfo.setRequestInfo()
         ("drafts", draftIndexService.indexDocuments())
@@ -146,7 +146,7 @@ trait InternController {
     }
 
     post("/index/article") {
-      val requestInfo = RequestInfo()
+      val requestInfo = RequestInfo.fromThreadContext()
       val articleIndex = Future {
         requestInfo.setRequestInfo()
         ("articles", articleIndexService.indexDocuments())
@@ -156,7 +156,7 @@ trait InternController {
     }
 
     post("/index/learningpath") {
-      val requestInfo = RequestInfo()
+      val requestInfo = RequestInfo.fromThreadContext()
       val learningPathIndex = Future {
         requestInfo.setRequestInfo()
         ("learningpaths", learningPathIndexService.indexDocuments())
@@ -177,7 +177,7 @@ trait InternController {
       bundles match {
         case Failure(ex) => errorHandler(ex)
         case Success((taxonomyBundle, grepBundle)) =>
-          val requestInfo = RequestInfo()
+          val requestInfo = RequestInfo.fromThreadContext()
           val indexes = List(
             Future {
               requestInfo.setRequestInfo()

--- a/search-api/src/main/scala/no/ndla/searchapi/controller/NdlaController.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/controller/NdlaController.scala
@@ -10,11 +10,10 @@ package no.ndla.searchapi.controller
 
 import enumeratum.Json4s
 import no.ndla.common.errors.AccessDeniedException
-import no.ndla.common.model.domain.{ArticleType, Availability}
 import no.ndla.common.model.domain.draft.{DraftStatus, RevisionStatus}
 import no.ndla.common.model.domain.learningpath.EmbedType
-import no.ndla.common.scalatra.NdlaControllerBase
-import no.ndla.network.{ApplicationUrl, AuthUser}
+import no.ndla.common.model.domain.{ArticleType, Availability}
+import no.ndla.network.scalatra.NdlaControllerBase
 import no.ndla.search.{IndexNotFoundException, NdlaSearchException}
 import no.ndla.searchapi.Props
 import no.ndla.searchapi.model.api.{Error, ErrorHelpers, TaxonomyException}
@@ -47,13 +46,6 @@ trait NdlaController {
 
     before() {
       contentType = formats("json")
-      ApplicationUrl.set(request)
-      AuthUser.set(request)
-    }
-
-    after() {
-      AuthUser.clear()
-      ApplicationUrl.clear()
     }
 
     import ErrorHelpers._

--- a/search-api/src/main/scala/no/ndla/searchapi/controller/SearchController.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/controller/SearchController.scala
@@ -11,9 +11,9 @@ package no.ndla.searchapi.controller
 import no.ndla.common.errors.AccessDeniedException
 import no.ndla.common.model.domain.draft.DraftStatus
 import no.ndla.common.model.domain.{ArticleType, Availability}
-import no.ndla.common.scalatra.NdlaSwaggerSupport
 import no.ndla.language.Language.AllLanguages
 import no.ndla.network.clients.FeideApiClient
+import no.ndla.network.scalatra.NdlaSwaggerSupport
 import no.ndla.searchapi.Props
 import no.ndla.searchapi.auth.{Role, User}
 import no.ndla.searchapi.integration.SearchApiClient

--- a/search-api/src/main/scala/no/ndla/searchapi/integration/GrepApiClient.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/integration/GrepApiClient.scala
@@ -48,7 +48,7 @@ trait GrepApiClient {
       val startFetch                            = System.currentTimeMillis()
       implicit val ec: ExecutionContextExecutor = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(3))
 
-      val requestInfo = RequestInfo()
+      val requestInfo = RequestInfo.fromThreadContext()
 
       /** Calls function in separate thread and converts Try to Future */
       def tryToFuture[T](x: () => Try[T]) = Future { requestInfo.setRequestInfo(); x() }.flatMap(Future.fromTry)

--- a/search-api/src/main/scala/no/ndla/searchapi/integration/SearchApiClient.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/integration/SearchApiClient.scala
@@ -75,7 +75,7 @@ trait SearchApiClient {
         "page"      -> page.toString,
         "page-size" -> pageSize.toString
       )
-      val reqs = RequestInfo()
+      val reqs = RequestInfo.fromThreadContext()
       reqs.setRequestInfo()
       get[DomainDumpResults[T]](dumpDomainPath, params, timeout = 120000) match {
         case Success(result) =>

--- a/search-api/src/main/scala/no/ndla/searchapi/integration/TaxonomyApiClient.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/integration/TaxonomyApiClient.scala
@@ -77,7 +77,7 @@ trait TaxonomyApiClient {
       val startFetch                            = System.currentTimeMillis()
       implicit val ec: ExecutionContextExecutor = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(12))
 
-      val requestInfo = RequestInfo()
+      val requestInfo = RequestInfo.fromThreadContext()
 
       /** Calls function in separate thread and converts Try to Future */
       def tryToFuture[T](x: () => Try[T]) = Future { requestInfo.setRequestInfo(); x() }.flatMap(Future.fromTry)

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/MultiDraftSearchService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/MultiDraftSearchService.scala
@@ -259,7 +259,7 @@ trait MultiDraftSearchService {
       val threadPoolSize = if (searchIndex.nonEmpty) searchIndex.size else 1
       implicit val ec: ExecutionContextExecutor =
         ExecutionContext.fromExecutor(Executors.newFixedThreadPool(threadPoolSize))
-      val requestInfo = RequestInfo()
+      val requestInfo = RequestInfo.fromThreadContext()
 
       val draftFuture = Future {
         requestInfo.setRequestInfo()

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/MultiSearchService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/MultiSearchService.scala
@@ -198,7 +198,7 @@ trait MultiSearchService {
       val threadPoolSize = if (searchIndex.nonEmpty) searchIndex.size else 1
       implicit val ec: ExecutionContextExecutor =
         ExecutionContext.fromExecutor(Executors.newFixedThreadPool(threadPoolSize))
-      val requestInfo = RequestInfo()
+      val requestInfo = RequestInfo.fromThreadContext()
 
       val articleFuture = Future {
         requestInfo.setRequestInfo()

--- a/search-api/src/test/scala/no/ndla/searchapi/TestEnvironment.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/TestEnvironment.scala
@@ -9,9 +9,9 @@
 package no.ndla.searchapi
 
 import com.typesafe.scalalogging.StrictLogging
-import no.ndla.common.scalatra.{NdlaControllerBase, NdlaSwaggerSupport}
 import no.ndla.network.NdlaClient
 import no.ndla.network.clients.{FeideApiClient, RedisClient}
+import no.ndla.network.scalatra.{NdlaControllerBase, NdlaSwaggerSupport}
 import no.ndla.search.{BaseIndexService, Elastic4sClient, NdlaE4sClient}
 import no.ndla.searchapi.auth.User
 import no.ndla.searchapi.controller.{HealthController, InternController, NdlaController, SearchController}


### PR DESCRIPTION
Endrer så vi kun bruker `RequestInfo` og (wrappere i den igjen) for å sette tråd-context variabler.
Nå er også alle threadlocal/context tingene wrappet i objekter som gjør de litt tryggere å bruke.

Måtte flytte scalatra-biten av `common` til `network`, men det har liten praktisk betydning annet enn at jeg måtte endre importene.

Dette fikser feilene med `5xx` ved publisering og div lagring, og gjør forhåpentligvis at sånne feil er litt vanskeligere å lage :smile: 