### PR TITLE
draft-api: Allow manual status-change on PATCH endpoint

### DIFF
--- a/concept-api/src/main/scala/no/ndla/conceptapi/model/domain/Concept.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/model/domain/Concept.scala
@@ -115,4 +115,7 @@ object ConceptStatus extends Enumeration {
     }
 
   def valueOf(s: String): Option[ConceptStatus.Value] = values.find(_.toString == s.toUpperCase)
+
+  val thatDoesNotRequireResponsible: Seq[ConceptStatus.Value] = Seq(PUBLISHED, UNPUBLISHED, ARCHIVED)
+  val thatRequiresResponsible: ConceptStatus.ValueSet = this.values.filterNot(thatDoesNotRequireResponsible.contains)
 }

--- a/concept-api/src/main/scala/no/ndla/conceptapi/model/domain/StateTransition.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/model/domain/StateTransition.scala
@@ -16,7 +16,7 @@ case class StateTransition(
     from: ConceptStatus.Value,
     to: ConceptStatus.Value,
     otherStatesToKeepOnTransition: Set[ConceptStatus.Value],
-    sideEffect: SideEffect,
+    sideEffects: Seq[SideEffect],
     addCurrentStateToOthersOnTransition: Boolean,
     requiredRoles: Set[Role.Value],
     illegalStatuses: Set[ConceptStatus.Value]
@@ -24,7 +24,7 @@ case class StateTransition(
 
   def keepCurrentOnTransition: StateTransition                      = copy(addCurrentStateToOthersOnTransition = true)
   def keepStates(toKeep: Set[ConceptStatus.Value]): StateTransition = copy(otherStatesToKeepOnTransition = toKeep)
-  def withSideEffect(sideEffect: SideEffect): StateTransition       = copy(sideEffect = sideEffect)
+  def withSideEffect(sideEffect: SideEffect): StateTransition       = copy(sideEffects = sideEffects :+ sideEffect)
   def require(roles: Set[Role.Value]): StateTransition              = copy(requiredRoles = roles)
 
   def illegalStatuses(illegalStatuses: Set[ConceptStatus.Value]): StateTransition =
@@ -38,7 +38,7 @@ object StateTransition {
       from,
       to,
       Set(ConceptStatus.PUBLISHED),
-      SideEffect.none,
+      Seq.empty[SideEffect],
       addCurrentStateToOthersOnTransition = false,
       UserInfo.WriteRoles,
       Set()

--- a/concept-api/src/main/scala/no/ndla/conceptapi/service/StateTransitionRules.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/service/StateTransitionRules.scala
@@ -10,13 +10,13 @@ package no.ndla.conceptapi.service
 import cats.effect.IO
 import no.ndla.conceptapi.auth.UserInfo
 import no.ndla.conceptapi.model.api.ErrorHelpers
-import no.ndla.conceptapi.model.domain.SideEffect.SideEffect
 import no.ndla.conceptapi.model.domain
-import no.ndla.conceptapi.model.domain.{ConceptStatus, SideEffect, StateTransition}
+import no.ndla.conceptapi.model.domain.ConceptStatus._
+import no.ndla.conceptapi.model.domain.SideEffect.SideEffect
+import no.ndla.conceptapi.model.domain.{ConceptStatus, StateTransition}
 import no.ndla.conceptapi.repository.{DraftConceptRepository, PublishedConceptRepository}
 import no.ndla.conceptapi.service.search.DraftConceptIndexService
 import no.ndla.conceptapi.validation.ContentValidator
-import no.ndla.conceptapi.model.domain.ConceptStatus._
 import no.ndla.network.model.RequestInfo
 
 import scala.language.postfixOps
@@ -53,17 +53,17 @@ trait StateTransitionRules {
       (IN_PROGRESS        -> INTERNAL_REVIEW)     keepStates Set(PUBLISHED),
       (IN_PROGRESS        -> PUBLISHED)           keepStates Set() require UserInfo.PublishRoles withSideEffect publishConcept withSideEffect resetResponsible,
        INTERNAL_REVIEW    -> INTERNAL_REVIEW,
-      (INTERNAL_REVIEW     -> IN_PROGRESS)        keepStates Set(PUBLISHED),
-      (INTERNAL_REVIEW     -> EXTERNAL_REVIEW)    keepStates Set(PUBLISHED),
-      (INTERNAL_REVIEW     -> QUALITY_ASSURANCE)  keepStates Set(PUBLISHED),
+      (INTERNAL_REVIEW    -> IN_PROGRESS)        keepStates Set(PUBLISHED),
+      (INTERNAL_REVIEW    -> EXTERNAL_REVIEW)    keepStates Set(PUBLISHED),
+      (INTERNAL_REVIEW    -> QUALITY_ASSURANCE)  keepStates Set(PUBLISHED),
        ARCHIVED           -> ARCHIVED             withSideEffect resetResponsible,
        ARCHIVED           -> IN_PROGRESS,
       (ARCHIVED           -> PUBLISHED)           keepStates Set() require UserInfo.PublishRoles withSideEffect publishConcept withSideEffect resetResponsible,
        QUALITY_ASSURANCE  -> QUALITY_ASSURANCE,
       (QUALITY_ASSURANCE  -> LANGUAGE)            keepStates Set(PUBLISHED) require UserInfo.PublishRoles,
       (QUALITY_ASSURANCE  -> PUBLISHED)           keepStates Set() require UserInfo.PublishRoles withSideEffect publishConcept withSideEffect resetResponsible,
-       (QUALITY_ASSURANCE  -> IN_PROGRESS)        keepStates Set(PUBLISHED),
-       (QUALITY_ASSURANCE  -> INTERNAL_REVIEW)    keepStates Set(PUBLISHED),
+      (QUALITY_ASSURANCE  -> IN_PROGRESS)        keepStates Set(PUBLISHED),
+      (QUALITY_ASSURANCE  -> INTERNAL_REVIEW)    keepStates Set(PUBLISHED),
       (PUBLISHED          -> IN_PROGRESS)         keepCurrentOnTransition,
       (PUBLISHED          -> UNPUBLISHED)         keepStates Set() require UserInfo.PublishRoles withSideEffect unpublishConcept withSideEffect resetResponsible,
        UNPUBLISHED        -> UNPUBLISHED          withSideEffect resetResponsible,
@@ -80,11 +80,11 @@ trait StateTransitionRules {
        FOR_APPROVAL       -> IN_PROGRESS          keepStates Set(PUBLISHED),
        FOR_APPROVAL       -> INTERNAL_REVIEW      keepStates Set(PUBLISHED),
       (FOR_APPROVAL       -> PUBLISHED)           keepStates Set() require UserInfo.PublishRoles withSideEffect publishConcept withSideEffect resetResponsible,
-       END_CONTROL       -> END_CONTROL,
-      (END_CONTROL       -> FOR_APPROVAL)         keepStates Set(PUBLISHED),
-      (END_CONTROL       -> IN_PROGRESS)          keepStates Set(PUBLISHED),
-      (END_CONTROL       -> INTERNAL_REVIEW)      keepStates Set(PUBLISHED),
-      (END_CONTROL       -> PUBLISHED)            keepStates Set() require UserInfo.PublishRoles withSideEffect publishConcept withSideEffect resetResponsible,
+       END_CONTROL        -> END_CONTROL,
+      (END_CONTROL        -> FOR_APPROVAL)         keepStates Set(PUBLISHED),
+      (END_CONTROL        -> IN_PROGRESS)          keepStates Set(PUBLISHED),
+      (END_CONTROL        -> INTERNAL_REVIEW)      keepStates Set(PUBLISHED),
+      (END_CONTROL        -> PUBLISHED)            keepStates Set() require UserInfo.PublishRoles withSideEffect publishConcept withSideEffect resetResponsible,
     )
     // format: on
 
@@ -97,33 +97,50 @@ trait StateTransitionRules {
         .find(transition => transition.from == from && transition.to == to)
         .filter(t => user.hasRoles(t.requiredRoles))
 
+    private def validateTransition(current: domain.Concept, transition: StateTransition): Try[Unit] = {
+      val statusRequiresResponsible = ConceptStatus.thatRequiresResponsible.contains(transition.to)
+      if (statusRequiresResponsible && current.responsible.isEmpty) {
+        return Failure(
+          IllegalStatusStateTransition(
+            s"The action triggered a state transition to ${transition.to}, this is invalid without setting new responsible."
+          )
+        )
+      }
+
+      val containsIllegalStatuses = current.status.other.intersect(transition.illegalStatuses)
+      if (containsIllegalStatuses.nonEmpty) {
+        val illegalStateTransition = IllegalStatusStateTransition(
+          s"Cannot go to ${transition.to} when concept contains $containsIllegalStatuses"
+        )
+        return Failure(illegalStateTransition)
+      }
+
+      Success(())
+    }
+
     private[service] def doTransitionWithoutSideEffect(
         current: domain.Concept,
         to: ConceptStatus.Value,
         user: UserInfo
-    ): (Try[domain.Concept], SideEffect) = {
+    ): (Try[domain.Concept], Seq[SideEffect]) = {
       getTransition(current.status.current, to, user) match {
         case Some(t) =>
-          val currentToOther =
-            if (t.addCurrentStateToOthersOnTransition) Set(current.status.current)
-            else Set.empty
-
-          val containsIllegalStatuses = current.status.other.intersect(t.illegalStatuses)
-          if (containsIllegalStatuses.nonEmpty) {
-            val illegalStateTransition = IllegalStatusStateTransition(
-              s"Cannot go to $to when concept contains $containsIllegalStatuses"
-            )
-            return (Failure(illegalStateTransition), SideEffect.fromOutput(Failure(illegalStateTransition)))
+          validateTransition(current, t) match {
+            case Failure(ex) => (Failure(ex), Seq.empty)
+            case Success(_) =>
+              val currentToOther =
+                if (t.addCurrentStateToOthersOnTransition) Set(current.status.current)
+                else Set.empty
+              val other            = current.status.other.intersect(t.otherStatesToKeepOnTransition) ++ currentToOther
+              val newStatus        = domain.Status(to, other)
+              val convertedArticle = current.copy(status = newStatus)
+              (Success(convertedArticle), t.sideEffects)
           }
-          val other            = current.status.other.intersect(t.otherStatesToKeepOnTransition) ++ currentToOther
-          val newStatus        = domain.Status(to, other)
-          val convertedArticle = current.copy(status = newStatus)
-          (Success(convertedArticle), t.sideEffect)
         case None =>
           val illegalStateTransition = IllegalStatusStateTransition(
             s"Cannot go to $to when concept is ${current.status.current}"
           )
-          (Failure(illegalStateTransition), SideEffect.fromOutput(Failure(illegalStateTransition)))
+          (Failure(illegalStateTransition), Seq.empty)
       }
     }
 
@@ -132,11 +149,15 @@ trait StateTransitionRules {
         to: ConceptStatus.Value,
         user: UserInfo
     ): IO[Try[domain.Concept]] = {
-      val (convertedArticle, sideEffect) = doTransitionWithoutSideEffect(current, to, user)
-      val requestInfo                    = RequestInfo.fromThreadContext()
+      val (convertedArticle, sideEffects) = doTransitionWithoutSideEffect(current, to, user)
+      val requestInfo                     = RequestInfo.fromThreadContext()
       IO {
         requestInfo.setRequestInfo()
-        convertedArticle.flatMap(concept => sideEffect(concept))
+        convertedArticle.flatMap(conceptBeforeSideEffect => {
+          sideEffects.foldLeft(Try(conceptBeforeSideEffect))((accumulatedConcept, sideEffect) => {
+            accumulatedConcept.flatMap(c => sideEffect(c))
+          })
+        })
       }
     }
   }

--- a/concept-api/src/main/scala/no/ndla/conceptapi/validation/ContentValidator.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/validation/ContentValidator.scala
@@ -33,12 +33,23 @@ trait ContentValidator {
           concept.visualElement.flatMap(ve => validateVisualElement(ve)) ++
           concept.metaImage.flatMap(mi => validateMetaImage(mi)) ++
           validateTitles(concept.title) ++
-          concept.copyright.map(co => validateCopyright(co)).getOrElse(Seq())
+          concept.copyright.map(co => validateCopyright(co)).getOrElse(Seq()) ++
+          validateResponsible(concept)
 
       if (validationErrors.isEmpty) {
         Success(concept)
       } else {
         Failure(new ValidationException(errors = validationErrors))
+      }
+    }
+
+    private def validateResponsible(concept: Concept): Option[ValidationMessage] = {
+      val statusRequiresResponsible = ConceptStatus.thatRequiresResponsible.contains(concept.status.current)
+      Option.when(concept.responsible.isEmpty && statusRequiresResponsible) {
+        ValidationMessage(
+          "responsibleId",
+          s"Responsible needs to be set if the status is not ${ConceptStatus.thatDoesNotRequireResponsible}"
+        )
       }
     }
 

--- a/concept-api/src/test/scala/no/ndla/conceptapi/TestData.scala
+++ b/concept-api/src/test/scala/no/ndla/conceptapi/TestData.scala
@@ -31,6 +31,7 @@ object TestData {
 
   val userWithNoRoles     = UserInfo("unit test", Set.empty)
   val userWithWriteAccess = UserInfo("unit test", Set(Role.WRITE))
+  val userWithWriteAndPublishAccess = UserInfo("unit test", Set(Role.ADMIN, Role.WRITE))
 
   val today     = LocalDateTime.now().minusDays(0)
   val yesterday = LocalDateTime.now().minusDays(1)

--- a/concept-api/src/test/scala/no/ndla/conceptapi/TestData.scala
+++ b/concept-api/src/test/scala/no/ndla/conceptapi/TestData.scala
@@ -29,8 +29,8 @@ object TestData {
   val authHeaderWithAllRoles =
     "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIxmtpZCI6Ik9FSTFNVVU0T0RrNU56TTVNekkyTXpaRE9EazFOMFl3UXpkRE1EUXlPRFZDUXpRM1FUSTBNQSJ9.eyJodHRwczovL25kbGEubm8vY2xpZW50X2lkIjoieHh4eXl5IiwiaXNzIjoiaHR0cHM6Ly9uZGxhLmV1LmF1dGgwLmNvbS8iLCJzdWIiOiJ4eHh5eXlAY2xpZW50cyIsImF1ZCI6Im5kbGFfc3lzdGVtIiwiaWF0IjoxNTEwMzA1NzczLCJleHAiOjE1MTAzOTIxNzMsInNjb3BlIjoiYXJ0aWNsZXMtdGVzdDpwdWJsaXNoIGRyYWZ0cy10ZXN0OndyaXRlIGRyYWZ0cy10ZXN0OnNldF90b19wdWJsaXNoIiwiZ3R5IjoiY2xpZW50LWNyZWRlbnRpYWxzIn0.gsM-U84ykgaxMSbL55w6UYIIQUouPIB6YOmJuj1KhLFnrYctu5vwYBo80zyr1je9kO_6L-rI7SUnrHVao9DFBZJmfFfeojTxIT3CE58hoCdxZQZdPUGePjQzROWRWeDfG96iqhRcepjbVF9pMhKp6FNqEVOxkX00RZg9vFT8iMM"
 
-  val userWithNoRoles     = UserInfo("unit test", Set.empty)
-  val userWithWriteAccess = UserInfo("unit test", Set(Role.WRITE))
+  val userWithNoRoles               = UserInfo("unit test", Set.empty)
+  val userWithWriteAccess           = UserInfo("unit test", Set(Role.WRITE))
   val userWithWriteAndPublishAccess = UserInfo("unit test", Set(Role.ADMIN, Role.WRITE))
 
   val today     = LocalDateTime.now().minusDays(0)

--- a/concept-api/src/test/scala/no/ndla/conceptapi/service/StateTransitionRulesTest.scala
+++ b/concept-api/src/test/scala/no/ndla/conceptapi/service/StateTransitionRulesTest.scala
@@ -1,0 +1,166 @@
+package no.ndla.conceptapi.service
+
+import no.ndla.common.model.domain.draft.Copyright
+import no.ndla.common.model.domain.{Author, Responsible, Tag, Title}
+import no.ndla.conceptapi.{TestData, TestEnvironment, UnitSuite}
+import no.ndla.conceptapi.model.domain
+import no.ndla.conceptapi.model.domain.{ConceptContent, ConceptStatus, Status}
+import org.mockito.invocation.InvocationOnMock
+
+import scala.util.Success
+
+class StateTransitionRulesTest extends UnitSuite with TestEnvironment {
+  test("That publishing article results in responsibleId being reset") {
+    val beforeResponsible = Responsible("heisann", clock.now())
+    val concept = domain.Concept(
+      id = Some(1L),
+      revision = Some(1),
+      title = Seq(Title("tittel", "nb")),
+      content = Seq(ConceptContent("content", "nb")),
+      copyright = Some(
+        Copyright(
+          license = Some("CC-BY-4.0"),
+          origin = None,
+          creators = Seq(Author("writer", "Ape Katt")),
+          processors = Seq.empty,
+          rightsholders = Seq.empty,
+          agreementId = None,
+          validFrom = None,
+          validTo = None
+        )
+      ),
+      source = None,
+      created = TestData.today,
+      updated = TestData.today,
+      updatedBy = Seq("user"),
+      metaImage = Seq.empty,
+      tags = Seq(Tag(Seq("Hei", "hå"), "nb")),
+      subjectIds = Set.empty,
+      articleIds = Seq.empty,
+      status = Status(ConceptStatus.IN_PROGRESS, Set.empty),
+      visualElement = Seq.empty,
+      responsible = Some(Responsible("hei", TestData.today))
+    )
+    val status            = domain.Status(ConceptStatus.IN_PROGRESS, Set.empty)
+    val transitionsToTest = StateTransitionRules.StateTransitions.filter(_.to == ConceptStatus.PUBLISHED)
+    when(writeService.publishConcept(any)).thenAnswer((i: InvocationOnMock) =>
+      Success(i.getArgument[domain.Concept](0))
+    )
+    when(writeService.unpublishConcept(any)).thenAnswer((i: InvocationOnMock) =>
+      Success(i.getArgument[domain.Concept](0))
+    )
+    for (t <- transitionsToTest) {
+      val fromDraft = concept.copy(status = status.copy(current = t.from), responsible = Some(beforeResponsible))
+      val result = StateTransitionRules
+        .doTransition(fromDraft, ConceptStatus.PUBLISHED, TestData.userWithWriteAndPublishAccess)
+        .unsafeRunSync()
+
+      if (result.get.responsible.isDefined) {
+        fail(s"${t.from} -> ${t.to} did not reset responsible >:( Look at the sideeffects in `StateTransitionRules`")
+      }
+    }
+  }
+
+  test("That archiving article results in responsibleId being reset") {
+    val beforeResponsible = Responsible("heisann", clock.now())
+    val concept = domain.Concept(
+      id = Some(1L),
+      revision = Some(1),
+      title = Seq(Title("tittel", "nb")),
+      content = Seq(ConceptContent("content", "nb")),
+      copyright = Some(
+        Copyright(
+          license = Some("CC-BY-4.0"),
+          origin = None,
+          creators = Seq(Author("writer", "Ape Katt")),
+          processors = Seq.empty,
+          rightsholders = Seq.empty,
+          agreementId = None,
+          validFrom = None,
+          validTo = None
+        )
+      ),
+      source = None,
+      created = TestData.today,
+      updated = TestData.today,
+      updatedBy = Seq("user"),
+      metaImage = Seq.empty,
+      tags = Seq(Tag(Seq("Hei", "hå"), "nb")),
+      subjectIds = Set.empty,
+      articleIds = Seq.empty,
+      status = Status(ConceptStatus.IN_PROGRESS, Set.empty),
+      visualElement = Seq.empty,
+      responsible = Some(Responsible("hei", TestData.today))
+    )
+    val status            = domain.Status(ConceptStatus.IN_PROGRESS, Set.empty)
+    val transitionsToTest = StateTransitionRules.StateTransitions.filter(_.to == ConceptStatus.ARCHIVED)
+    when(writeService.publishConcept(any)).thenAnswer((i: InvocationOnMock) =>
+      Success(i.getArgument[domain.Concept](0))
+    )
+    when(writeService.unpublishConcept(any)).thenAnswer((i: InvocationOnMock) =>
+      Success(i.getArgument[domain.Concept](0))
+    )
+    for (t <- transitionsToTest) {
+      val fromDraft = concept.copy(status = status.copy(current = t.from), responsible = Some(beforeResponsible))
+      val result = StateTransitionRules
+        .doTransition(fromDraft, ConceptStatus.ARCHIVED, TestData.userWithWriteAndPublishAccess)
+        .unsafeRunSync()
+
+      if (result.get.responsible.isDefined) {
+        fail(s"${t.from} -> ${t.to} did not reset responsible >:( Look at the sideeffects in `StateTransitionRules`")
+      }
+    }
+  }
+
+  test("That unpublishing article results in responsibleId being reset") {
+    val beforeResponsible = Responsible("heisann", clock.now())
+    val concept = domain.Concept(
+      id = Some(1L),
+      revision = Some(1),
+      title = Seq(Title("tittel", "nb")),
+      content = Seq(ConceptContent("content", "nb")),
+      copyright = Some(
+        Copyright(
+          license = Some("CC-BY-4.0"),
+          origin = None,
+          creators = Seq(Author("writer", "Ape Katt")),
+          processors = Seq.empty,
+          rightsholders = Seq.empty,
+          agreementId = None,
+          validFrom = None,
+          validTo = None
+        )
+      ),
+      source = None,
+      created = TestData.today,
+      updated = TestData.today,
+      updatedBy = Seq("user"),
+      metaImage = Seq.empty,
+      tags = Seq(Tag(Seq("Hei", "hå"), "nb")),
+      subjectIds = Set.empty,
+      articleIds = Seq.empty,
+      status = Status(ConceptStatus.IN_PROGRESS, Set.empty),
+      visualElement = Seq.empty,
+      responsible = Some(Responsible("hei", TestData.today))
+    )
+    val status            = domain.Status(ConceptStatus.IN_PROGRESS, Set.empty)
+    val transitionsToTest = StateTransitionRules.StateTransitions.filter(_.to == ConceptStatus.UNPUBLISHED)
+    when(writeService.publishConcept(any)).thenAnswer((i: InvocationOnMock) =>
+      Success(i.getArgument[domain.Concept](0))
+    )
+    when(writeService.unpublishConcept(any)).thenAnswer((i: InvocationOnMock) =>
+      Success(i.getArgument[domain.Concept](0))
+    )
+    for (t <- transitionsToTest) {
+      val fromDraft = concept.copy(status = status.copy(current = t.from), responsible = Some(beforeResponsible))
+      val result = StateTransitionRules
+        .doTransition(fromDraft, ConceptStatus.UNPUBLISHED, TestData.userWithWriteAndPublishAccess)
+        .unsafeRunSync()
+
+      if (result.get.responsible.isDefined) {
+        fail(s"${t.from} -> ${t.to} did not reset responsible >:( Look at the sideeffects in `StateTransitionRules`")
+      }
+    }
+  }
+
+}

--- a/concept-api/src/test/scala/no/ndla/conceptapi/validation/ContentValidatorTest.scala
+++ b/concept-api/src/test/scala/no/ndla/conceptapi/validation/ContentValidatorTest.scala
@@ -7,9 +7,10 @@
 
 package no.ndla.conceptapi.validation
 
-import no.ndla.common.model.domain.{Author, Title}
+import no.ndla.common.model.domain.{Author, Responsible, Title}
 import no.ndla.common.errors.{ValidationException, ValidationMessage}
 import no.ndla.common.model.domain.draft.Copyright
+import no.ndla.conceptapi.model.domain.Concept
 import no.ndla.conceptapi.{TestData, TestEnvironment, UnitSuite}
 
 import scala.util.{Failure, Success}
@@ -18,9 +19,13 @@ class ContentValidatorTest extends UnitSuite with TestEnvironment {
   override val converterService = new ConverterService
   override val contentValidator = new ContentValidator
 
+  val baseConcept: Concept = TestData.domainConcept.copy(
+    responsible = Some(Responsible("hei", TestData.today))
+  )
+
   test("That title validation fails if no titles exist") {
 
-    val conceptToValidate = TestData.domainConcept.copy(
+    val conceptToValidate = baseConcept.copy(
       title = Seq()
     )
 
@@ -31,7 +36,7 @@ class ContentValidatorTest extends UnitSuite with TestEnvironment {
   }
 
   test("That title validation succeeds if titles exist") {
-    val conceptToValidate = TestData.domainConcept.copy(
+    val conceptToValidate = baseConcept.copy(
       title = Seq(Title("Amazing title", "nb"))
     )
 
@@ -40,13 +45,13 @@ class ContentValidatorTest extends UnitSuite with TestEnvironment {
   }
   test("Copyright validation succeeds if license is omitted and copyright holders are empty") {
     val concept =
-      TestData.domainConcept.copy(copyright = Some(Copyright(None, None, Seq(), Seq(), Seq(), None, None, None)))
+      baseConcept.copy(copyright = Some(Copyright(None, None, Seq(), Seq(), Seq(), None, None, None)))
     val result = contentValidator.validateConcept(concept)
     result should be(Success(concept))
   }
 
   test("Copyright validation fails if license is included and copyright holders are empty") {
-    val concept = TestData.domainConcept.copy(
+    val concept = baseConcept.copy(
       copyright = Some(Copyright(Some("CC-BY-4.0"), None, Seq(), Seq(), Seq(), None, None, None))
     )
     val Failure(exception: ValidationException) = contentValidator.validateConcept(concept)
@@ -57,7 +62,7 @@ class ContentValidatorTest extends UnitSuite with TestEnvironment {
 
   test("Copyright validation succeeds if license is included and copyright holders are not empty") {
 
-    val concept = TestData.domainConcept.copy(
+    val concept = baseConcept.copy(
       copyright =
         Some(Copyright(Some("CC-BY-4.0"), None, Seq(Author("creator", "test")), Seq(), Seq(), None, None, None))
     )


### PR DESCRIPTION
Tror dette er nok for at vi skal kunne skrive om til en request for status-endring + lagring i editorial.