### PR TITLE
Add transition to allow for quick changes in articles

### DIFF
--- a/draft-api/src/main/scala/no/ndla/draftapi/service/StateTransitionRules.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/service/StateTransitionRules.scala
@@ -128,6 +128,7 @@ trait StateTransitionRules {
       (IN_PROGRESS           -> INTERNAL_REVIEW)       keepCurrentOnTransition,
       (IN_PROGRESS           -> QUALITY_ASSURANCE)     .require(PublishRoles, articleHasBeenPublished) keepStates Set(PUBLISHED),
       (IN_PROGRESS           -> LANGUAGE)              .require(PublishRoles, articleHasBeenPublished) keepStates Set(PUBLISHED),
+      (IN_PROGRESS           -> END_CONTROL)           .require(PublishRoles, articleHasBeenPublished) keepStates Set(PUBLISHED) withSideEffect validateArticleApiArticle,
       (IN_PROGRESS           -> PUBLISHED)             require DirectPublishRoles withSideEffect publishWithSoftValidation,
       (IN_PROGRESS           -> ARCHIVED)              .require(PublishRoles, articleHasNotBeenPublished) illegalStatuses Set(PUBLISHED),
        EXTERNAL_REVIEW       -> IN_PROGRESS            keepStates Set(PUBLISHED),

--- a/draft-api/src/test/scala/no/ndla/draftapi/service/StateTransitionRulesTest.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/service/StateTransitionRulesTest.scala
@@ -131,7 +131,7 @@ class StateTransitionRulesTest extends UnitSuite with TestEnvironment {
   }
 
   test("doTransition should fail when performing an illegal transition") {
-    val (res, _) = doTransitionWithoutSideEffect(InProcessArticle, END_CONTROL, TestData.userWithPublishAccess, false)
+    val (res, _) = doTransitionWithoutSideEffect(InProcessArticle, FOR_APPROVAL, TestData.userWithPublishAccess, false)
     res.isFailure should be(true)
   }
 


### PR DESCRIPTION
Legger til overgang fra i arbeid til sluttkontroll for enklere fiksing av skrivefeil i publiserte artikler.