### PR TITLE
Sorting in search

### DIFF
--- a/concept-api/src/main/scala/no/ndla/conceptapi/model/domain/Sort.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/model/domain/Sort.scala
@@ -27,6 +27,8 @@ object Sort extends Enum[Sort] {
   case object ByIdAsc                      extends Sort("id")
   case object ByResponsibleLastUpdatedDesc extends Sort("-responsibleLastUpdated")
   case object ByResponsibleLastUpdatedAsc  extends Sort("responsibleLastUpdated")
+  case object ByStatusAsc                  extends Sort("status")
+  case object ByStatusDesc                 extends Sort("-status")
 
   def valueOf(s: String): Option[Sort] = Sort.values.find(_.entryName == s)
 

--- a/concept-api/src/main/scala/no/ndla/conceptapi/service/search/SearchService.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/service/search/SearchService.scala
@@ -167,23 +167,8 @@ trait SearchService {
           fieldSort("responsible.lastUpdated").sortOrder(SortOrder.Asc).missing("_last")
         case Sort.ByResponsibleLastUpdatedDesc =>
           fieldSort("responsible.lastUpdated").sortOrder(SortOrder.Desc).missing("_last")
-      }
-    }
-
-    def getSortDefinition(sort: Sort): FieldSort = {
-      sort match {
-        case Sort.ByTitleAsc        => fieldSort("title.lower").order(SortOrder.Asc).missing("_last")
-        case Sort.ByTitleDesc       => fieldSort("title.lower").order(SortOrder.Desc).missing("_last")
-        case Sort.ByRelevanceAsc    => fieldSort("_score").order(SortOrder.Asc)
-        case Sort.ByRelevanceDesc   => fieldSort("_score").order(SortOrder.Desc)
-        case Sort.ByLastUpdatedAsc  => fieldSort("lastUpdated").order(SortOrder.Asc).missing("_last")
-        case Sort.ByLastUpdatedDesc => fieldSort("lastUpdated").order(SortOrder.Desc).missing("_last")
-        case Sort.ByIdAsc           => fieldSort("id").order(SortOrder.Asc).missing("_last")
-        case Sort.ByIdDesc          => fieldSort("id").order(SortOrder.Desc).missing("_last")
-        case Sort.ByResponsibleLastUpdatedAsc =>
-          fieldSort("responsible.lastUpdated").sortOrder(SortOrder.Asc).missing("_last")
-        case Sort.ByResponsibleLastUpdatedDesc =>
-          fieldSort("responsible.lastUpdated").sortOrder(SortOrder.Desc).missing("_last")
+        case Sort.ByStatusAsc  => fieldSort("status.current").sortOrder(SortOrder.Asc).missing("_last")
+        case Sort.ByStatusDesc => fieldSort("status.current").sortOrder(SortOrder.Desc).missing("_last")
       }
     }
 

--- a/concept-api/src/test/scala/no/ndla/conceptapi/service/search/DraftConceptSearchServiceTest.scala
+++ b/concept-api/src/test/scala/no/ndla/conceptapi/service/search/DraftConceptSearchServiceTest.scala
@@ -814,4 +814,14 @@ class DraftConceptSearchServiceTest extends IntegrationSuite(EnableElasticsearch
     hits.head.copyright.head.origin should be(Some("Gotham City"))
     hits.head.copyright.head.creators.length should be(1)
   }
+
+  test("that sorting for status works") {
+    val Success(search) =
+      draftConceptSearchService.all(searchSettings.copy(sort = Sort.ByStatusAsc, withIdIn = List(1, 8, 9, 10)))
+    search.results.map(_.id) should be(Seq(8, 10, 1, 9))
+
+    val Success(search2) =
+      draftConceptSearchService.all(searchSettings.copy(sort = Sort.ByStatusDesc, withIdIn = List(1, 8, 9, 10)))
+    search2.results.map(_.id) should be(Seq(9, 1, 10, 8))
+  }
 }

--- a/search-api/src/main/scala/no/ndla/searchapi/model/domain/Sort.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/model/domain/Sort.scala
@@ -32,6 +32,8 @@ object Sort extends Enum[Sort] {
   case object ByRevisionDateDesc           extends Sort("-revisionDate")
   case object ByResponsibleLastUpdatedAsc  extends Sort("responsibleLastUpdated")
   case object ByResponsibleLastUpdatedDesc extends Sort("-responsibleLastUpdated")
+  case object ByStatusAsc                  extends Sort("status")
+  case object ByStatusDesc                 extends Sort("-status")
 
   def valueOf(s: String): Option[Sort] = Sort.values.find(_.entryName == s)
 

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/SearchService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/SearchService.scala
@@ -368,6 +368,8 @@ trait SearchService {
           }
         case Sort.ByDurationAsc     => fieldSort("duration").sortOrder(SortOrder.Asc).missing("_last")
         case Sort.ByDurationDesc    => fieldSort("duration").sortOrder(SortOrder.Desc).missing("_last")
+        case Sort.ByStatusAsc       => fieldSort("draftStatus.current").sortOrder(SortOrder.Asc).missing("_last")
+        case Sort.ByStatusDesc      => fieldSort("draftStatus.current").sortOrder(SortOrder.Desc).missing("_last")
         case Sort.ByRelevanceAsc    => fieldSort("_score").sortOrder(SortOrder.Asc)
         case Sort.ByRelevanceDesc   => fieldSort("_score").sortOrder(SortOrder.Desc)
         case Sort.ByLastUpdatedAsc  => fieldSort("lastUpdated").sortOrder(SortOrder.Asc).missing("_last")


### PR DESCRIPTION
Legger til sortering for søk i {draft,concept}-api :smile:

Kan testes ved å spinne opp draft og concept og teste at `status` og `-status` fungerer som sorterings-parametere.