### PR TITLE
draft-api: Make passing comments optional on `PATCH` :^)

### DIFF
--- a/draft-api/src/main/scala/no/ndla/draftapi/model/api/UpdatedArticle.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/model/api/UpdatedArticle.scala
@@ -40,5 +40,5 @@ case class UpdatedArticle(
     @(ApiModelProperty @field)(description = "A list of all revisions of the article") revisionMeta: Option[Seq[RevisionMeta]],
     @(ApiModelProperty @field)(description = "NDLA ID representing the editor responsible for this article") responsibleId: Deletable[String],
     @(ApiModelProperty @field)(description = "The path to the frontpage article") slug: Option[String],
-    @(ApiModelProperty @field)(description = "Information about a comment attached to an article") comments: List[UpdatedComment],
+    @(ApiModelProperty @field)(description = "Information about a comment attached to an article") comments: Option[List[UpdatedComment]],
 )

--- a/draft-api/src/main/scala/no/ndla/draftapi/service/ConverterService.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/service/ConverterService.scala
@@ -727,6 +727,10 @@ trait ConverterService {
         case (Right(_), existing) => existing
       }
 
+      val updatedComments = article.comments
+        .map(comments => updatedCommentToDomain(comments, toMergeInto.comments))
+        .getOrElse(toMergeInto.comments)
+
       failableFields match {
         case Failure(ex) => Failure(ex)
         case Success((allNotes, newContent)) =>
@@ -748,7 +752,7 @@ trait ConverterService {
             revisionMeta = updatedRevisionMeta,
             responsible = responsible,
             slug = article.slug.orElse(toMergeInto.slug),
-            comments = updatedCommentToDomain(article.comments, toMergeInto.comments)
+            comments = updatedComments
           )
 
           val articleWithNewContent = article.copy(content = newContent)
@@ -833,7 +837,7 @@ trait ConverterService {
             .map(responsibleId => Responsible(responsibleId = responsibleId, lastUpdated = clock.now()))
 
           for {
-            comments <- updatedCommentToDomainNullDocument(article.comments)
+            comments <- updatedCommentToDomainNullDocument(article.comments.getOrElse(List.empty))
             notes    <- mergedNotes
           } yield Draft(
             id = Some(id),

--- a/draft-api/src/test/scala/no/ndla/draftapi/TestData.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/TestData.scala
@@ -132,7 +132,7 @@ object TestData {
     None,
     Right(None),
     None,
-    List.empty
+    None
   )
 
   val sampleApiUpdateArticle: UpdatedArticle = blankUpdatedArticle.copy(


### PR DESCRIPTION
Kan testes ved å se at man ikke mister kommentarer dersom man ikke sender inn (eller sender `null`) på `PATCH` endepunktet.