### PR TITLE
Bump javamelody. Do not send metrics to cloudwatch

### DIFF
--- a/network/src/main/scala/no/ndla/network/scalatra/NdlaScalatraServer.scala
+++ b/network/src/main/scala/no/ndla/network/scalatra/NdlaScalatraServer.scala
@@ -35,14 +35,6 @@ class NdlaScalatraServer[PropType <: BaseProps, CR <: BaseComponentRegistry[Prop
     context.addEventListener(new SessionListener)
     val monitoringFilter = new FilterHolder(new MonitoringFilter())
     monitoringFilter.setInitParameter(Parameter.APPLICATION_NAME.getCode, props.ApplicationName)
-    props.Environment match {
-      case "local" =>
-      case _ =>
-        monitoringFilter.setInitParameter(
-          Parameter.CLOUDWATCH_NAMESPACE.getCode,
-          "NDLA/APP".replace("APP", props.ApplicationName)
-        )
-    }
     context.addFilter(monitoringFilter, "/*", util.EnumSet.of(DispatcherType.REQUEST, DispatcherType.ASYNC))
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -34,7 +34,7 @@ object Dependencies {
     val ScalikeJDBCV          = "4.0.0"
     val TestContainersV       = "1.15.1"
     val JsoupV                = "1.15.3"
-    val JavaMelodyV           = "1.91.0"
+    val JavaMelodyV           = "1.92.0"
 
     lazy val scalaUri = "io.lemonlabs" %% "scala-uri" % "3.5.0"
 


### PR DESCRIPTION
Skipper å sende metrics fra javamelody til cloudwatch. Det er masse data som vi aldri ser på.