### PR TITLE
draft-api: Fix bug which resulted in 409 when publishing

### DIFF
--- a/draft-api/src/main/scala/no/ndla/draftapi/controller/InternController.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/controller/InternController.scala
@@ -207,7 +207,7 @@ trait InternController {
     get("/dump/article/:id") {
       // Dumps one domain article
       val id = long("id")
-      draftRepository.withId(id) match {
+      draftRepository.withId(id)(ReadOnlyAutoSession) match {
         case Some(article) => Ok(article)
         case None          => errorHandler(NotFoundException(s"Could not find draft with id: '$id"))
       }

--- a/draft-api/src/main/scala/no/ndla/draftapi/repository/DraftRepository.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/repository/DraftRepository.scala
@@ -249,7 +249,7 @@ trait DraftRepository {
       failIfRevisionMismatch(count, article, newRevision)
     }
 
-    def withId(articleId: Long): Option[Draft] =
+    def withId(articleId: Long)(implicit session: DBSession): Option[Draft] =
       articleWhere(
         sqls"""
               ar.article_id=${articleId.toInt}
@@ -402,7 +402,7 @@ trait DraftRepository {
 
     private def articleWhere(
         whereClause: SQLSyntax
-    )(implicit session: DBSession = ReadOnlyAutoSession): Option[Draft] = {
+    )(implicit session: DBSession): Option[Draft] = {
       val ar = DBArticle.syntax("ar")
       sql"select ${ar.result.*} from ${DBArticle.as(ar)} where ar.document is not NULL and $whereClause"
         .map(DBArticle.fromResultSet(ar))
@@ -430,7 +430,7 @@ trait DraftRepository {
         .single()
     }
 
-    def withSlug(slug: String): Option[Draft] = articleWhere(sqls"ar.slug=$slug")
+    def withSlug(slug: String)(implicit session: DBSession): Option[Draft] = articleWhere(sqls"ar.slug=$slug")
 
     def slugExists(slug: String, articleId: Option[Long])(implicit
         session: DBSession = ReadOnlyAutoSession

--- a/draft-api/src/main/scala/no/ndla/draftapi/service/ConverterService.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/service/ConverterService.scala
@@ -897,7 +897,7 @@ trait ConverterService {
     def stateTransitionsToApi(user: UserInfo, articleId: Option[Long]): Try[Map[String, Seq[String]]] =
       articleId match {
         case Some(id) =>
-          draftRepository.withId(id) match {
+          draftRepository.withId(id)(ReadOnlyAutoSession) match {
             case Some(article) => Success(_stateTransitionsToApi(user, Some(article)))
             case None          => Failure(NotFoundException("The article does not exist"))
           }

--- a/draft-api/src/main/scala/no/ndla/draftapi/service/ReadService.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/service/ReadService.scala
@@ -54,14 +54,14 @@ trait ReadService {
       draftRepository.getIdFromExternalId(externalId.toString)(ReadOnlyAutoSession).map(api.ContentId)
 
     def withId(id: Long, language: String, fallback: Boolean = false): Try[api.Article] = {
-      draftRepository.withId(id).map(addUrlsOnEmbedResources) match {
+      draftRepository.withId(id)(ReadOnlyAutoSession).map(addUrlsOnEmbedResources) match {
         case None          => Failure(NotFoundException(s"The article with id $id was not found"))
         case Some(article) => converterService.toApiArticle(article, language, fallback)
       }
     }
 
     def getArticleBySlug(slug: String, language: String, fallback: Boolean = false): Try[api.Article] = {
-      draftRepository.withSlug(slug) match {
+      draftRepository.withSlug(slug)(ReadOnlyAutoSession) match {
         case None          => Failure(NotFoundException(s"The article with slug '$slug' was not found"))
         case Some(article) => converterService.toApiArticle(article, language, fallback)
       }

--- a/draft-api/src/main/scala/no/ndla/draftapi/service/WriteService.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/service/WriteService.scala
@@ -259,7 +259,7 @@ trait WriteService {
         user: UserInfo,
         isImported: Boolean
     ): Try[api.Article] = {
-      draftRepository.withId(id) match {
+      draftRepository.withId(id)(ReadOnlyAutoSession) match {
         case None => Failure(api.NotFoundException(s"No article with id $id was found"))
         case Some(draft) =>
           for {
@@ -561,7 +561,7 @@ trait WriteService {
         oldNdlaUpdatedDate: Option[LocalDateTime],
         importId: Option[String]
     ): Try[api.Article] = {
-      draftRepository.withId(articleId) match {
+      draftRepository.withId(articleId)(ReadOnlyAutoSession) match {
         case Some(existing) =>
           updateExistingArticle(
             existing,
@@ -678,7 +678,7 @@ trait WriteService {
     }
 
     def deleteLanguage(id: Long, language: String, userInfo: UserInfo): Try[api.Article] = {
-      draftRepository.withId(id) match {
+      draftRepository.withId(id)(ReadOnlyAutoSession) match {
         case Some(article) =>
           article.title.size match {
             case 1 => Failure(api.OperationNotAllowedException("Only one language left"))
@@ -837,7 +837,7 @@ trait WriteService {
         articleFieldsToUpdate: Seq[api.PartialArticleFields],
         language: String
     ): (Long, Try[Draft]) =
-      draftRepository.withId(id) match {
+      draftRepository.withId(id)(ReadOnlyAutoSession) match {
         case None => id -> Failure(api.NotFoundException(s"Could not find draft with id of ${id} to partial publish"))
         case Some(article) =>
           partialPublish(article, articleFieldsToUpdate, language)
@@ -933,7 +933,7 @@ trait WriteService {
         case Some(contentUri) =>
           parseArticleIdAndRevision(contentUri) match {
             case (Success(articleId), _) =>
-              draftRepository.withId(articleId) match {
+              draftRepository.withId(articleId)(ReadOnlyAutoSession) match {
                 case Some(article) => article.revisionMeta
                 case _             => Seq.empty
               }
@@ -981,7 +981,7 @@ trait WriteService {
 
     def updateArticleWithRevisions(articleId: Long, revisions: Seq[common.draft.RevisionMeta]): Try[_] = {
       draftRepository
-        .withId(articleId)
+        .withId(articleId)(ReadOnlyAutoSession)
         .traverse(article => {
           val revisionMeta = article.revisionMeta ++ revisions
           val toUpdate     = article.copy(revisionMeta = revisionMeta.distinct)

--- a/draft-api/src/main/scala/no/ndla/draftapi/validation/ContentValidator.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/validation/ContentValidator.scala
@@ -32,6 +32,7 @@ import no.ndla.language.model.Iso639
 import no.ndla.mapping.License.getLicense
 import no.ndla.validation.SlugValidator.validateSlug
 import no.ndla.validation._
+import scalikejdbc.ReadOnlyAutoSession
 
 import java.time.LocalDateTime
 import scala.jdk.CollectionConverters._
@@ -109,7 +110,7 @@ trait ContentValidator {
     }
 
     def validateArticleApiArticle(id: Long, importValidate: Boolean): Try[ContentId] = {
-      draftRepository.withId(id) match {
+      draftRepository.withId(id)(ReadOnlyAutoSession) match {
         case None => Failure(NotFoundException(s"Article with id $id does not exist"))
         case Some(draft) =>
           converterService
@@ -125,7 +126,7 @@ trait ContentValidator {
         importValidate: Boolean,
         user: UserInfo
     ): Try[ContentId] = {
-      draftRepository.withId(id) match {
+      draftRepository.withId(id)(ReadOnlyAutoSession) match {
         case None => Failure(NotFoundException(s"Article with id $id does not exist"))
         case Some(existing) =>
           converterService

--- a/draft-api/src/test/scala/no/ndla/draftapi/repository/DraftRepositoryTest.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/repository/DraftRepositoryTest.scala
@@ -104,8 +104,8 @@ class DraftRepositoryTest extends IntegrationSuite(EnablePostgresContainer = tru
       sampleArticle.copy(id = Some(2), status = Status(DraftStatus.ARCHIVED, Set.empty))
     )(AutoSession)
 
-    repository.withId(1).isDefined should be(true)
-    repository.withId(2).isDefined should be(true)
+    repository.withId(1)(ReadOnlyAutoSession).isDefined should be(true)
+    repository.withId(2)(ReadOnlyAutoSession).isDefined should be(true)
   }
 
   test("that importIdOfArticle works correctly") {
@@ -152,10 +152,10 @@ class DraftRepositoryTest extends IntegrationSuite(EnablePostgresContainer = tru
 
     repository.updateArticle(art1.copy(content = updatedContent))(AutoSession)
 
-    repository.withId(art1.id.get).get.content should be(updatedContent)
-    repository.withId(art2.id.get).get.content should be(art2.content)
-    repository.withId(art3.id.get).get.content should be(art3.content)
-    repository.withId(art4.id.get).get.content should be(art4.content)
+    repository.withId(art1.id.get)(ReadOnlyAutoSession).get.content should be(updatedContent)
+    repository.withId(art2.id.get)(ReadOnlyAutoSession).get.content should be(art2.content)
+    repository.withId(art3.id.get)(ReadOnlyAutoSession).get.content should be(art3.content)
+    repository.withId(art4.id.get)(ReadOnlyAutoSession).get.content should be(art4.content)
   }
 
   test("That storing an article an retrieving it returns the original article") {
@@ -172,10 +172,10 @@ class DraftRepositoryTest extends IntegrationSuite(EnablePostgresContainer = tru
     repository.insert(art3)(AutoSession)
     repository.insert(art4)(AutoSession)
 
-    repository.withId(art1.id.get).get should be(art1)
-    repository.withId(art2.id.get).get should be(art2)
-    repository.withId(art3.id.get).get should be(art3)
-    repository.withId(art4.id.get).get should be(art4)
+    repository.withId(art1.id.get)(ReadOnlyAutoSession).get should be(art1)
+    repository.withId(art2.id.get)(ReadOnlyAutoSession).get should be(art2)
+    repository.withId(art3.id.get)(ReadOnlyAutoSession).get should be(art3)
+    repository.withId(art4.id.get)(ReadOnlyAutoSession).get should be(art4)
   }
 
   test("That updateWithExternalIds updates article correctly") {
@@ -185,7 +185,7 @@ class DraftRepositoryTest extends IntegrationSuite(EnablePostgresContainer = tru
     val updatedContent = Seq(ArticleContent("This is updated with external ids yo", "en"))
     val updatedArt     = art1.copy(content = updatedContent)
     repository.updateWithExternalIds(updatedArt, List("1234", "5678"), List.empty, None)(AutoSession)
-    repository.withId(art1.id.get).get should be(updatedArt)
+    repository.withId(art1.id.get)(ReadOnlyAutoSession).get should be(updatedArt)
   }
 
   test("That getAllIds returns all articles") {
@@ -363,7 +363,7 @@ class DraftRepositoryTest extends IntegrationSuite(EnablePostgresContainer = tru
     )
 
     val inserted = repository.insert(draftArticle1)(AutoSession)
-    val fetched  = repository.withId(inserted.id.get).get
+    val fetched  = repository.withId(inserted.id.get)(ReadOnlyAutoSession).get
     fetched.notes should be(prevNotes1)
     fetched.previousVersionsNotes should be(Seq.empty)
 
@@ -411,7 +411,7 @@ class DraftRepositoryTest extends IntegrationSuite(EnablePostgresContainer = tru
   test("withId parse relatedContent correctly") {
     repository.insert(sampleArticle.copy(id = Some(1), relatedContent = Seq(Right(2))))(AutoSession)
 
-    val Right(relatedId) = repository.withId(1).get.relatedContent.head
+    val Right(relatedId) = repository.withId(1)(ReadOnlyAutoSession).get.relatedContent.head
     relatedId should be(2L)
 
   }

--- a/draft-api/src/test/scala/no/ndla/draftapi/service/ConverterServiceTest.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/service/ConverterServiceTest.scala
@@ -181,7 +181,7 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
     val articleId: Long = 1
     val article: Draft =
       TestData.sampleArticleWithPublicDomain.copy(id = Some(articleId), status = Status(DraftStatus.PLANNED, Set()))
-    when(draftRepository.withId(articleId)).thenReturn(Some(article))
+    when(draftRepository.withId(eqTo(articleId))(any)).thenReturn(Some(article))
     val Success(noTrans) = service.stateTransitionsToApi(TestData.userWithWriteAccess, Some(articleId))
     noTrans(PLANNED.toString) should contain(DraftStatus.ARCHIVED.toString)
     noTrans(IN_PROGRESS.toString) should contain(DraftStatus.ARCHIVED.toString)
@@ -199,7 +199,7 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
     val articleId: Long = 1
     val article: Draft =
       TestData.sampleArticleWithPublicDomain.copy(id = Some(articleId), status = Status(DraftStatus.PUBLISHED, Set()))
-    when(draftRepository.withId(articleId)).thenReturn(Some(article))
+    when(draftRepository.withId(eqTo(articleId))(any)).thenReturn(Some(article))
     val Success(noTrans) = service.stateTransitionsToApi(TestData.userWithWriteAccess, Some(articleId))
 
     noTrans(PLANNED.toString) should not contain (DraftStatus.ARCHIVED.toString)
@@ -217,7 +217,7 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
     val articleId: Long = 1
     val unpublished: Draft =
       TestData.sampleArticleWithPublicDomain.copy(id = Some(articleId), status = Status(DraftStatus.IN_PROGRESS, Set()))
-    when(draftRepository.withId(articleId)).thenReturn(Some(unpublished))
+    when(draftRepository.withId(eqTo(articleId))(any)).thenReturn(Some(unpublished))
     val Success(transOne) = service.stateTransitionsToApi(TestData.userWithWriteAccess, Some(articleId))
     transOne(IN_PROGRESS.toString) should not contain (DraftStatus.LANGUAGE.toString)
 
@@ -226,7 +226,7 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
         id = Some(articleId),
         status = Status(DraftStatus.IN_PROGRESS, Set(DraftStatus.PUBLISHED))
       )
-    when(draftRepository.withId(articleId)).thenReturn(Some(published))
+    when(draftRepository.withId(eqTo(articleId))(any)).thenReturn(Some(published))
     val Success(transTwo) = service.stateTransitionsToApi(TestData.userWithWriteAccess, Some(articleId))
     transTwo(IN_PROGRESS.toString) should contain(DraftStatus.LANGUAGE.toString)
   }
@@ -239,7 +239,7 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
         id = Some(articleId),
         status = Status(DraftStatus.PLANNED, Set(DraftStatus.PUBLISHED))
       )
-    when(draftRepository.withId(articleId)).thenReturn(Some(article))
+    when(draftRepository.withId(eqTo(articleId))(any)).thenReturn(Some(article))
     val Success(noTrans) = service.stateTransitionsToApi(TestData.userWithWriteAccess, None)
 
     noTrans(PLANNED.toString) should not contain (DraftStatus.ARCHIVED)

--- a/draft-api/src/test/scala/no/ndla/draftapi/service/ReadServiceTest.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/service/ReadServiceTest.scala
@@ -52,7 +52,7 @@ class ReadServiceTest extends UnitSuite with TestEnvironment {
       visualElement = Seq(VisualElement(visualElementBefore, "nb"))
     )
 
-    when(draftRepository.withId(1)).thenReturn(Option(article))
+    when(draftRepository.withId(eqTo(1))(any)).thenReturn(Option(article))
     when(draftRepository.getExternalIdsFromId(any[Long])(any[DBSession])).thenReturn(List("54321"))
 
     val expectedResult = converterService

--- a/draft-api/src/test/scala/no/ndla/draftapi/service/WriteServiceTest.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/service/WriteServiceTest.scala
@@ -71,7 +71,7 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
       x(mock[DBSession])
     }).when(draftRepository).rollbackOnFailure(any)
 
-    when(draftRepository.withId(articleId)).thenReturn(Option(article))
+    when(draftRepository.withId(eqTo(articleId))(any)).thenReturn(Option(article))
     when(agreementRepository.withId(agreementId)).thenReturn(Option(agreement))
     when(articleIndexService.indexDocument(any[Draft])).thenAnswer((invocation: InvocationOnMock) =>
       Try(invocation.getArgument[Draft](0))
@@ -288,7 +288,7 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
       responsible = Some(Responsible("hei", TestData.today))
     )
     val updatedArticle = TestData.sampleApiUpdateArticle.copy(status = Some("IN_PROGRESS"))
-    when(draftRepository.withId(existing.id.get)).thenReturn(Some(existing))
+    when(draftRepository.withId(eqTo(existing.id.get))(any)).thenReturn(Some(existing))
     val Success(result) = service.updateArticle(
       existing.id.get,
       updatedArticle,
@@ -311,7 +311,7 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
       status = TestData.statusWithPublished,
       responsible = Some(Responsible("hei", TestData.today))
     )
-    when(draftRepository.withId(existing.id.get)).thenReturn(Some(existing))
+    when(draftRepository.withId(eqTo(existing.id.get))(any)).thenReturn(Some(existing))
     val Success(result) = service.updateArticle(
       existing.id.get,
       updatedArticle,
@@ -333,7 +333,7 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
         status = TestData.statusWithInProcess,
         responsible = Some(Responsible("hei", TestData.today))
       )
-      when(draftRepository.withId(existing.id.get)).thenReturn(Some(existing))
+      when(draftRepository.withId(eqTo(existing.id.get))(any)).thenReturn(Some(existing))
       val Success(result) = service.updateArticle(
         existing.id.get,
         updatedArticle,
@@ -352,7 +352,7 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
         status = TestData.statusWithExternalReview,
         responsible = Some(Responsible("hei", TestData.today))
       )
-      when(draftRepository.withId(existing.id.get)).thenReturn(Some(existing))
+      when(draftRepository.withId(eqTo(existing.id.get))(any)).thenReturn(Some(existing))
       val Success(result) = service.updateArticle(
         existing.id.get,
         updatedArticle,
@@ -371,7 +371,7 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
         status = TestData.statusWithInternalReview,
         responsible = Some(Responsible("hei", TestData.today))
       )
-      when(draftRepository.withId(existing.id.get)).thenReturn(Some(existing))
+      when(draftRepository.withId(eqTo(existing.id.get))(any)).thenReturn(Some(existing))
       val Success(result) = service.updateArticle(
         existing.id.get,
         updatedArticle,
@@ -390,7 +390,7 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
         status = TestData.statusWithEndControl,
         responsible = Some(Responsible("hei", TestData.today))
       )
-      when(draftRepository.withId(existing.id.get)).thenReturn(Some(existing))
+      when(draftRepository.withId(eqTo(existing.id.get))(any)).thenReturn(Some(existing))
       when(contentValidator.validateArticle(any[Draft])).thenReturn(Success(existing))
       when(articleApiClient.validateArticle(any[domain.article.Article], any[Boolean])).thenAnswer(
         (i: InvocationOnMock) => {
@@ -424,7 +424,7 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
       )
     val articleCaptor: ArgumentCaptor[Draft] = ArgumentCaptor.forClass(classOf[Draft])
 
-    when(draftRepository.withId(anyLong)).thenReturn(Some(article))
+    when(draftRepository.withId(anyLong)(any)).thenReturn(Some(article))
     service.deleteLanguage(article.id.get, "nn", UserInfo("asdf", Set()))
     verify(draftRepository).updateArticle(articleCaptor.capture(), anyBoolean)(any)
 
@@ -505,7 +505,7 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
         notes = updatedArticle.notes.map(_.copy(timestamp = today))
       )
 
-    when(draftRepository.withId(10)).thenReturn(Some(articleToUpdate))
+    when(draftRepository.withId(eqTo(10))(any)).thenReturn(Some(articleToUpdate))
     when(draftRepository.updateArticle(any[Draft], eqTo(false))(any)).thenReturn(Success(updatedAndInserted))
 
     when(articleIndexService.indexAsync(any, any[Draft])(any))
@@ -544,7 +544,7 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
         content = Seq(ArticleContent("<section> Valid Content </section>", "nb"))
       )
 
-    when(draftRepository.withId(anyLong)).thenReturn(Some(article))
+    when(draftRepository.withId(anyLong)(any)).thenReturn(Some(article))
     service.updateArticle(1, updatedArticle, List(), List(), TestData.userWithPublishAccess, None, None, None)
 
     val argCap: ArgumentCaptor[Draft] = ArgumentCaptor.forClass(classOf[Draft])
@@ -593,7 +593,7 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
           )
           .get
     )
-    when(draftRepository.withId(anyLong)).thenReturn(Some(article))
+    when(draftRepository.withId(anyLong)(any)).thenReturn(Some(article))
 
     service.copyArticleFromId(5, userinfo, "*", true, true)
 
@@ -641,7 +641,7 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
           )
           .get
     )
-    when(draftRepository.withId(anyLong)).thenReturn(Some(article))
+    when(draftRepository.withId(anyLong)(any)).thenReturn(Some(article))
     service.copyArticleFromId(5, userinfo, "*", true, false)
 
     val cap: ArgumentCaptor[Draft] = ArgumentCaptor.forClass(classOf[Draft])
@@ -658,7 +658,7 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
     )
 
     val existing = TestData.sampleDomainArticle.copy(status = TestData.statusWithPublished)
-    when(draftRepository.withId(existing.id.get)).thenReturn(Some(existing))
+    when(draftRepository.withId(eqTo(existing.id.get))(any)).thenReturn(Some(existing))
     val Success(result1) = service.updateArticle(
       existing.id.get,
       updatedArticle,
@@ -687,7 +687,7 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
       title = Seq(Title(existingTitle, "nb")),
       status = TestData.statusWithPublished
     )
-    when(draftRepository.withId(existing.id.get)).thenReturn(Some(existing))
+    when(draftRepository.withId(eqTo(existing.id.get))(any)).thenReturn(Some(existing))
     val Success(result1) = service.updateArticle(
       existing.id.get,
       updatedArticle,
@@ -738,7 +738,7 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
       tags = Seq.empty
     )
 
-    when(draftRepository.withId(existing.id.get)).thenReturn(Some(existing))
+    when(draftRepository.withId(eqTo(existing.id.get))(any)).thenReturn(Some(existing))
     when(writeService.partialPublish(any, any, any)).thenReturn((existing.id.get, Success(existing)))
     when(articleApiClient.partialPublishArticle(any, any)).thenReturn(Success(existing.id.get))
 
@@ -798,7 +798,7 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
       responsible = Some(Responsible("hei", TestData.today))
     )
 
-    when(draftRepository.withId(existing.id.get)).thenReturn(Some(existing))
+    when(draftRepository.withId(eqTo(existing.id.get))(any)).thenReturn(Some(existing))
     when(writeService.partialPublish(any, any, any)).thenReturn((existing.id.get, Success(existing)))
     when(articleApiClient.partialPublishArticle(any, any)).thenReturn(Success(existing.id.get))
 
@@ -858,7 +858,7 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
       responsible = Some(Responsible("hei", TestData.today))
     )
 
-    when(draftRepository.withId(existing.id.get)).thenReturn(Some(existing))
+    when(draftRepository.withId(eqTo(existing.id.get))(any)).thenReturn(Some(existing))
     when(writeService.partialPublish(any, any, any)).thenReturn((existing.id.get, Success(existing)))
     when(articleApiClient.partialPublishArticle(any, any)).thenReturn(Success(existing.id.get))
 
@@ -1164,7 +1164,7 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
       status = RevisionStatus.fromString(savedRevision.status, RevisionStatus.NeedsRevision)
     )
     val another: Draft = article.copy(revisionMeta = Seq(domainRev))
-    when(draftRepository.withId(articleId)).thenReturn(Option(another))
+    when(draftRepository.withId(eqTo(articleId))(any)).thenReturn(Option(another))
 
     val updated2 = service.updateArticle(
       articleId,
@@ -1217,7 +1217,7 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
       tags = Seq.empty
     )
 
-    when(draftRepository.withId(existing.id.get)).thenReturn(Some(existing))
+    when(draftRepository.withId(eqTo(existing.id.get))(any)).thenReturn(Some(existing))
     when(writeService.partialPublish(any, any, any)).thenReturn((existing.id.get, Success(existing)))
     when(articleApiClient.partialPublishArticle(any, any)).thenReturn(Success(existing.id.get))
 
@@ -1394,9 +1394,9 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
     when(taxonomyApiClient.getNode(nodeId)).thenReturn(Success(node))
     when(taxonomyApiClient.getChildNodes(nodeId)).thenReturn(Success(List(child)))
     when(taxonomyApiClient.getChildResources(anyString())).thenReturn(Success(List(resource)))
-    when(draftRepository.withId(1)).thenReturn(Some(article1))
-    when(draftRepository.withId(2)).thenReturn(Some(article2))
-    when(draftRepository.withId(3)).thenReturn(Some(article3))
+    when(draftRepository.withId(eqTo(1))(any)).thenReturn(Some(article1))
+    when(draftRepository.withId(eqTo(2))(any)).thenReturn(Some(article2))
+    when(draftRepository.withId(eqTo(3))(any)).thenReturn(Some(article3))
     service.copyRevisionDates(nodeId) should be(Success(()))
     verify(draftRepository, times(3)).updateArticle(any[Draft], any[Boolean])(any[DBSession])
   }
@@ -1414,9 +1414,9 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
     when(taxonomyApiClient.getNode(nodeId)).thenReturn(Success(node))
     when(taxonomyApiClient.getChildNodes(nodeId)).thenReturn(Success(List(child)))
     when(taxonomyApiClient.getChildResources(anyString())).thenReturn(Success(List(resource)))
-    when(draftRepository.withId(1)).thenReturn(Some(article1))
-    when(draftRepository.withId(2)).thenReturn(Some(article2))
-    when(draftRepository.withId(3)).thenReturn(Some(article3))
+    when(draftRepository.withId(eqTo(1))(any)).thenReturn(Some(article1))
+    when(draftRepository.withId(eqTo(2))(any)).thenReturn(Some(article2))
+    when(draftRepository.withId(eqTo(3))(any)).thenReturn(Some(article3))
     service.copyRevisionDates(nodeId) should be(Success(()))
     verify(draftRepository, times(0)).updateArticle(any[Draft], any[Boolean])(any[DBSession])
   }
@@ -1438,8 +1438,8 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
     when(taxonomyApiClient.getNode(nodeId)).thenReturn(Success(node))
     when(taxonomyApiClient.getChildNodes(nodeId)).thenReturn(Success(List(child)))
     when(taxonomyApiClient.getChildResources(anyString())).thenReturn(Success(List(resource)))
-    when(draftRepository.withId(1)).thenReturn(Some(article1))
-    when(draftRepository.withId(2)).thenReturn(Some(article2))
+    when(draftRepository.withId(eqTo(1))(any)).thenReturn(Some(article1))
+    when(draftRepository.withId(eqTo(2))(any)).thenReturn(Some(article2))
     service.copyRevisionDates(nodeId) should be(Success(()))
     verify(draftRepository, times(2)).updateArticle(any[Draft], any[Boolean])(any[DBSession])
   }


### PR DESCRIPTION
Problemet var at vi ikke brukte samme transaksjon for å hente ut draft'en vi lagde ny rad med etter vi oppdaterte den. Det resulterte i at revisjonen som vi hentet ut var den gamle og derfor fikk vi 409.

Det betyr forsåvidt at før vi skrev om til å ikke ha default variabler for `DBSession` så hadde vi en potensiell race condition her 😄 