### PR TITLE
Be consistent with `reponsibleId` field in `UpdatedConcept` and `NewConcept`

### DIFF
--- a/concept-api/src/main/scala/no/ndla/conceptapi/model/api/UpdatedConcept.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/model/api/UpdatedConcept.scala
@@ -26,6 +26,6 @@ case class UpdatedConcept(
     @(ApiModelProperty @field)(description = "Article id to which the concept is connected to") articleIds: Option[Seq[Long]],
     @(ApiModelProperty @field)(description = "The new status of the concept") status: Option[String],
     @(ApiModelProperty @field)(description = "A visual element for the concept. May be anything from an image to a video or H5P") visualElement: Option[String],
-    @(ApiModelProperty @field)(description = "NDLA ID representing the editor responsible for this article") responsible: Deletable[String],
+    @(ApiModelProperty @field)(description = "NDLA ID representing the editor responsible for this article") responsibleId: Deletable[String],
     // format: on
 )

--- a/concept-api/src/main/scala/no/ndla/conceptapi/service/ConverterService.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/service/ConverterService.scala
@@ -225,7 +225,7 @@ trait ConverterService {
         else toMergeInto.updatedBy
       }
 
-      val responsible = updateConcept.responsible match {
+      val responsible = updateConcept.responsibleId match {
         case Left(_)                    => None
         case Right(Some(responsibleId)) => Some(Responsible(responsibleId, clock.now()))
         case Right(None)                => toMergeInto.responsible
@@ -261,7 +261,7 @@ trait ConverterService {
         case Left(_)     => Seq.empty
       }
 
-      val responsible = concept.responsible match {
+      val responsible = concept.responsibleId match {
         case Left(_)                    => None
         case Right(Some(responsibleId)) => Some(Responsible(responsibleId, clock.now()))
         case Right(_)                   => None


### PR DESCRIPTION
Meg bekjent så er ikke dette tatt i bruk ennå, og det er enklere for alle om feltet heter det samme i `UpdatedConcept` og `NewConcept` :smile: