### PR TITLE
Validation: image-id to match new attributemethod in frontend

### DIFF
--- a/validation/src/main/resources/embed-tag-rules.json
+++ b/validation/src/main/resources/embed-tag-rules.json
@@ -267,7 +267,7 @@
         "data-name",
         "data-email",
         "data-description",
-        "data-imageid"
+        "data-image-id"
       ],
       "optional": [
         ["data-blob-color"],


### PR DESCRIPTION
I Editorial nå så lagres/sendes `imageId` som `image-id` som data tag, det hadde ikke jeg tatt høyde for. 