### PR TITLE
#3450: Add "all subject pages" endpoint

### DIFF
--- a/common/src/main/scala/no/ndla/common/implicits/package.scala
+++ b/common/src/main/scala/no/ndla/common/implicits/package.scala
@@ -40,6 +40,8 @@ package object implicits {
     }
   }
   implicit class TryQuestionMark[A](private val self: Try[A]) extends AnyVal {
+
+    /** See [[tryQuestionMarkOperator]] docs above */
     def ? : A = macro tryQuestionMarkOperator
   }
 

--- a/common/src/test/scala/no/ndla/common/QuestionMarkOperatorTest.scala
+++ b/common/src/test/scala/no/ndla/common/QuestionMarkOperatorTest.scala
@@ -1,0 +1,49 @@
+package no.ndla.common
+
+import no.ndla.scalatestsuite.UnitTestSuite
+import no.ndla.common.implicits._
+
+import scala.util.{Failure, Success, Try}
+
+class QuestionMarkOperatorTest extends UnitTestSuite {
+
+  val testException              = new RuntimeException("Bad method")
+  def failingMethod: Try[Int]    = Failure(testException)
+  def succeedingMethod: Try[Int] = Success(1)
+
+  def someMethod: Option[Int] = Some(1)
+  def noneMethod: Option[Int] = None
+
+  test("That question mark operator works on success for try methods") {
+    def tryMethod(): Try[String] = {
+      val someData = succeedingMethod.?
+      Success(someData.toString)
+    }
+    tryMethod() should be(Success("1"))
+  }
+
+  test("That question mark operator works on failure for try methods") {
+    def tryMethod(): Try[String] = {
+      val someData = failingMethod.?
+      Success(someData.toString)
+    }
+    tryMethod() should be(Failure(testException))
+  }
+
+  test("That question mark operator works on some for option methods") {
+    def optMethod(): Option[String] = {
+      val someData = someMethod.?
+      Some(someData.toString)
+    }
+    optMethod() should be(Some("1"))
+  }
+
+  test("That question mark operator works on none for option methods") {
+    def optMethod(): Option[String] = {
+      val someData = noneMethod.?
+      Some(someData.toString)
+    }
+    optMethod() should be(None)
+  }
+
+}

--- a/frontpage-api/src/main/scala/no/ndla/frontpageapi/controller/FrontPageController.scala
+++ b/frontpage-api/src/main/scala/no/ndla/frontpageapi/controller/FrontPageController.scala
@@ -23,11 +23,6 @@ trait FrontPageController {
   class FrontPageController() extends SwaggerService {
     override val prefix: EndpointInput[Unit] = "frontpage-api" / "v1" / "frontpage"
 
-    private val errorOutputs = oneOf(
-      oneOfVariant(NotFoundError),
-      oneOfVariant(GenericError)
-    )
-
     override val endpoints: List[ServerEndpoint[Any, IO]] = List(
       endpoint.get
         .summary("Get data to display on the front page")

--- a/frontpage-api/src/main/scala/no/ndla/frontpageapi/controller/Service.scala
+++ b/frontpage-api/src/main/scala/no/ndla/frontpageapi/controller/Service.scala
@@ -6,16 +6,11 @@
  */
 package no.ndla.frontpageapi.controller
 
-import no.ndla.frontpageapi.model.api.ErrorHelpers
 import cats.effect.IO
 import com.typesafe.scalalogging.StrictLogging
-import io.circe.generic.auto._
-import no.ndla.frontpageapi.model.api._
+import no.ndla.frontpageapi.model.api.ErrorHelpers
 import org.http4s.HttpRoutes
-import sttp.model.StatusCode
 import sttp.tapir._
-import sttp.tapir.generic.auto._
-import sttp.tapir.json.circe._
 import sttp.tapir.server.ServerEndpoint
 
 trait Service {
@@ -41,18 +36,5 @@ trait Service {
         )
       })
     }
-
-    protected val NotFoundError: EndpointOutput[NotFoundError] =
-      statusCode(StatusCode.NotFound).and(jsonBody[NotFoundError])
-    protected val GenericError: EndpointOutput[GenericError] =
-      statusCode(StatusCode.InternalServerError).and(jsonBody[GenericError])
-    protected val BadRequestError: EndpointOutput[BadRequestError] =
-      statusCode(StatusCode.BadRequest).and(jsonBody[BadRequestError])
-    protected val UnprocessableEntityError: EndpointOutput[UnprocessableEntityError] =
-      statusCode(StatusCode.UnprocessableEntity).and(jsonBody[UnprocessableEntityError])
-    protected val ForbiddenError: EndpointOutput[ForbiddenError] =
-      statusCode(StatusCode.Forbidden).and(jsonBody[ForbiddenError])
-    protected val UnauthorizedError: EndpointOutput[UnauthorizedError] =
-      statusCode(StatusCode.Unauthorized).and(jsonBody[UnauthorizedError])
   }
 }

--- a/frontpage-api/src/main/scala/no/ndla/frontpageapi/controller/SubjectPageController.scala
+++ b/frontpage-api/src/main/scala/no/ndla/frontpageapi/controller/SubjectPageController.scala
@@ -10,46 +10,30 @@ package no.ndla.frontpageapi.controller
 import cats.effect.IO
 import cats.implicits._
 import io.circe.generic.auto._
+import no.ndla.frontpageapi.Props
 import no.ndla.frontpageapi.auth.UserInfo
 import no.ndla.frontpageapi.model.api.{
-  Error,
   ErrorHelpers,
   NewSubjectFrontPageData,
   SubjectPageData,
   UpdatedSubjectFrontPageData
 }
-import no.ndla.frontpageapi.model.domain.Errors.{NotFoundException, ValidationException}
+import no.ndla.frontpageapi.model.domain.Errors.ValidationException
 import no.ndla.frontpageapi.service.{ReadService, WriteService}
-import no.ndla.frontpageapi.Props
 import sttp.tapir._
 import sttp.tapir.generic.auto._
 import sttp.tapir.json.circe.jsonBody
 import sttp.tapir.model.CommaSeparated
 import sttp.tapir.server.ServerEndpoint
 
-import scala.util.{Failure, Success, Try}
-
 trait SubjectPageController {
   this: ReadService with WriteService with Props with ErrorHelpers with Service =>
   val subjectPageController: SubjectPageController
 
+  import ErrorHelpers.handleErrorOrOkClass
+
   class SubjectPageController extends SwaggerService {
     override val prefix: EndpointInput[Unit] = "frontpage-api" / "v1" / "subjectpage"
-
-    private val errorOutputs = oneOf[Error](
-      oneOfVariant(NotFoundError),
-      oneOfVariant(GenericError),
-      oneOfDefaultVariant(GenericError)
-    )
-
-    implicit class handleErrorOrOkClass[T](t: Try[T]) {
-      def handleErrorsOrOk: Either[Error, T] = {
-        t match {
-          case Success(value) => value.asRight
-          case Failure(ex)    => ErrorHelpers.returnError(ex).asLeft
-        }
-      }
-    }
 
     import UserInfo._
     override val endpoints: List[ServerEndpoint[Any, IO]] = List(
@@ -74,10 +58,9 @@ trait SubjectPageController {
         .out(jsonBody[SubjectPageData])
         .errorOut(errorOutputs)
         .serverLogicPure { case (id, language, fallback) =>
-          readService.subjectPage(id, language, fallback) match {
-            case Some(s) => s.asRight
-            case None    => ErrorHelpers.notFound.asLeft
-          }
+          readService
+            .subjectPage(id, language, fallback)
+            .handleErrorsOrOk
         },
       endpoint.get
         .summary("Fetch subject pages that matches ids parameter")
@@ -101,9 +84,7 @@ trait SubjectPageController {
         .securityIn(auth.bearer[Option[UserInfo]]())
         .in(jsonBody[NewSubjectFrontPageData])
         .out(jsonBody[SubjectPageData])
-        .errorOut(
-          oneOf(oneOfVariant(GenericError), oneOfVariant(ForbiddenError), oneOfVariant(UnprocessableEntityError))
-        )
+        .errorOut(errorOutputs)
         .serverSecurityLogicPure {
           case Some(user) if user.canWrite => user.asRight
           case Some(_)                     => ErrorHelpers.forbidden.asLeft
@@ -111,11 +92,11 @@ trait SubjectPageController {
         }
         .serverLogicPure { _ => newSubjectFrontPageData =>
           {
-            writeService.newSubjectPage(newSubjectFrontPageData) match {
-              case Success(s)                       => s.asRight
-              case Failure(ex: ValidationException) => ErrorHelpers.unprocessableEntity(ex.getMessage).asLeft
-              case Failure(_)                       => ErrorHelpers.generic.asLeft
-            }
+            writeService
+              .newSubjectPage(newSubjectFrontPageData)
+              .partialOverride { case ex: ValidationException =>
+                ErrorHelpers.unprocessableEntity(ex.getMessage)
+              }
           }
         },
       endpoint.patch
@@ -126,9 +107,7 @@ trait SubjectPageController {
         .in(query[String]("language").default(props.DefaultLanguage))
         .in(query[Boolean]("fallback").default(false))
         .out(jsonBody[SubjectPageData])
-        .errorOut(
-          oneOf(oneOfVariant(GenericError), oneOfVariant(ForbiddenError), oneOfVariant(UnprocessableEntityError))
-        )
+        .errorOut(errorOutputs)
         .serverSecurityLogicPure {
           case Some(user) if user.canWrite => user.asRight
           case Some(_)                     => ErrorHelpers.forbidden.asLeft
@@ -136,14 +115,12 @@ trait SubjectPageController {
         }
         .serverLogicPure { _ =>
           { case (subjectPage, id, language, fallback) =>
-            writeService.updateSubjectPage(id, subjectPage, language) match {
-              case Success(s)                       => s.asRight
-              case Failure(_: NotFoundException)    => ErrorHelpers.notFound.asLeft
-              case Failure(ex: ValidationException) => ErrorHelpers.unprocessableEntity(ex.getMessage).asLeft
-              case Failure(_)                       => ErrorHelpers.generic.asLeft
-            }
+            writeService
+              .updateSubjectPage(id, subjectPage, language)
+              .partialOverride { case ex: ValidationException =>
+                ErrorHelpers.unprocessableEntity(ex.getMessage)
+              }
           }
-
         }
     )
   }

--- a/frontpage-api/src/main/scala/no/ndla/frontpageapi/controller/SubjectPageController.scala
+++ b/frontpage-api/src/main/scala/no/ndla/frontpageapi/controller/SubjectPageController.scala
@@ -54,6 +54,19 @@ trait SubjectPageController {
     import UserInfo._
     override val endpoints: List[ServerEndpoint[Any, IO]] = List(
       endpoint.get
+        .summary("Fetch all subjectpages")
+        .in(query[Int]("page").default(1))
+        .in(query[Int]("page-size").default(props.DefaultPageSize))
+        .in(query[String]("language").default(props.DefaultLanguage))
+        .in(query[Boolean]("fallback").default(false))
+        .errorOut(errorOutputs)
+        .out(jsonBody[List[SubjectPageData]])
+        .serverLogicPure { case (page, pageSize, language, fallback) =>
+          readService
+            .subjectPages(page, pageSize, language, fallback)
+            .handleErrorsOrOk
+        },
+      endpoint.get
         .summary("Get data to display on a subject page")
         .in(path[Long]("subjectpage-id").description("The subjectpage id"))
         .in(query[String]("language").default(props.DefaultLanguage))
@@ -79,7 +92,9 @@ trait SubjectPageController {
         .serverLogicPure { case (ids, language, fallback, pageSize, page) =>
           val parsedPageSize = if (pageSize < 1) props.DefaultPageSize else pageSize
           val parsedPage     = if (page < 1) 1 else page
-          readService.getSubjectPageByIds(ids.values, language, fallback, parsedPageSize, parsedPage).handleErrorsOrOk
+          readService
+            .getSubjectPageByIds(ids.values, language, fallback, parsedPageSize, parsedPage)
+            .handleErrorsOrOk
         },
       endpoint.post
         .summary("Create new subject page")

--- a/frontpage-api/src/main/scala/no/ndla/frontpageapi/model/api/Error.scala
+++ b/frontpage-api/src/main/scala/no/ndla/frontpageapi/model/api/Error.scala
@@ -11,13 +11,22 @@ import no.ndla.common.Clock
 
 import java.time.LocalDateTime
 import no.ndla.frontpageapi.Props
-import no.ndla.frontpageapi.model.domain.Errors.ValidationException
+import no.ndla.frontpageapi.model.domain.Errors.{LanguageNotFoundException, NotFoundException, ValidationException}
+import org.log4s.{Logger, getLogger}
+import sttp.model.StatusCode
+import io.circe.generic.auto._
+import sttp.tapir._
+import sttp.tapir.generic.auto._
+import sttp.tapir.json.circe.jsonBody
+
+import scala.util.{Failure, Success, Try}
 
 sealed trait Error {
   val code: String
   val description: String
   val occuredAt: LocalDateTime
 }
+
 case class NotFoundError(code: String, description: String, occuredAt: LocalDateTime)            extends Error
 case class GenericError(code: String, description: String, occuredAt: LocalDateTime)             extends Error
 case class BadRequestError(code: String, description: String, occuredAt: LocalDateTime)          extends Error
@@ -28,7 +37,37 @@ case class ForbiddenError(code: String, description: String, occuredAt: LocalDat
 trait ErrorHelpers {
   this: Props with Clock =>
 
+  val NotFoundVariant: EndpointOutput[NotFoundError] =
+    statusCode(StatusCode.NotFound).and(jsonBody[NotFoundError])
+
+  val GenericVariant: EndpointOutput[GenericError] =
+    statusCode(StatusCode.InternalServerError).and(jsonBody[GenericError])
+
+  val BadRequestVariant: EndpointOutput[BadRequestError] =
+    statusCode(StatusCode.BadRequest).and(jsonBody[BadRequestError])
+
+  val UnauthorizedVariant: EndpointOutput[UnauthorizedError] =
+    statusCode(StatusCode.Unauthorized).and(jsonBody[UnauthorizedError])
+
+  val ForbiddenVariant: EndpointOutput[ForbiddenError] =
+    statusCode(StatusCode.Forbidden).and(jsonBody[ForbiddenError])
+
+  val UnprocessableEntityVariant: EndpointOutput[UnprocessableEntityError] =
+    statusCode(StatusCode.UnprocessableEntity).and(jsonBody[UnprocessableEntityError])
+
+  val errorOutputs: EndpointOutput.OneOf[Error, Error] =
+    oneOf[Error](
+      oneOfVariant(NotFoundVariant),
+      oneOfVariant(GenericVariant),
+      oneOfVariant(BadRequestVariant),
+      oneOfVariant(UnauthorizedVariant),
+      oneOfVariant(ForbiddenVariant),
+      oneOfVariant(UnprocessableEntityVariant)
+    )
+
   object ErrorHelpers {
+    val logger: Logger = getLogger
+
     val GENERIC              = "GENERIC"
     val NOT_FOUND            = "NOT_FOUND"
     val BAD_REQUEST          = "BAD_REQUEST"
@@ -43,20 +82,57 @@ trait ErrorHelpers {
     val UNAUTHORIZED_DESCRIPTION = "Missing user/client-id or role"
     val FORBIDDEN_DESCRIPTION    = "You do not have the required permissions to access that resource"
 
-    def generic: GenericError   = GenericError(GENERIC, GENERIC_DESCRIPTION, clock.now())
-    def notFound: NotFoundError = NotFoundError(NOT_FOUND, NOT_FOUND_DESCRIPTION, clock.now())
+    def generic: GenericError                       = GenericError(GENERIC, GENERIC_DESCRIPTION, clock.now())
+    def notFound: NotFoundError                     = NotFoundError(NOT_FOUND, NOT_FOUND_DESCRIPTION, clock.now())
+    def notFoundWithMsg(msg: String): NotFoundError = NotFoundError(NOT_FOUND, msg, clock.now())
+    def badRequest(msg: String = BAD_REQUEST): BadRequestError = BadRequestError(BAD_REQUEST, msg, clock.now())
+    def unauthorized: UnauthorizedError = UnauthorizedError(UNAUTHORIZED, UNAUTHORIZED_DESCRIPTION, clock.now())
+    def forbidden: ForbiddenError       = ForbiddenError(FORBIDDEN, FORBIDDEN_DESCRIPTION, clock.now())
+    def unprocessableEntity(msg: String = UNPROCESSABLE_ENTITY): UnprocessableEntityError =
+      UnprocessableEntityError(UNPROCESSABLE_ENTITY, msg, clock.now())
 
     def returnError(ex: Throwable): Error = {
       ex match {
-        case a: ValidationException => unprocessableEntity(a.getMessage)
-        case _                      => generic
+        case a: ValidationException        => badRequest(ex.getMessage)
+        case ex: NotFoundException         => notFoundWithMsg(ex.getMessage)
+        case ex: LanguageNotFoundException => notFoundWithMsg(ex.getMessage)
+        case ex =>
+          logger.error(ex)(s"Internal error: ${ex.getMessage}")
+          generic
       }
     }
 
-    def badRequest(msg: String): BadRequestError = BadRequestError(BAD_REQUEST, msg, clock.now())
-    def unprocessableEntity(msg: String): UnprocessableEntityError =
-      UnprocessableEntityError(UNPROCESSABLE_ENTITY, msg, clock.now())
-    def unauthorized: UnauthorizedError = UnauthorizedError(UNAUTHORIZED, UNAUTHORIZED_DESCRIPTION, clock.now())
-    def forbidden: ForbiddenError       = ForbiddenError(FORBIDDEN, FORBIDDEN_DESCRIPTION, clock.now())
+    implicit class handleErrorOrOkClass[T](t: Try[T]) {
+      import cats.implicits._
+
+      /** Function to handle any error If the error is not defined in the default errorHandler [[returnError]] we
+        * fallback to a generic 500 error.
+        */
+      def handleErrorsOrOk: Either[Error, T] = {
+        t match {
+          case Success(value) => value.asRight
+          case Failure(ex)    => ErrorHelpers.returnError(ex).asLeft
+        }
+      }
+
+      /** Function to override one or more of error responses:
+        * {{{
+        *     someMethodThatReturnsTry().partialOverride { case x: SomeExceptionToHandle =>
+        *         ErrorHelpers.unprocessableEntity("Cannot process")
+        *     }
+        * }}}
+        *
+        * If the error is not defined in the callback or in the default errorHandler [[returnError]] we fallback to a
+        * generic 500 error.
+        */
+      def partialOverride(callback: PartialFunction[Throwable, Error]): Either[Error, T] = {
+        t match {
+          case Success(value)                          => value.asRight
+          case Failure(ex) if callback.isDefinedAt(ex) => callback(ex).asLeft
+          case Failure(ex)                             => ErrorHelpers.returnError(ex).asLeft
+        }
+      }
+
+    }
   }
 }

--- a/frontpage-api/src/main/scala/no/ndla/frontpageapi/repository/SubjectPageRepository.scala
+++ b/frontpage-api/src/main/scala/no/ndla/frontpageapi/repository/SubjectPageRepository.scala
@@ -42,6 +42,7 @@ trait SubjectPageRepository {
       })
     }
 
+
     def updateSubjectPage(
         subj: SubjectFrontPageData
     )(implicit session: DBSession = AutoSession): Try[SubjectFrontPageData] = {
@@ -51,6 +52,23 @@ trait SubjectPageRepository {
 
       Try(sql"update ${DBSubjectFrontPageData.table} set document=${dataObject} where id=${subj.id}".update())
         .map(_ => subj)
+    }
+
+    def all(offset: Int, limit: Int)(implicit session: DBSession = ReadOnlyAutoSession): Try[List[SubjectFrontPageData]] = {
+      val su = DBSubjectFrontPageData.syntax("su")
+      Try {
+        sql"""
+            select ${su.result.*}
+            from ${DBSubjectFrontPageData.as(su)}
+            where su.document is not null
+            order by su.id
+            offset $offset
+            limit $limit
+         """
+          .map(DBSubjectFrontPageData.fromDb(su))
+          .list()
+          .sequence
+      }.flatten
     }
 
     def withId(subjectId: Long): Option[SubjectFrontPageData] =

--- a/frontpage-api/src/test/scala/no/ndla/frontpageapi/service/ReadServiceTest.scala
+++ b/frontpage-api/src/test/scala/no/ndla/frontpageapi/service/ReadServiceTest.scala
@@ -1,0 +1,44 @@
+/*
+ * Part of NDLA frontpage-api.
+ * Copyright (C) 2023 NDLA
+ *
+ * See LICENSE
+ */
+
+package no.ndla.frontpageapi.service
+
+import no.ndla.frontpageapi.model.domain
+import no.ndla.frontpageapi.model.domain.VisualElementType
+import no.ndla.frontpageapi.{TestData, TestEnvironment, UnitSuite}
+
+import scala.util.Success
+
+class ReadServiceTest extends UnitSuite with TestEnvironment {
+  override val readService: ReadService = new ReadService
+
+  test("That all subjectpages does not fail on 404 because of language") {
+    val norwegianSubjectPage = TestData.domainSubjectPage.copy(
+      id = Some(2),
+      metaDescription = Seq(
+        domain.MetaDescription("hei", "nb")
+      ),
+      about = Seq(
+        domain.AboutSubject("tittel", "besk", "nb", domain.VisualElement(VisualElementType.Image, "", None))
+      )
+    )
+    val englishSubjectPage = TestData.domainSubjectPage.copy(
+      id = Some(2),
+      metaDescription = Seq(
+        domain.MetaDescription("hello", "en")
+      ),
+      about = Seq(
+        domain.AboutSubject("title", "desc", "en", domain.VisualElement(VisualElementType.Image, "1", None))
+      )
+    )
+
+    when(subjectPageRepository.all(any, any)(any)).thenReturn(Success(List(norwegianSubjectPage, englishSubjectPage)))
+
+    val result = readService.subjectPages(1, 10, "en", fallback = false)
+    result.get.map(_.id) should be(List(2))
+  }
+}


### PR DESCRIPTION
Fixes NDLANO/Issues#3450

- Legger til endepunkt `/frontpage-api/v1/subjectpages/`
- Legger til tester for spørsmålstegn operatorene :smile: 
- Gjør feilhåndtering litt mer generisk
  - Tidligere så endte vi med å ikke logge feil skikkelig siden vi bare returnerte 500 og ikke gjorde noe med feilen. Nå blir alle feil på en eller annen måte sendt igjennom `ErrorHelpers.returnError`