### PR TITLE
fix bug with data-title in iframe embeds, write regression test

### DIFF
--- a/validation/src/main/resources/embed-tag-rules.json
+++ b/validation/src/main/resources/embed-tag-rules.json
@@ -142,12 +142,12 @@
           "data-width",
           "data-height"
         ],
+        ["data-title"],
         [
           "data-title",
           "data-caption",
           "data-imageid"
-        ],
-        ["data-title"]
+        ]
       ],
       "validSrcDomains": [
         ".*.ndla.no",

--- a/validation/src/test/scala/no/ndla/validation/EmbedTagValidatorTest.scala
+++ b/validation/src/test/scala/no/ndla/validation/EmbedTagValidatorTest.scala
@@ -665,4 +665,23 @@ class EmbedTagValidatorTest extends UnitSuite {
     embedTagValidator.numDirectEqualSiblings(embed) should be(3)
   }
 
+  test("validate should return no errors when data-title is used as a standalone tag in iframe") {
+    val attrs = generateAttributes(
+      Map(
+        // Iframe Required
+        TagAttributes.DataResource.toString -> ResourceType.IframeContent.toString,
+        TagAttributes.DataType.toString     -> ResourceType.IframeContent.toString,
+        TagAttributes.DataUrl.toString      -> "https://google.ndla.no/",
+        // Iframe Optional-1
+        TagAttributes.DataWidth.toString  -> "700",
+        TagAttributes.DataHeight.toString -> "500",
+        // Iframe Optional that i want to test
+        TagAttributes.DataTitle.toString -> "Min tittel"
+      )
+    )
+
+    val res = embedTagValidator.validate("content", s"""<$EmbedTagName $attrs />""")
+    res.size should be(0)
+  }
+
 }


### PR DESCRIPTION
Fikset bug med `data-title`. Problemet var at ved validering så henter vi den første gruppa som matcher attributtet. Dersom gruppa hadde flere attributter, så fikk vi en validation error at resten av attributtene ikke var oppfylt. Det å flytte en standalone `data-title` tag til toppen løser problemet, for da må kun denne oppfylles.

Skrev en test for å unngå regresjon.