### PR TITLE
draft-api: Add `latestEditedConcepts` to user data

### DIFF
--- a/draft-api/src/main/scala/no/ndla/draftapi/model/api/UpdatedUserData.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/model/api/UpdatedUserData.scala
@@ -15,5 +15,6 @@ import scala.annotation.meta.field
 case class UpdatedUserData(
     @(ApiModelProperty @field)(description = "User's saved searches") savedSearches: Option[Seq[String]],
     @(ApiModelProperty @field)(description = "User's last edited articles") latestEditedArticles: Option[Seq[String]],
+    @(ApiModelProperty @field)(description = "User's last edited concepts") latestEditedConcepts: Option[Seq[String]],
     @(ApiModelProperty @field)(description = "User's favorite subjects") favoriteSubjects: Option[Seq[String]]
 )

--- a/draft-api/src/main/scala/no/ndla/draftapi/model/api/UserData.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/model/api/UserData.scala
@@ -9,12 +9,11 @@ package no.ndla.draftapi.model.api
 
 import org.scalatra.swagger.annotations.{ApiModel, ApiModelProperty}
 
-import scala.annotation.meta.field
-
 @ApiModel(description = "Information about user data")
 case class UserData(
-    @(ApiModelProperty @field)(description = "The auth0 id of the user") userId: String,
-    @(ApiModelProperty @field)(description = "User's saved searches") savedSearches: Option[Seq[String]],
-    @(ApiModelProperty @field)(description = "User's last edited articles") latestEditedArticles: Option[Seq[String]],
-    @(ApiModelProperty @field)(description = "User's favorite subjects") favoriteSubjects: Option[Seq[String]]
+    @ApiModelProperty(description = "The auth0 id of the user") userId: String,
+    @ApiModelProperty(description = "User's saved searches") savedSearches: Option[Seq[String]],
+    @ApiModelProperty(description = "User's last edited articles") latestEditedArticles: Option[Seq[String]],
+    @ApiModelProperty(description = "User's last edited concepts") latestEditedConcepts: Option[Seq[String]],
+    @ApiModelProperty(description = "User's favorite subjects") favoriteSubjects: Option[Seq[String]]
 )

--- a/draft-api/src/main/scala/no/ndla/draftapi/model/domain/Content.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/model/domain/Content.scala
@@ -34,6 +34,7 @@ case class UserData(
     userId: String,
     savedSearches: Option[Seq[String]],
     latestEditedArticles: Option[Seq[String]],
+    latestEditedConcepts: Option[Seq[String]],
     favoriteSubjects: Option[Seq[String]]
 )
 

--- a/draft-api/src/main/scala/no/ndla/draftapi/service/ConverterService.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/service/ConverterService.scala
@@ -461,6 +461,7 @@ trait ConverterService {
         userId = userData.userId,
         savedSearches = userData.savedSearches,
         latestEditedArticles = userData.latestEditedArticles,
+        latestEditedConcepts = userData.latestEditedConcepts,
         favoriteSubjects = userData.favoriteSubjects
       )
     }

--- a/draft-api/src/main/scala/no/ndla/draftapi/service/WriteService.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/service/WriteService.scala
@@ -769,6 +769,7 @@ trait WriteService {
             userId = userId,
             savedSearches = None,
             latestEditedArticles = None,
+            latestEditedConcepts = None,
             favoriteSubjects = None
           )
         )
@@ -784,6 +785,7 @@ trait WriteService {
             userId = userId,
             savedSearches = updatedUserData.savedSearches,
             latestEditedArticles = updatedUserData.latestEditedArticles,
+            latestEditedConcepts = updatedUserData.latestEditedConcepts,
             favoriteSubjects = updatedUserData.favoriteSubjects
           )
           userDataRepository.insert(newUserData).map(converterService.toApiUserData)
@@ -792,6 +794,7 @@ trait WriteService {
           val toUpdate = existing.copy(
             savedSearches = updatedUserData.savedSearches.orElse(existing.savedSearches),
             latestEditedArticles = updatedUserData.latestEditedArticles.orElse(existing.latestEditedArticles),
+            latestEditedConcepts = updatedUserData.latestEditedConcepts.orElse(existing.latestEditedConcepts),
             favoriteSubjects = updatedUserData.favoriteSubjects.orElse(existing.favoriteSubjects)
           )
           userDataRepository.update(toUpdate).map(converterService.toApiUserData)

--- a/draft-api/src/test/scala/no/ndla/draftapi/TestData.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/TestData.scala
@@ -534,10 +534,23 @@ object TestData {
   )
 
   val emptyDomainUserData: domain.UserData =
-    domain.UserData(id = None, userId = "", savedSearches = None, latestEditedArticles = None, favoriteSubjects = None)
+    domain.UserData(
+      id = None,
+      userId = "",
+      savedSearches = None,
+      latestEditedArticles = None,
+      favoriteSubjects = None,
+      latestEditedConcepts = None
+    )
 
   val emptyApiUserData: api.UserData =
-    api.UserData(userId = "", savedSearches = None, latestEditedArticles = None, favoriteSubjects = None)
+    api.UserData(
+      userId = "",
+      savedSearches = None,
+      latestEditedArticles = None,
+      favoriteSubjects = None,
+      latestEditedConcepts = None
+    )
 
   val newAgreement: NewAgreement = NewAgreement(
     "newTitle",


### PR DESCRIPTION
Vi trenger `latestEditedConcepts` på brukerobjektet for å ha kontroll på hvilke som er de siste redigerte forklaringene til en bruker :^)
Føles litt weird i draft-api, men vi har ingen bruker-objekter på samme måte noe annet sted og dette inneholder allerede ikke-draft-ting så tenker det er beste plassen.