### PR TITLE
search-api: distinguish between draft and public taxonomy

### DIFF
--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/integration/TaxonomyApiClient.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/integration/TaxonomyApiClient.scala
@@ -17,6 +17,7 @@ import cats.implicits._
 import no.ndla.common.model.domain.Title
 import no.ndla.language.Language
 import no.ndla.learningpathapi.Props
+import no.ndla.network.TaxonomyData.{TAXONOMY_VERSION_HEADER, defaultVersion}
 import sttp.client3.Response
 
 import scala.concurrent.duration.DurationInt
@@ -227,7 +228,7 @@ trait TaxonomyApiClient {
         quickRequest
           .get(uri"$url".withParams(params: _*))
           .readTimeout(taxonomyTimeout)
-          .header("VersionHash", "default")
+          .header(TAXONOMY_VERSION_HEADER, defaultVersion)
       )
     }
 

--- a/network/src/main/scala/no/ndla/network/TaxonomyData.scala
+++ b/network/src/main/scala/no/ndla/network/TaxonomyData.scala
@@ -11,9 +11,9 @@ package no.ndla.network
 import javax.servlet.http.HttpServletRequest
 
 object TaxonomyData {
-  private val TAXONOMY_VERSION_HEADER = "VersionHash"
-  private val taxonomyVersion         = new ThreadLocal[String]
-  private val defaultVersion          = "default"
+  val TAXONOMY_VERSION_HEADER = "VersionHash"
+  private val taxonomyVersion = new ThreadLocal[String]
+  val defaultVersion          = "default"
 
   def set(value: String): Unit = {
     val taxonomyVersionValue = Option(value).getOrElse(defaultVersion)

--- a/search-api/src/main/scala/no/ndla/searchapi/controller/InternController.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/controller/InternController.scala
@@ -170,7 +170,7 @@ trait InternController {
       val bundles = for {
         taxonomyBundleDraft     <- taxonomyApiClient.getTaxonomyBundle(false)
         taxonomyBundlePublished <- taxonomyApiClient.getTaxonomyBundle(true)
-        grepBundle              <- grepApiClient.getGrepBundle(())
+        grepBundle              <- grepApiClient.getGrepBundle()
       } yield (taxonomyBundleDraft, taxonomyBundlePublished, grepBundle)
 
       val start = System.currentTimeMillis()

--- a/search-api/src/main/scala/no/ndla/searchapi/controller/InternController.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/controller/InternController.scala
@@ -139,7 +139,7 @@ trait InternController {
       val requestInfo = RequestInfo.fromThreadContext()
       val draftIndex = Future {
         requestInfo.setRequestInfo()
-        ("drafts", draftIndexService.indexDocuments())
+        ("drafts", draftIndexService.indexDocuments(shouldUsePublishedTax = false))
       }
 
       resolveResultFutures(List(draftIndex))
@@ -149,7 +149,7 @@ trait InternController {
       val requestInfo = RequestInfo.fromThreadContext()
       val articleIndex = Future {
         requestInfo.setRequestInfo()
-        ("articles", articleIndexService.indexDocuments())
+        ("articles", articleIndexService.indexDocuments(shouldUsePublishedTax = true))
       }
 
       resolveResultFutures(List(articleIndex))
@@ -159,7 +159,7 @@ trait InternController {
       val requestInfo = RequestInfo.fromThreadContext()
       val learningPathIndex = Future {
         requestInfo.setRequestInfo()
-        ("learningpaths", learningPathIndexService.indexDocuments())
+        ("learningpaths", learningPathIndexService.indexDocuments(shouldUsePublishedTax = true))
       }
 
       resolveResultFutures(List(learningPathIndex))
@@ -168,28 +168,29 @@ trait InternController {
     post("/index") {
       val runInBackground = booleanOrDefault("run-in-background", default = false)
       val bundles = for {
-        taxonomyBundle <- taxonomyApiClient.getTaxonomyBundle()
-        grepBundle     <- grepApiClient.getGrepBundle()
-      } yield (taxonomyBundle, grepBundle)
+        taxonomyBundleDraft     <- taxonomyApiClient.getTaxonomyBundle(false)
+        taxonomyBundlePublished <- taxonomyApiClient.getTaxonomyBundle(true)
+        grepBundle              <- grepApiClient.getGrepBundle(())
+      } yield (taxonomyBundleDraft, taxonomyBundlePublished, grepBundle)
 
       val start = System.currentTimeMillis()
 
       bundles match {
         case Failure(ex) => errorHandler(ex)
-        case Success((taxonomyBundle, grepBundle)) =>
+        case Success((taxonomyBundleDraft, taxonomyBundlePublished, grepBundle)) =>
           val requestInfo = RequestInfo.fromThreadContext()
           val indexes = List(
             Future {
               requestInfo.setRequestInfo()
-              ("learningpaths", learningPathIndexService.indexDocuments(taxonomyBundle, grepBundle))
+              ("learningpaths", learningPathIndexService.indexDocuments(taxonomyBundlePublished, grepBundle))
             },
             Future {
               requestInfo.setRequestInfo()
-              ("articles", articleIndexService.indexDocuments(taxonomyBundle, grepBundle))
+              ("articles", articleIndexService.indexDocuments(taxonomyBundlePublished, grepBundle))
             },
             Future {
               requestInfo.setRequestInfo()
-              ("drafts", draftIndexService.indexDocuments(taxonomyBundle, grepBundle))
+              ("drafts", draftIndexService.indexDocuments(taxonomyBundleDraft, grepBundle))
             }
           )
           if (runInBackground) {

--- a/search-api/src/main/scala/no/ndla/searchapi/integration/GrepApiClient.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/integration/GrepApiClient.scala
@@ -40,7 +40,7 @@ trait GrepApiClient {
     def getAllTverrfagligeTemaer: Try[List[GrepElement]] =
       get[List[GrepElement]](s"$GrepApiEndpoint/tverrfaglige-temaer-lk20/").map(_.distinct)
 
-    val getGrepBundle: Memoize[Try[GrepBundle]] = Memoize(() => getGrepBundleUncached)
+    val getGrepBundle: Memoize[Unit, Try[GrepBundle]] = new Memoize(1000 * 60, _ => getGrepBundleUncached)
 
     /** The memoized function of this [[getGrepBundle]] should probably be used in most cases */
     private def getGrepBundleUncached: Try[GrepBundle] = {

--- a/search-api/src/main/scala/no/ndla/searchapi/integration/GrepApiClient.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/integration/GrepApiClient.scala
@@ -40,7 +40,10 @@ trait GrepApiClient {
     def getAllTverrfagligeTemaer: Try[List[GrepElement]] =
       get[List[GrepElement]](s"$GrepApiEndpoint/tverrfaglige-temaer-lk20/").map(_.distinct)
 
-    val getGrepBundle: Memoize[Unit, Try[GrepBundle]] = new Memoize(1000 * 60, _ => getGrepBundleUncached)
+    // NOTE: We add a helper so we dont have to provide `()` where this is used :^)
+    val getGrepBundle: () => Try[GrepBundle] = () => _getGrepBundle(())
+
+    private val _getGrepBundle: Memoize[Unit, Try[GrepBundle]] = new Memoize(1000 * 60, _ => getGrepBundleUncached)
 
     /** The memoized function of this [[getGrepBundle]] should probably be used in most cases */
     private def getGrepBundleUncached: Try[GrepBundle] = {

--- a/search-api/src/main/scala/no/ndla/searchapi/integration/TaxonomyApiClient.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/integration/TaxonomyApiClient.scala
@@ -9,6 +9,7 @@ package no.ndla.searchapi.integration
 
 import com.typesafe.scalalogging.StrictLogging
 import no.ndla.network.NdlaClient
+import no.ndla.network.TaxonomyData.{TAXONOMY_VERSION_HEADER, defaultVersion}
 import no.ndla.network.model.RequestInfo
 import no.ndla.search.model.SearchableLanguageFormats
 import no.ndla.searchapi.Props
@@ -92,7 +93,7 @@ trait TaxonomyApiClient {
     }
 
     private def getVersionHashHeader(shouldUsePublishedTax: Boolean): Map[String, String] = {
-      if (shouldUsePublishedTax) Map.empty else Map("versionHash" -> "default")
+      if (shouldUsePublishedTax) Map.empty else Map(TAXONOMY_VERSION_HEADER -> defaultVersion)
     }
 
     val getTaxonomyBundle: Memoize[Boolean, Try[TaxonomyBundle]] =

--- a/search-api/src/main/scala/no/ndla/searchapi/integration/TaxonomyApiClient.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/integration/TaxonomyApiClient.scala
@@ -84,10 +84,10 @@ trait TaxonomyApiClient {
         filterVisibles: Boolean,
         shouldUsePublishedTax: Boolean
     ): Try[List[SearchableTaxonomyContext]] = {
-      implicit val formats = SearchableLanguageFormats.JSonFormatsWithMillis
+      implicit val formats: Formats = SearchableLanguageFormats.JSonFormatsWithMillis
       get[List[SearchableTaxonomyContext]](
         s"$TaxonomyApiEndpoint/queries/$contentUri",
-        headers = getVersionHashHeader(shouldUsePublishedTax) + Map("filterVisibles" -> filterVisibles.toString)
+        headers = getVersionHashHeader(shouldUsePublishedTax) ++ Map("filterVisibles" -> filterVisibles.toString)
       )
     }
 
@@ -100,7 +100,7 @@ trait TaxonomyApiClient {
 
     /** The memoized function of this [[getTaxonomyBundle]] should probably be used in most cases */
     private def getTaxonomyBundleUncached(shouldUsePublishedTax: Boolean): Try[TaxonomyBundle] = {
-      logger.info("Fetching taxonomy in bulk...")
+      logger.info(s"Fetching ${if (shouldUsePublishedTax) "published" else "draft"} taxonomy in bulk...")
       val startFetch                            = System.currentTimeMillis()
       implicit val ec: ExecutionContextExecutor = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(12))
 

--- a/search-api/src/main/scala/no/ndla/searchapi/integration/TaxonomyApiClient.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/integration/TaxonomyApiClient.scala
@@ -34,45 +34,72 @@ trait TaxonomyApiClient {
     private val TaxonomyApiEndpoint           = s"$TaxonomyUrl/v1"
     private val timeoutSeconds                = 600.seconds
 
-    def getAllResources: Try[List[Resource]] =
-      get[List[Resource]](s"$TaxonomyApiEndpoint/resources/")
+    def getAllResources(shouldUsePublishedTax: Boolean): Try[List[Resource]] =
+      get[List[Resource]](s"$TaxonomyApiEndpoint/resources/", headers = getVersionHashHeader(shouldUsePublishedTax))
 
-    def getAllSubjects: Try[List[TaxSubject]] =
-      get[List[TaxSubject]](s"$TaxonomyApiEndpoint/subjects/")
+    def getAllSubjects(shouldUsePublishedTax: Boolean): Try[List[TaxSubject]] =
+      get[List[TaxSubject]](s"$TaxonomyApiEndpoint/subjects/", headers = getVersionHashHeader(shouldUsePublishedTax))
 
-    def getAllTopics: Try[List[Topic]] =
-      get[List[Topic]](s"$TaxonomyApiEndpoint/topics/")
+    def getAllTopics(shouldUsePublishedTax: Boolean): Try[List[Topic]] =
+      get[List[Topic]](s"$TaxonomyApiEndpoint/topics/", headers = getVersionHashHeader(shouldUsePublishedTax))
 
-    def getAllResourceTypes: Try[List[ResourceType]] =
-      get[List[ResourceType]](s"$TaxonomyApiEndpoint/resource-types/").map(_.distinct)
+    def getAllResourceTypes(shouldUsePublishedTax: Boolean): Try[List[ResourceType]] =
+      get[List[ResourceType]](
+        s"$TaxonomyApiEndpoint/resource-types/",
+        headers = getVersionHashHeader(shouldUsePublishedTax)
+      ).map(_.distinct)
 
-    def getAllTopicResourceConnections: Try[List[TopicResourceConnection]] =
-      get[List[TopicResourceConnection]](s"$TaxonomyApiEndpoint/topic-resources/")
+    def getAllTopicResourceConnections(shouldUsePublishedTax: Boolean): Try[List[TopicResourceConnection]] =
+      get[List[TopicResourceConnection]](
+        s"$TaxonomyApiEndpoint/topic-resources/",
+        headers = getVersionHashHeader(shouldUsePublishedTax)
+      )
 
-    def getAllTopicSubtopicConnections: Try[List[TopicSubtopicConnection]] =
-      get[List[TopicSubtopicConnection]](s"$TaxonomyApiEndpoint/topic-subtopics/")
+    def getAllTopicSubtopicConnections(shouldUsePublishedTax: Boolean): Try[List[TopicSubtopicConnection]] =
+      get[List[TopicSubtopicConnection]](
+        s"$TaxonomyApiEndpoint/topic-subtopics/",
+        headers = getVersionHashHeader(shouldUsePublishedTax)
+      )
 
-    def getAllResourceResourceTypeConnections: Try[List[ResourceResourceTypeConnection]] =
-      get[List[ResourceResourceTypeConnection]](s"$TaxonomyApiEndpoint/resource-resourcetypes/").map(_.distinct)
+    def getAllResourceResourceTypeConnections(
+        shouldUsePublishedTax: Boolean
+    ): Try[List[ResourceResourceTypeConnection]] =
+      get[List[ResourceResourceTypeConnection]](
+        s"$TaxonomyApiEndpoint/resource-resourcetypes/",
+        headers = getVersionHashHeader(shouldUsePublishedTax)
+      ).map(_.distinct)
 
-    def getAllSubjectTopicConnections: Try[List[SubjectTopicConnection]] =
-      get[List[SubjectTopicConnection]](s"$TaxonomyApiEndpoint/subject-topics/")
+    def getAllSubjectTopicConnections(shouldUsePublishedTax: Boolean): Try[List[SubjectTopicConnection]] =
+      get[List[SubjectTopicConnection]](
+        s"$TaxonomyApiEndpoint/subject-topics/",
+        headers = getVersionHashHeader(shouldUsePublishedTax)
+      )
 
-    def getAllRelevances: Try[List[Relevance]] =
-      get[List[Relevance]](s"$TaxonomyApiEndpoint/relevances/").map(_.distinct)
+    def getAllRelevances(shouldUsePublishedTax: Boolean): Try[List[Relevance]] =
+      get[List[Relevance]](s"$TaxonomyApiEndpoint/relevances/", headers = getVersionHashHeader(shouldUsePublishedTax))
+        .map(_.distinct)
 
-    def getSearchableTaxonomy(contentUri: String, filterVisibles: Boolean): Try[List[SearchableTaxonomyContext]] = {
+    def getSearchableTaxonomy(
+        contentUri: String,
+        filterVisibles: Boolean,
+        shouldUsePublishedTax: Boolean
+    ): Try[List[SearchableTaxonomyContext]] = {
       implicit val formats = SearchableLanguageFormats.JSonFormatsWithMillis
       get[List[SearchableTaxonomyContext]](
         s"$TaxonomyApiEndpoint/queries/$contentUri",
-        "filterVisibles" -> filterVisibles.toString
+        headers = getVersionHashHeader(shouldUsePublishedTax) + Map("filterVisibles" -> filterVisibles.toString)
       )
     }
 
-    val getTaxonomyBundle: Memoize[Try[TaxonomyBundle]] = Memoize(() => getTaxonomyBundleUncached)
+    private def getVersionHashHeader(shouldUsePublishedTax: Boolean): Map[String, String] = {
+      if (shouldUsePublishedTax) Map.empty else Map("versionHash" -> "default")
+    }
+
+    val getTaxonomyBundle: Memoize[Boolean, Try[TaxonomyBundle]] =
+      new Memoize(1000 * 60, shouldUsePublishedTax => getTaxonomyBundleUncached(shouldUsePublishedTax))
 
     /** The memoized function of this [[getTaxonomyBundle]] should probably be used in most cases */
-    private def getTaxonomyBundleUncached: Try[TaxonomyBundle] = {
+    private def getTaxonomyBundleUncached(shouldUsePublishedTax: Boolean): Try[TaxonomyBundle] = {
       logger.info("Fetching taxonomy in bulk...")
       val startFetch                            = System.currentTimeMillis()
       implicit val ec: ExecutionContextExecutor = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(12))
@@ -80,17 +107,20 @@ trait TaxonomyApiClient {
       val requestInfo = RequestInfo.fromThreadContext()
 
       /** Calls function in separate thread and converts Try to Future */
-      def tryToFuture[T](x: () => Try[T]) = Future { requestInfo.setRequestInfo(); x() }.flatMap(Future.fromTry)
+      def tryToFuture[T](x: Boolean => Try[T]) =
+        Future { requestInfo.setRequestInfo(); x(shouldUsePublishedTax) }.flatMap(Future.fromTry)
 
-      val relevances                      = tryToFuture(() => getAllRelevances)
-      val resourceResourceTypeConnections = tryToFuture(() => getAllResourceResourceTypeConnections)
-      val resourceTypes                   = tryToFuture(() => getAllResourceTypes)
-      val resources                       = tryToFuture(() => getAllResources)
-      val subjectTopicConnections         = tryToFuture(() => getAllSubjectTopicConnections)
-      val subjects                        = tryToFuture(() => getAllSubjects)
-      val topicResourceConnections        = tryToFuture(() => getAllTopicResourceConnections)
-      val topicSubtopicConnections        = tryToFuture(() => getAllTopicSubtopicConnections)
-      val topics                          = tryToFuture(() => getAllTopics)
+      // format: off
+      val relevances                      = tryToFuture(shouldUsePublishedTax => getAllRelevances(shouldUsePublishedTax))
+      val resourceResourceTypeConnections = tryToFuture(shouldUsePublishedTax => getAllResourceResourceTypeConnections(shouldUsePublishedTax))
+      val resourceTypes                   = tryToFuture(shouldUsePublishedTax => getAllResourceTypes(shouldUsePublishedTax))
+      val resources                       = tryToFuture(shouldUsePublishedTax => getAllResources(shouldUsePublishedTax))
+      val subjectTopicConnections         = tryToFuture(shouldUsePublishedTax => getAllSubjectTopicConnections(shouldUsePublishedTax))
+      val subjects                        = tryToFuture(shouldUsePublishedTax => getAllSubjects(shouldUsePublishedTax))
+      val topicResourceConnections        = tryToFuture(shouldUsePublishedTax => getAllTopicResourceConnections(shouldUsePublishedTax))
+      val topicSubtopicConnections        = tryToFuture(shouldUsePublishedTax => getAllTopicSubtopicConnections(shouldUsePublishedTax))
+      val topics                          = tryToFuture(shouldUsePublishedTax => getAllTopics(shouldUsePublishedTax))
+      // format: on
 
       val x = for {
         f2  <- relevances
@@ -114,9 +144,12 @@ trait TaxonomyApiClient {
       }
     }
 
-    private def get[A](url: String, params: (String, String)*)(implicit mf: Manifest[A], formats: Formats): Try[A] = {
+    private def get[A](url: String, headers: Map[String, String], params: (String, String)*)(implicit
+        mf: Manifest[A],
+        formats: Formats
+    ): Try[A] = {
       ndlaClient.fetchWithForwardedAuth[A](
-        quickRequest.get(uri"$url?$params").readTimeout(timeoutSeconds)
+        quickRequest.get(uri"$url?$params").headers(headers).readTimeout(timeoutSeconds)
       )
     }
   }

--- a/search-api/src/main/scala/no/ndla/searchapi/service/StandaloneIndexing.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/StandaloneIndexing.scala
@@ -80,21 +80,24 @@ class StandaloneIndexing(props: SearchApiProperties, componentRegistry: Componen
 
   def doStandaloneIndexing(): Nothing = {
     val bundles = for {
-      taxonomyBundle <- componentRegistry.taxonomyApiClient.getTaxonomyBundle()
-      grepBundle     <- componentRegistry.grepApiClient.getGrepBundle()
-    } yield (taxonomyBundle, grepBundle)
+      taxonomyBundleDraft     <- componentRegistry.taxonomyApiClient.getTaxonomyBundle(false)
+      taxonomyBundlePublished <- componentRegistry.taxonomyApiClient.getTaxonomyBundle(true)
+      grepBundle              <- componentRegistry.grepApiClient.getGrepBundle(())
+    } yield (taxonomyBundleDraft, taxonomyBundlePublished, grepBundle)
 
     val start = System.currentTimeMillis()
 
     val reindexResult = bundles match {
       case Failure(ex) => Seq(Failure(ex))
-      case Success((taxonomyBundle, grepBundle)) =>
+      case Success((taxonomyBundleDraft, taxonomyBundlePublished, grepBundle)) =>
         implicit val ec: ExecutionContextExecutorService =
           ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(props.SearchIndexes.size))
 
         def reindexWithIndexService[C <: Content](
-            indexService: componentRegistry.IndexService[C]
+            indexService: componentRegistry.IndexService[C],
+            shouldUsePublishedTax: Boolean
         )(implicit mf: Manifest[C]): Future[Try[ReindexResult]] = {
+          val taxonomyBundle = if (shouldUsePublishedTax) taxonomyBundlePublished else taxonomyBundleDraft
           val reindexFuture = Future {
             indexService.indexDocuments(taxonomyBundle, grepBundle)
           }
@@ -114,9 +117,9 @@ class StandaloneIndexing(props: SearchApiProperties, componentRegistry: Componen
         Await.result(
           Future.sequence(
             Seq(
-              reindexWithIndexService(componentRegistry.learningPathIndexService),
-              reindexWithIndexService(componentRegistry.articleIndexService),
-              reindexWithIndexService(componentRegistry.draftIndexService)
+              reindexWithIndexService(componentRegistry.learningPathIndexService, shouldUsePublishedTax = true),
+              reindexWithIndexService(componentRegistry.articleIndexService, shouldUsePublishedTax = true),
+              reindexWithIndexService(componentRegistry.draftIndexService, shouldUsePublishedTax = false)
             )
           ),
           Duration.Inf

--- a/search-api/src/main/scala/no/ndla/searchapi/service/StandaloneIndexing.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/StandaloneIndexing.scala
@@ -82,7 +82,7 @@ class StandaloneIndexing(props: SearchApiProperties, componentRegistry: Componen
     val bundles = for {
       taxonomyBundleDraft     <- componentRegistry.taxonomyApiClient.getTaxonomyBundle(false)
       taxonomyBundlePublished <- componentRegistry.taxonomyApiClient.getTaxonomyBundle(true)
-      grepBundle              <- componentRegistry.grepApiClient.getGrepBundle(())
+      grepBundle              <- componentRegistry.grepApiClient.getGrepBundle()
     } yield (taxonomyBundleDraft, taxonomyBundlePublished, grepBundle)
 
     val start = System.currentTimeMillis()

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/IndexService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/IndexService.scala
@@ -46,7 +46,7 @@ trait IndexService {
     ): Try[IndexRequest]
 
     def indexDocument(imported: D): Try[D] = {
-      val grepBundle = grepApiClient.getGrepBundle(()) match {
+      val grepBundle = grepApiClient.getGrepBundle() match {
         case Success(bundle) => Some(bundle)
         case Failure(_) =>
           logger.error(
@@ -71,7 +71,7 @@ trait IndexService {
     def indexDocuments(shouldUsePublishedTax: Boolean)(implicit mf: Manifest[D]): Try[ReindexResult] = {
       val bundles = for {
         taxonomyBundle <- taxonomyApiClient.getTaxonomyBundle(shouldUsePublishedTax)
-        grepBundle     <- grepApiClient.getGrepBundle(())
+        grepBundle     <- grepApiClient.getGrepBundle()
       } yield (taxonomyBundle, grepBundle)
       bundles match {
         case Failure(ex) =>
@@ -83,7 +83,7 @@ trait IndexService {
 
     def reindexDocument(id: Long)(implicit mf: Manifest[D]): Try[D] = {
       for {
-        grepBundle <- grepApiClient.getGrepBundle(())
+        grepBundle <- grepApiClient.getGrepBundle()
         _          <- createIndexIfNotExists()
         toIndex    <- apiClient.getSingle[D](id)
         request    <- createIndexRequest(toIndex, searchIndex, None, Some(grepBundle))

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/MultiDraftSearchService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/MultiDraftSearchService.scala
@@ -263,11 +263,11 @@ trait MultiDraftSearchService {
 
       val draftFuture = Future {
         requestInfo.setRequestInfo()
-        draftIndexService.indexDocuments()
+        draftIndexService.indexDocuments(shouldUsePublishedTax = false)
       }
       val learningPathFuture = Future {
         requestInfo.setRequestInfo()
-        learningPathIndexService.indexDocuments()
+        learningPathIndexService.indexDocuments(shouldUsePublishedTax = true)
       }
 
       handleScheduledIndexResults(SearchIndexes(SearchType.Drafts), draftFuture)

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/MultiSearchService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/MultiSearchService.scala
@@ -202,11 +202,11 @@ trait MultiSearchService {
 
       val articleFuture = Future {
         requestInfo.setRequestInfo()
-        articleIndexService.indexDocuments()
+        articleIndexService.indexDocuments(shouldUsePublishedTax = true)
       }
       val learningPathFuture = Future {
         requestInfo.setRequestInfo()
-        learningPathIndexService.indexDocuments()
+        learningPathIndexService.indexDocuments(shouldUsePublishedTax = true)
       }
 
       handleScheduledIndexResults(SearchIndexes(SearchType.Articles), articleFuture)

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
@@ -189,7 +189,12 @@ trait SearchConverterService {
       val articleId = ai.id.get
       val taxonomyForArticle = taxonomyBundle match {
         case Some(bundle) => getTaxonomyContexts(articleId, "article", bundle, filterVisibles = true)
-        case None         => taxonomyApiClient.getSearchableTaxonomy(s"urn:article:$articleId", filterVisibles = true)
+        case None =>
+          taxonomyApiClient.getSearchableTaxonomy(
+            s"urn:article:$articleId",
+            filterVisibles = true,
+            shouldUsePublishedTax = true
+          )
       }
 
       val traits               = getArticleTraits(ai.content)
@@ -259,7 +264,12 @@ trait SearchConverterService {
     ): Try[SearchableLearningPath] = {
       val taxonomyForLearningPath = taxonomyBundle match {
         case Some(bundle) => getTaxonomyContexts(lp.id.get, "learningpath", bundle, filterVisibles = true)
-        case None => taxonomyApiClient.getSearchableTaxonomy(s"urn:learningpath:${lp.id.get}", filterVisibles = true)
+        case None =>
+          taxonomyApiClient.getSearchableTaxonomy(
+            s"urn:learningpath:${lp.id.get}",
+            filterVisibles = true,
+            shouldUsePublishedTax = true
+          )
       }
 
       val supportedLanguages = getSupportedLanguages(lp.title, lp.description).toList
@@ -306,7 +316,12 @@ trait SearchConverterService {
         val draftId = draft.id.get
         taxonomyBundle match {
           case Some(bundle) => getTaxonomyContexts(draftId, "article", bundle, filterVisibles = false)
-          case None         => taxonomyApiClient.getSearchableTaxonomy(s"urn:article:$draftId", filterVisibles = false)
+          case None =>
+            taxonomyApiClient.getSearchableTaxonomy(
+              s"urn:article:$draftId",
+              filterVisibles = false,
+              shouldUsePublishedTax = false
+            )
         }
       }
 

--- a/search-api/src/test/scala/no/ndla/searchapi/caching/MemoizeTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/caching/MemoizeTest.scala
@@ -23,20 +23,20 @@ class MemoizeTest extends UnitSuite {
 
   test("That an uncached value will do an actual call") {
     val targetMock     = mock[Target]
-    val memoizedTarget = new Memoize[String](10000, targetMock.targetMethod _)
+    val memoizedTarget = new Memoize[Unit, String](10000, _ => targetMock.targetMethod())
 
     when(targetMock.targetMethod()).thenReturn("Hello from mock")
-    memoizedTarget() should equal("Hello from mock")
+    memoizedTarget(()) should equal("Hello from mock")
     verify(targetMock, times(1)).targetMethod()
   }
 
   test("That a cached value will not forward the call to the target") {
     val targetMock     = mock[Target]
-    val memoizedTarget = new Memoize[String](10000, targetMock.targetMethod _)
+    val memoizedTarget = new Memoize[Unit, String](10000, _ => targetMock.targetMethod())
 
     when(targetMock.targetMethod()).thenReturn("Hello from mock")
     Seq(1 to 10).foreach(i => {
-      memoizedTarget() should equal("Hello from mock")
+      memoizedTarget(()) should equal("Hello from mock")
     })
     verify(targetMock, times(1)).targetMethod()
   }
@@ -44,27 +44,27 @@ class MemoizeTest extends UnitSuite {
   test("That the cache is invalidated after cacheMaxAge") {
     val cacheMaxAgeInMs = 500
     val targetMock      = mock[Target]
-    val memoizedTarget  = new Memoize[String](cacheMaxAgeInMs, targetMock.targetMethod _)
+    val memoizedTarget  = new Memoize[Unit, String](cacheMaxAgeInMs, _ => targetMock.targetMethod())
 
     when(targetMock.targetMethod()).thenReturn("Hello from mock")
 
-    memoizedTarget() should equal("Hello from mock")
-    memoizedTarget() should equal("Hello from mock")
+    memoizedTarget(()) should equal("Hello from mock")
+    memoizedTarget(()) should equal("Hello from mock")
     Thread.sleep(cacheMaxAgeInMs)
-    memoizedTarget() should equal("Hello from mock")
-    memoizedTarget() should equal("Hello from mock")
+    memoizedTarget(()) should equal("Hello from mock")
+    memoizedTarget(()) should equal("Hello from mock")
 
     verify(targetMock, times(2)).targetMethod()
   }
 
   test("That calling slow function twice will wait for first to finish and only call target once") {
     val targetMock     = mock[Target]
-    val memoizedTarged = new Memoize[String](10000, targetMock.slowTargetMethod _)
+    val memoizedTarged = new Memoize[Unit, String](10000, _ => targetMock.slowTargetMethod())
 
     when(targetMock.slowTargetMethod()).thenCallRealMethod()
 
-    memoizedTarged() should be("Slow Hei")
-    memoizedTarged() should be("Slow Hei")
+    memoizedTarged(()) should be("Slow Hei")
+    memoizedTarged(()) should be("Slow Hei")
 
     verify(targetMock, times(1)).slowTargetMethod()
   }

--- a/search-api/src/test/scala/no/ndla/searchapi/service/search/SearchConverterServiceTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/service/search/SearchConverterServiceTest.scala
@@ -131,7 +131,7 @@ class SearchConverterServiceTest extends UnitSuite with TestEnvironment {
     )
 
     when(taxonomyApiClient.getTaxonomyBundle)
-      .thenReturn(new Memoize[Try[TaxonomyBundle]](0, () => Success(emptyBundle)))
+      .thenReturn(new Memoize[Boolean, Try[TaxonomyBundle]](0, _ => Success(emptyBundle)))
   }
 
   test("That asSearchableArticle converts titles with correct language") {


### PR DESCRIPTION
Kjørte `/intern/index/` på search-api og det ser ut til å fungere. Gjerne sjekk de andre path'ene og se om data har mening