### PR TITLE
Fix role assignment algorithm

### DIFF
--- a/network/src/main/scala/no/ndla/network/clients/FeideApiClient.scala
+++ b/network/src/main/scala/no/ndla/network/clients/FeideApiClient.scala
@@ -32,10 +32,17 @@ case class FeideExtendedUserInfo(
     eduPersonPrincipalName: String
 ) {
 
-  def isTeacher: Boolean = {
+  private def isStudentAffiliation: Boolean = this.eduPersonAffiliation.contains("student")
+  private def isTeacherAffiliation: Boolean = {
     this.eduPersonAffiliation.contains("staff") ||
     this.eduPersonAffiliation.contains("faculty") ||
     this.eduPersonAffiliation.contains("employee")
+  }
+
+  def isTeacher: Boolean = {
+    if (this.isStudentAffiliation) false
+    else if (this.isTeacherAffiliation) true
+    else false
   }
 
   def availabilities: Seq[Availability.Value] = {


### PR DESCRIPTION
There might be cases where Feide user has both student and employee affiliation. In those cases we want to assign the lowest privileged role which is the Student role.