### PR TITLE
Context-types only returns contexts in taxonomy.

### DIFF
--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/TaxonomyFiltering.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/TaxonomyFiltering.scala
@@ -74,20 +74,10 @@ trait TaxonomyFiltering {
   protected def contextTypeFilter(contextTypes: List[LearningResourceType.Value]): Option[BoolQuery] =
     if (contextTypes.isEmpty) None
     else {
-      val articleTypeQuery = contextTypes.map(ct => termQuery("articleType", ct.toString))
-
-      val notArticleTypeQuery = if (contextTypes.contains(LearningResourceType.LearningPath)) {
-        List(boolQuery().not(existsQuery("articleType")))
-      } else {
-        List.empty
-      }
-
       val taxonomyContextQuery =
         contextTypes.map(ct => nestedQuery("contexts", termQuery("contexts.contextType", ct.toString)))
 
-      Some(
-        boolQuery().should(articleTypeQuery ++ taxonomyContextQuery ++ notArticleTypeQuery)
-      )
+      Some(boolQuery().should(taxonomyContextQuery))
     }
 
 }

--- a/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceTest.scala
@@ -477,8 +477,8 @@ class MultiDraftSearchServiceTest extends IntegrationSuite(EnableElasticsearchCo
       )
     )
 
-    search.totalCount should be(13)
-    search.results.map(_.id) should be(Seq(1, 2, 3, 5, 6, 7, 8, 9, 10, 11, 12, 13, 15))
+    search.totalCount should be(12)
+    search.results.map(_.id) should be(Seq(1, 2, 3, 5, 6, 7, 8, 9, 10, 11, 12, 15))
   }
 
   test("That filtering on learning-resource-type works") {
@@ -492,8 +492,8 @@ class MultiDraftSearchServiceTest extends IntegrationSuite(EnableElasticsearchCo
     search.totalCount should be(7)
     search.results.map(_.id) should be(Seq(1, 2, 3, 5, 6, 7, 12))
 
-    search2.totalCount should be(6)
-    search2.results.map(_.id) should be(Seq(8, 9, 10, 11, 13, 15))
+    search2.totalCount should be(5)
+    search2.results.map(_.id) should be(Seq(8, 9, 10, 11, 15))
   }
 
   test("That filtering on article-type works") {
@@ -517,25 +517,13 @@ class MultiDraftSearchServiceTest extends IntegrationSuite(EnableElasticsearchCo
     search3.results.map(_.id) should be(Seq(16))
   }
 
-  test("That filtering on multiple context-types returns every type") {
-    val Success(search) = multiDraftSearchService.matchingQuery(
-      multiDraftSearchSettings.copy(
-        language = "*",
-        learningResourceTypes = List(LearningResourceType.Article, LearningResourceType.TopicArticle)
-      )
-    )
-
-    search.totalCount should be(13)
-    search.results.map(_.id) should be(Seq(1, 2, 3, 5, 6, 7, 8, 9, 10, 11, 12, 13, 15))
-  }
-
-  test("That filtering on learningpath learningresourcetype returns learningpaths") {
+  test("That filtering on learningpath learningresourcetype returns learningpaths in structure") {
     val Success(search) = multiDraftSearchService.matchingQuery(
       multiDraftSearchSettings.copy(language = "*", learningResourceTypes = List(LearningResourceType.LearningPath))
     )
 
-    search.totalCount should be(6)
-    search.results.map(_.id) should be(Seq(1, 2, 3, 4, 5, 6))
+    search.totalCount should be(5)
+    search.results.map(_.id) should be(Seq(1, 2, 3, 4, 5))
     search.results.map(_.url.contains("learningpath")).distinct should be(Seq(true))
   }
 
@@ -730,26 +718,6 @@ class MultiDraftSearchServiceTest extends IntegrationSuite(EnableElasticsearchCo
     )
     search1.results.map(_.id) should be(expectedIds)
 
-  }
-
-  test("Filtering for learningresourcetype should still work if no context") {
-    val Success(search1) = multiDraftSearchService.matchingQuery(
-      multiDraftSearchSettings.copy(learningResourceTypes = List(LearningResourceType.TopicArticle))
-    )
-
-    search1.results.map(_.id) should be(Seq(8, 9, 11, 13, 15))
-    search1.results.apply(3).contexts should be(List.empty)
-
-    val Success(search2) = multiDraftSearchService.matchingQuery(
-      multiDraftSearchSettings.copy(
-        query = Some("kek"),
-        language = AllLanguages,
-        learningResourceTypes = List(LearningResourceType.LearningPath)
-      )
-    )
-
-    search2.results.map(_.id) should be(Seq(6))
-    search2.results.last.contexts should be(List.empty)
   }
 
   test("That search matches previous notes on drafts") {

--- a/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceTest.scala
@@ -490,13 +490,13 @@ class MultiSearchServiceTest
     search.results.map(_.id) should be(Seq(1, 2, 3, 5, 6, 7, 8, 9, 10, 11, 12))
   }
 
-  test("That filtering on learningpath learningresourcetype returns learningpaths") {
+  test("That filtering on learningpath learningresourcetype returns learningpaths in structure") {
     val Success(search) = multiSearchService.matchingQuery(
       searchSettings.copy(language = "*", learningResourceTypes = List(LearningResourceType.LearningPath))
     )
 
-    search.totalCount should be(6)
-    search.results.map(_.id) should be(Seq(1, 2, 3, 4, 5, 6))
+    search.totalCount should be(5)
+    search.results.map(_.id) should be(Seq(1, 2, 3, 4, 5))
     search.results.filter(_.contexts.nonEmpty).map(_.contexts.head.learningResourceType) should be(
       Seq.fill(5) { LearningResourceType.LearningPath.toString }
     )


### PR DESCRIPTION
Endrer bruk av context-types parameter til kun returnere ting som ligger i kontekst.
Ønsket er at emne-gruppa i søket kun skal returnerere emner i taksonomi. Og i og med at parameteret er context-type så gir det meining at kun ting som har kontekst returneres.