### PR TITLE
Endre endepunkt for å sjekke bruk av artikkel

### DIFF
--- a/draft-api/src/main/scala/no/ndla/draftapi/integration/LearningpathApiClient.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/integration/LearningpathApiClient.scala
@@ -19,11 +19,11 @@ trait LearningpathApiClient {
   val learningpathApiClient: LearningpathApiClient
 
   class LearningpathApiClient {
-    implicit val format          = org.json4s.DefaultFormats
-    private val InternalEndpoint = s"http://${props.LearningpathApiHost}/intern"
+    implicit val format  = org.json4s.DefaultFormats
+    private val Endpoint = s"http://${props.LearningpathApiHost}/learningpath-api/v2/learningpaths"
 
-    def getLearningpathsWithPaths(paths: Seq[String]): Try[Seq[LearningPath]] = {
-      get[Seq[LearningPath]](s"$InternalEndpoint/containsArticle?paths=${paths.mkString(",")}")
+    def getLearningpathsWithId(articleId: Long): Try[Seq[LearningPath]] = {
+      get[Seq[LearningPath]](s"$Endpoint/contains-article/$articleId")
     }
 
     private def get[A](endpointUrl: String, params: (String, String)*)(implicit

--- a/draft-api/src/main/scala/no/ndla/draftapi/service/StateTransitionRules.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/service/StateTransitionRules.scala
@@ -279,19 +279,7 @@ trait StateTransitionRules {
     }
 
     private[this] def learningPathsUsingArticle(articleId: Long): Seq[LearningPath] = {
-      val resources = taxonomyApiClient.queryResource(articleId).getOrElse(List.empty).flatMap(_.paths)
-      val topics    = taxonomyApiClient.queryTopic(articleId).getOrElse(List.empty).flatMap(_.paths)
-      val plainPaths = List(
-        s"/article-iframe/*/$articleId",
-        s"/article-iframe/*/$articleId/",
-        s"/article-iframe/*/$articleId/\\?*",
-        s"/article-iframe/*/$articleId\\?*",
-        s"/article/$articleId"
-      )
-
-      val paths = resources ++ topics ++ plainPaths
-
-      learningpathApiClient.getLearningpathsWithPaths(paths) match {
+      learningpathApiClient.getLearningpathsWithId(articleId) match {
         case Success(learningpaths) => learningpaths
         case _                      => Seq.empty
       }

--- a/draft-api/src/test/scala/no/ndla/draftapi/service/StateTransitionRulesTest.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/service/StateTransitionRulesTest.scala
@@ -184,7 +184,7 @@ class StateTransitionRulesTest extends UnitSuite with TestEnvironment {
     val editorNotes     = Seq(common.EditorNote("Status endret", "unit_test", expectedStatus, LocalDateTime.now()))
     val expectedArticle = InProcessArticle.copy(status = expectedStatus, notes = editorNotes)
 
-    when(learningpathApiClient.getLearningpathsWithPaths(Seq.empty)).thenReturn(Success(Seq.empty))
+    when(learningpathApiClient.getLearningpathsWithId(any[Long])).thenReturn(Success(Seq.empty))
     when(searchApiClient.draftsWhereUsed(any[Long])).thenReturn(Seq.empty)
     when(searchApiClient.publishedWhereUsed(any[Long])).thenReturn(Seq.empty)
     when(taxonomyApiClient.queryResource(any[Long])).thenReturn(Success(List.empty))
@@ -238,8 +238,7 @@ class StateTransitionRulesTest extends UnitSuite with TestEnvironment {
     val articleId: Long = 7
     val article         = TestData.sampleDomainArticle.copy(id = Some(articleId))
     val learningPath    = TestData.sampleLearningPath
-    when(learningpathApiClient.getLearningpathsWithPaths(any[Seq[String]]))
-      .thenReturn(Success(Seq(learningPath)))
+    when(learningpathApiClient.getLearningpathsWithId(any[Long])).thenReturn(Success(Seq(learningPath)))
 
     val res = StateTransitionRules.unpublishArticle(article, false)
     res.isFailure should be(true)
@@ -250,8 +249,7 @@ class StateTransitionRulesTest extends UnitSuite with TestEnvironment {
     val article         = TestData.sampleDomainArticle.copy(id = Some(articleId))
     when(taxonomyApiClient.queryResource(articleId)).thenReturn(Success(List.empty))
     when(taxonomyApiClient.queryTopic(articleId)).thenReturn(Success(List.empty))
-    when(learningpathApiClient.getLearningpathsWithPaths(any[Seq[String]]))
-      .thenReturn(Success(Seq.empty))
+    when(learningpathApiClient.getLearningpathsWithId(any[Long])).thenReturn(Success(Seq.empty))
     when(searchApiClient.draftsWhereUsed(any[Long])).thenReturn(Seq(SearchHit(1, Title("Title", "nb"))))
     when(searchApiClient.publishedWhereUsed(any[Long])).thenReturn(Seq(SearchHit(1, Title("Title", "nb"))))
 
@@ -266,16 +264,9 @@ class StateTransitionRulesTest extends UnitSuite with TestEnvironment {
 
   test("unpublishArticle should fail if article is used in a learningstep with a taxonomy-url") {
     val articleId: Long = 7
-    val externalId      = "169243"
     val article         = TestData.sampleDomainArticle.copy(id = Some(articleId))
     val learningPath    = TestData.sampleLearningPath
-    when(
-      learningpathApiClient
-        .getLearningpathsWithPaths(
-          Seq(s"/unknown/subjects/subject:15/topic:1:166611/topic:1:182229/resource:1:$externalId")
-        )
-    )
-      .thenReturn(Success(Seq(learningPath)))
+    when(learningpathApiClient.getLearningpathsWithId(articleId)).thenReturn(Success(Seq(learningPath)))
     when(draftRepository.getIdFromExternalId(any[String])(any[DBSession])).thenReturn(Some(articleId.toLong))
 
     val res = StateTransitionRules.unpublishArticle(article, false)
@@ -286,15 +277,7 @@ class StateTransitionRulesTest extends UnitSuite with TestEnvironment {
     reset(articleApiClient, taxonomyApiClient, learningpathApiClient)
     val articleId = 7
     val article   = TestData.sampleDomainArticle.copy(id = Some(articleId))
-    val paths = Seq(
-      s"/article-iframe/*/$articleId",
-      s"/article-iframe/*/$articleId/",
-      s"/article-iframe/*/$articleId/\\?*",
-      s"/article-iframe/*/$articleId\\?*",
-      s"/article/$articleId"
-    )
-    when(learningpathApiClient.getLearningpathsWithPaths(paths))
-      .thenReturn(Success(Seq.empty))
+    when(learningpathApiClient.getLearningpathsWithId(articleId)).thenReturn(Success(Seq.empty))
     when(articleApiClient.unpublishArticle(article)).thenReturn(Success(article))
     when(taxonomyApiClient.queryResource(articleId)).thenReturn(Success(List.empty))
     when(taxonomyApiClient.queryTopic(articleId)).thenReturn(Success(List.empty))
@@ -310,15 +293,7 @@ class StateTransitionRulesTest extends UnitSuite with TestEnvironment {
     val articleId: Long = 7
     val article         = TestData.sampleDomainArticle.copy(id = Some(articleId))
     val learningPath    = TestData.sampleLearningPath
-    val paths = Seq(
-      s"/article-iframe/*/$articleId",
-      s"/article-iframe/*/$articleId/",
-      s"/article-iframe/*/$articleId/\\?*",
-      s"/article-iframe/*/$articleId\\?*",
-      s"/article/$articleId"
-    )
-    when(learningpathApiClient.getLearningpathsWithPaths(paths))
-      .thenReturn(Success(Seq(learningPath)))
+    when(learningpathApiClient.getLearningpathsWithId(articleId)).thenReturn(Success(Seq(learningPath)))
     when(taxonomyApiClient.queryResource(articleId)).thenReturn(Success(List.empty))
     when(taxonomyApiClient.queryTopic(articleId)).thenReturn(Success(List.empty))
 
@@ -328,15 +303,9 @@ class StateTransitionRulesTest extends UnitSuite with TestEnvironment {
 
   test("checkIfArticleIsUsedInLearningStep should fail if article is used in a learningstep with a taxonomy-url") {
     val articleId: Long = 7
-    val externalId      = "169243"
     val article         = TestData.sampleDomainArticle.copy(id = Some(articleId))
     val learningPath    = TestData.sampleLearningPath
-    when(
-      learningpathApiClient.getLearningpathsWithPaths(
-        Seq(s"/unknown/subjects/subject:15/topic:1:166611/topic:1:182229/resource:1:$externalId")
-      )
-    )
-      .thenReturn(Success(Seq(learningPath)))
+    when(learningpathApiClient.getLearningpathsWithId(articleId)).thenReturn(Success(Seq(learningPath)))
     when(draftRepository.getIdFromExternalId(any[String])(any[DBSession])).thenReturn(Some(articleId.toLong))
 
     val Failure(res: ValidationException) = StateTransitionRules.checkIfArticleIsInUse(article, false)
@@ -347,14 +316,7 @@ class StateTransitionRulesTest extends UnitSuite with TestEnvironment {
     reset(articleApiClient, taxonomyApiClient, learningpathApiClient)
     val articleId = 7
     val article   = TestData.sampleDomainArticle.copy(id = Some(articleId))
-    val paths = Seq(
-      s"/article-iframe/*/$articleId",
-      s"/article-iframe/*/$articleId/",
-      s"/article-iframe/*/$articleId/\\?*",
-      s"/article-iframe/*/$articleId\\?*",
-      s"/article/$articleId"
-    )
-    when(learningpathApiClient.getLearningpathsWithPaths(paths)).thenReturn(Success(Seq.empty))
+    when(learningpathApiClient.getLearningpathsWithId(articleId)).thenReturn(Success(Seq.empty))
     when(articleApiClient.unpublishArticle(article)).thenReturn(Success(article))
     when(taxonomyApiClient.queryResource(articleId)).thenReturn(Success(List.empty))
     when(taxonomyApiClient.queryTopic(articleId)).thenReturn(Success(List.empty))

--- a/draft-api/src/test/scala/no/ndla/draftapi/validation/ContentValidatorTest.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/validation/ContentValidatorTest.scala
@@ -20,7 +20,8 @@ class ContentValidatorTest extends UnitSuite with TestEnvironment {
   val validDocument             = """<section><h1>heisann</h1><h2>heia</h2></section>"""
   val invalidDocument           = """<section><invalid></invalid></section>"""
 
-  val articleToValidate: Draft = TestData.sampleArticleWithByNcSa.copy(responsible = Some(Responsible("hei", TestData.today)))
+  val articleToValidate: Draft =
+    TestData.sampleArticleWithByNcSa.copy(responsible = Some(Responsible("hei", TestData.today)))
 
   test("validateArticle does not throw an exception on a valid document") {
     val article = articleToValidate.copy(content = Seq(ArticleContent(validDocument, "nb")))


### PR DESCRIPTION
Slutter å bruke tilsvarende kode i draft-api som finnes i learningpath-api