### PR TITLE
validation: Improve selection of optional tag groups

### DIFF
--- a/validation/src/test/scala/no/ndla/validation/EmbedTagValidatorTest.scala
+++ b/validation/src/test/scala/no/ndla/validation/EmbedTagValidatorTest.scala
@@ -317,7 +317,7 @@ class EmbedTagValidatorTest extends UnitSuite {
     val res = embedTagValidator.validate("content", tag)
     findErrorByMessage(
       res,
-      s"data-resource=${ResourceType.ConceptList} must contain all or none of the optional attributes"
+      s"data-resource=${ResourceType.ConceptList} must contain all or none of the attributes in the optional attribute groups"
     ).size should be(1)
 
     val tag2 = generateTagWithAttrs(
@@ -329,7 +329,7 @@ class EmbedTagValidatorTest extends UnitSuite {
     val res2 = embedTagValidator.validate("content", tag2)
     findErrorByMessage(
       res2,
-      s"data-resource=${ResourceType.ConceptList} must contain all or none of the optional attributes"
+      s"data-resource=${ResourceType.ConceptList} must contain all or none of the attributes in the optional attribute groups"
     ).size should be(1)
 
   }
@@ -681,7 +681,24 @@ class EmbedTagValidatorTest extends UnitSuite {
     )
 
     val res = embedTagValidator.validate("content", s"""<$EmbedTagName $attrs />""")
-    res.size should be(0)
+    res.headOption should be(None)
   }
 
+  test("validate should return no errors when data-title is used in a group in iframe") {
+    val attrs = generateAttributes(
+      Map(
+        TagAttributes.DataResource.toString -> ResourceType.IframeContent.toString,
+        TagAttributes.DataType.toString     -> ResourceType.IframeContent.toString,
+        TagAttributes.DataUrl.toString      -> "https://google.ndla.no/",
+        TagAttributes.DataWidth.toString    -> "700",
+        TagAttributes.DataHeight.toString   -> "500",
+        TagAttributes.DataTitle.toString    -> "Min tittel",
+        TagAttributes.DataCaption.toString  -> "heyho",
+        TagAttributes.DataImageId.toString  -> "123"
+      )
+    )
+
+    val res = embedTagValidator.validate("content", s"""<$EmbedTagName $attrs />""")
+    res.headOption should be(None)
+  }
 }


### PR DESCRIPTION
Løser egentlig samme problem som denne https://github.com/NDLANO/backend/pull/201, bare bittelitt mer future-safe.

Før så fant vi bare første optional-group med en tag som matcha når vi skulle validere en attributt og så om alle var fylt ut.
Nå finner vi alle utfylte optional groups og sjekker om det er noen optional tags igjen.