### PR TITLE
draft-api: Remove reverse sorting for comments

### DIFF
--- a/draft-api/src/main/scala/no/ndla/draftapi/service/ConverterService.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/service/ConverterService.scala
@@ -431,7 +431,7 @@ trait ConverterService {
             revisions = revisionMetas,
             responsible = responsible,
             slug = article.slug,
-            comments = article.comments.map(toApiComment).sortBy(_.created).reverse
+            comments = article.comments.map(toApiComment)
           )
         )
       } else {

--- a/draft-api/src/test/scala/no/ndla/draftapi/service/ConverterServiceTest.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/service/ConverterServiceTest.scala
@@ -10,7 +10,6 @@ package no.ndla.draftapi.service
 import cats.effect.unsafe.implicits.global
 import no.ndla.common
 import no.ndla.common.DateParser
-import no.ndla.common.model.api.draft.{Comment => ApiComment}
 import no.ndla.common.configuration.Constants.EmbedTagName
 import no.ndla.common.errors.ValidationException
 import no.ndla.common.model.domain.draft.DraftStatus._

--- a/draft-api/src/test/scala/no/ndla/draftapi/service/ConverterServiceTest.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/service/ConverterServiceTest.scala
@@ -77,29 +77,6 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
     result.isFailure should be(false)
   }
 
-  test("that toApiArticle sorts comments by created date, newest first") {
-    when(draftRepository.getExternalIdsFromId(any)(any)).thenReturn(List(TestData.externalId))
-    when(clock.now()).thenReturn(LocalDateTime.now())
-    val uuid    = UUID.randomUUID()
-    val comment = Comment(id = uuid, created = clock.now(), updated = clock.now(), content = "c", isOpen = true)
-    val commentCreatedToday     = comment.copy(created = clock.now())
-    val commentCreatedYesterday = comment.copy(created = clock.now().minusDays(1))
-    val commentCreatedTomorrow  = comment.copy(created = clock.now().plusDays(1))
-
-    val apiComment =
-      ApiComment(id = uuid.toString, content = "c", created = clock.now(), updated = clock.now(), isOpen = true)
-    val expectedCreatedToday     = apiComment.copy(created = clock.now())
-    val expectedCreatedYesterday = apiComment.copy(created = clock.now().minusDays(1))
-    val expectedCreatedTomorrow  = apiComment.copy(created = clock.now().plusDays(1))
-    val expectedOrder            = List(expectedCreatedTomorrow, expectedCreatedToday, expectedCreatedYesterday)
-
-    val article = TestData.sampleDomainArticle.copy(comments =
-      List(commentCreatedToday, commentCreatedTomorrow, commentCreatedYesterday)
-    )
-    val Success(result) = service.toApiArticle(article, "nb", fallback = true)
-    result.comments should be(expectedOrder)
-  }
-
   test("toDomainArticleShould should remove unneeded attributes on embed-tags") {
     val content =
       s"""<h1>hello</h1><$EmbedTagName ${TagAttributes.DataResource}="${ResourceType.Image}" ${TagAttributes.DataUrl}="http://some-url" data-random="hehe" />"""


### PR DESCRIPTION
Oppdaget en bug der kommentarer returneres i omvendt rekkefølge når man sender inn flere om gangen, feks med følgende json:
```
{
	"revision": 31,
	"title": "vi prøver ny tittel3222111",
	"language": "nb",
        "responsibleId": "hd5ZL5Lm4kKkumWgN2gjy9wx",
	"comments": [{"content": "2"}, {"content": "1"}]
}
```
så vil kommentarene returneres i omvendt rekkefølge fra draft-api.

Jeg tenker det gir mening at ingen sortering skjer i backend, og at rekkefølgen bestemmes av frontend, de vil jo da automatisk alltid være i riktig rekkefølge basert på når de opprettes..