### PR TITLE
Don't reset responsible if save as new from editorial

### DIFF
--- a/draft-api/src/main/scala/no/ndla/draftapi/repository/DraftRepository.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/repository/DraftRepository.scala
@@ -88,7 +88,7 @@ trait DraftRepository {
       article.copy(revision = Some(startRevision))
     }
 
-    def storeArticleAsNewVersion(article: Draft, user: Option[UserInfo])(implicit
+    def storeArticleAsNewVersion(article: Draft, user: Option[UserInfo], keepResponsible: Boolean = false)(implicit
         session: DBSession = AutoSession
     ): Try[Draft] = {
       article.id match {
@@ -109,7 +109,7 @@ trait DraftRepository {
                 .map(u => EditorNote("Artikkelen har blitt lagret som ny versjon", u.id, article.status, clock.now()))
                 .toList,
               previousVersionsNotes = article.previousVersionsNotes ++ article.notes,
-              responsible = None
+              responsible = if (keepResponsible) article.responsible else None
             )
 
             val dataObject = new PGobject()

--- a/draft-api/src/main/scala/no/ndla/draftapi/service/WriteService.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/service/WriteService.scala
@@ -317,7 +317,7 @@ trait WriteService {
         statusWasUpdated: Boolean
     ): Try[Draft] =
       if (shouldOnlyCopy) {
-        draftRepository.storeArticleAsNewVersion(article, Some(user))
+        draftRepository.storeArticleAsNewVersion(article, Some(user), keepResponsible = true)
       } else {
         externalIds match {
           case Nil => updateArticleAndStoreAsNewIfPublished(article, isImported, statusWasUpdated)

--- a/draft-api/src/test/scala/no/ndla/draftapi/service/WriteServiceTest.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/service/WriteServiceTest.scala
@@ -107,7 +107,7 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
         val arg = invocation.getArgument[Draft](0)
         Try(arg.copy(revision = Some(arg.revision.getOrElse(0) + 1)))
       })
-    when(draftRepository.storeArticleAsNewVersion(any[Draft], any[Option[UserInfo]])(any[DBSession]))
+    when(draftRepository.storeArticleAsNewVersion(any[Draft], any[Option[UserInfo]], any[Boolean])(any[DBSession]))
       .thenAnswer((invocation: InvocationOnMock) => {
         val arg = invocation.getArgument[Draft](0)
         Try(arg.copy(revision = Some(arg.revision.getOrElse(0) + 1)))
@@ -937,7 +937,9 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
     updated.get.notes.length should be(1)
 
     verify(draftRepository, never).updateArticle(any[Draft], anyBoolean)(any[DBSession])
-    verify(draftRepository, times(1)).storeArticleAsNewVersion(any[Draft], any[Option[UserInfo]])(any[DBSession])
+    verify(draftRepository, times(1)).storeArticleAsNewVersion(any[Draft], any[Option[UserInfo]], any[Boolean])(
+      any[DBSession]
+    )
   }
 
   test("contentWithClonedFiles clones files as expected") {

--- a/draft-api/src/test/scala/no/ndla/draftapi/validation/ContentValidatorTest.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/validation/ContentValidatorTest.scala
@@ -20,7 +20,8 @@ class ContentValidatorTest extends UnitSuite with TestEnvironment {
   val validDocument             = """<section><h1>heisann</h1><h2>heia</h2></section>"""
   val invalidDocument           = """<section><invalid></invalid></section>"""
 
-  val articleToValidate: Draft = TestData.sampleArticleWithByNcSa.copy(responsible = Some(Responsible("hei", TestData.today)))
+  val articleToValidate: Draft =
+    TestData.sampleArticleWithByNcSa.copy(responsible = Some(Responsible("hei", TestData.today)))
 
   test("validateArticle does not throw an exception on a valid document") {
     val article = articleToValidate.copy(content = Seq(ArticleContent(validDocument, "nb")))


### PR DESCRIPTION
Fixes NDLANO/Issues#3493

Beholder ansvarlig ved oppretting av ny versjon fra ed.