### PR TITLE
Add isActive to context and param to filter contexts.

### DIFF
--- a/search-api/src/main/scala/no/ndla/searchapi/integration/TaxonomyApiClient.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/integration/TaxonomyApiClient.scala
@@ -16,7 +16,6 @@ import no.ndla.search.model.SearchableLanguageFormats
 import no.ndla.searchapi.Props
 import no.ndla.searchapi.caching.Memoize
 import no.ndla.searchapi.model.api.TaxonomyException
-import no.ndla.searchapi.model.search.SearchableTaxonomyContext
 import no.ndla.searchapi.model.taxonomy._
 import org.json4s.Formats
 import sttp.client3.quick._
@@ -48,8 +47,8 @@ trait TaxonomyApiClient {
         contentUri: String,
         filterVisibles: Boolean,
         shouldUsePublishedTax: Boolean
-    ): Try[List[SearchableTaxonomyContext]] = {
-      get[List[SearchableTaxonomyContext]](
+    ): Try[List[TaxonomyContext]] = {
+      get[List[TaxonomyContext]](
         s"$TaxonomyApiEndpoint/queries/$contentUri",
         headers = getVersionHashHeader(shouldUsePublishedTax),
         params = "filterVisibles" -> filterVisibles.toString

--- a/search-api/src/main/scala/no/ndla/searchapi/model/api/ApiTaxonomyContext.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/model/api/ApiTaxonomyContext.scala
@@ -14,16 +14,20 @@ import scala.annotation.meta.field
 // format: off
 @ApiModel(description = "Taxonomy context for the resource")
 case class ApiTaxonomyContext(
-    @(ApiModelProperty @field)(description = "Id of the taoxonomy object") id: String,
-    @(ApiModelProperty @field)(description = "Name of the subject this context is in") subject: String,
-    @(ApiModelProperty @field)(description = "Id of the subject this context is in") subjectId: String,
-    @(ApiModelProperty @field)(description = "The relevance for this context") relevance: String,
-    @(ApiModelProperty @field)(description = "Path to the resource in this context") path: String,
-    @(ApiModelProperty @field)(description = "Breadcrumbs of path to the resource in this context") breadcrumbs: List[String],
-    @(ApiModelProperty @field)(description = "Filters connected to this object and subject. NOT IN USE.") filters: List[TaxonomyContextFilter], //TODO: To be removed
-    @(ApiModelProperty @field)(description = "Type in this context.") learningResourceType: String,
-    @(ApiModelProperty @field)(description = "Resource-types of this context.") resourceTypes: List[TaxonomyResourceType],
-    @(ApiModelProperty @field)(description = "Language for this context") language: String,
-    @(ApiModelProperty @field)(description = "Whether this context is the primary connection") isPrimaryConnection: Boolean
+  @(ApiModelProperty @field)(description = "Id of the taxonomy object") id: String,
+  @(ApiModelProperty @field)(description = "Id of the taxonomy object") publicId: String,
+  @(ApiModelProperty @field)(description = "Name of the subject this context is in") subject: String,
+  @(ApiModelProperty @field)(description = "Name of the subject this context is in") root: String,
+  @(ApiModelProperty @field)(description = "Id of the subject this context is in") subjectId: String,
+  @(ApiModelProperty @field)(description = "Id of the subject this context is in") rootId: String,
+  @(ApiModelProperty @field)(description = "The relevance for this context") relevance: String,
+  @(ApiModelProperty @field)(description = "Path to the resource in this context") path: String,
+  @(ApiModelProperty @field)(description = "Breadcrumbs of path to the resource in this context") breadcrumbs: List[String],
+  @(ApiModelProperty @field)(description = "Type in this context.") learningResourceType: String,
+  @(ApiModelProperty @field)(description = "Type in this context.") contextType: String,
+  @(ApiModelProperty @field)(description = "Resource-types of this context.") resourceTypes: List[TaxonomyResourceType],
+  @(ApiModelProperty @field)(description = "Language for this context") language: String,
+  @(ApiModelProperty @field)(description = "Whether this context is the primary connection") isPrimaryConnection: Boolean,
+  @(ApiModelProperty @field)(description = "Whether this context is the primary connection") isPrimary: Boolean
 )
 // format: on

--- a/search-api/src/main/scala/no/ndla/searchapi/model/search/SearchableTaxonomyContext.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/model/search/SearchableTaxonomyContext.scala
@@ -11,15 +11,16 @@ import no.ndla.search.model.{SearchableLanguageList, SearchableLanguageValues}
 
 // NOTE: This will need to match `TaxonomyContextDTO` in `taxonomy-api`
 case class SearchableTaxonomyContext(
-    id: String,
-    subjectId: String,
-    subject: SearchableLanguageValues,
+    publicId: String,
+    rootId: String,
+    root: SearchableLanguageValues,
     path: String,
     breadcrumbs: SearchableLanguageList,
     contextType: String,
     relevanceId: Option[String],
     relevance: SearchableLanguageValues,
     resourceTypes: List[SearchableTaxonomyResourceType],
-    parentTopicIds: List[String],
-    isPrimaryConnection: Boolean
+    parentIds: List[String],
+    isPrimary: Boolean,
+    isActive: Boolean
 )

--- a/search-api/src/main/scala/no/ndla/searchapi/model/search/settings/MultiDraftSearchSettings.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/model/search/settings/MultiDraftSearchSettings.scala
@@ -8,8 +8,7 @@
 package no.ndla.searchapi.model.search.settings
 
 import no.ndla.common.model.domain.draft.DraftStatus
-import no.ndla.searchapi.model.domain.Sort
-import no.ndla.searchapi.model.domain.LearningResourceType
+import no.ndla.searchapi.model.domain.{LearningResourceType, Sort}
 
 import java.time.LocalDateTime
 
@@ -42,5 +41,6 @@ case class MultiDraftSearchSettings(
     revisionDateFilterTo: Option[LocalDateTime],
     excludeRevisionHistory: Boolean,
     responsibleIdFilter: List[String],
-    articleTypes: List[String]
+    articleTypes: List[String],
+    filterInactive: Boolean
 )

--- a/search-api/src/main/scala/no/ndla/searchapi/model/search/settings/SearchSettings.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/model/search/settings/SearchSettings.scala
@@ -31,5 +31,6 @@ case class SearchSettings(
     embedResource: List[String],
     embedId: Option[String],
     availability: List[Availability.Value],
-    articleTypes: List[String]
+    articleTypes: List[String],
+    filterInactive: Boolean
 )

--- a/search-api/src/main/scala/no/ndla/searchapi/model/taxonomy/Node.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/model/taxonomy/Node.scala
@@ -45,7 +45,8 @@ case class TaxonomyContext(
     parentIds: List[String],
     isPrimary: Boolean,
     contextId: String,
-    isVisible: Boolean
+    isVisible: Boolean,
+    isActive: Boolean
 )
 
 case class TaxonomyTranslation(name: String, language: String)

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/IndexService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/IndexService.scala
@@ -302,12 +302,13 @@ trait IndexService {
     protected def getTaxonomyContextMapping: NestedField = {
       nestedField("contexts").fields(
         List(
-          keywordField("id"),
+          keywordField("publicId"),
           keywordField("path"),
           keywordField("contextType"),
-          keywordField("subjectId"),
-          keywordField("parentTopicIds"),
+          keywordField("rootId"),
+          keywordField("parentIds"),
           keywordField("relevanceId"),
+          booleanField("isActive"),
           nestedField("resourceTypes").fields(
             List(keywordField("id"))
           )

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/MultiDraftSearchService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/MultiDraftSearchService.scala
@@ -127,7 +127,7 @@ trait MultiDraftSearchService {
 
         e4sClient.execute(searchWithScroll) match {
           case Success(response) =>
-            getHits(response.result, settings.language).map(hits => {
+            getHits(response.result, settings.language, settings.filterInactive).map(hits => {
               SearchResult(
                 totalCount = response.result.totalHits,
                 page = Some(settings.page),
@@ -185,9 +185,10 @@ trait MultiDraftSearchService {
       )
       val taxonomyContextFilter       = contextTypeFilter(settings.learningResourceTypes)
       val taxonomyResourceTypesFilter = resourceTypeFilter(settings.resourceTypes, filterByNoResourceType = false)
-      val taxonomySubjectFilter       = subjectFilter(settings.subjects)
-      val taxonomyTopicFilter         = topicFilter(settings.topics)
+      val taxonomySubjectFilter       = subjectFilter(settings.subjects, settings.filterInactive)
+      val taxonomyTopicFilter         = topicFilter(settings.topics, settings.filterInactive)
       val taxonomyRelevanceFilter     = relevanceFilter(settings.relevanceIds, settings.subjects)
+      val taxonomyContextActiveFilter = contextActiveFilter(settings.filterInactive)
 
       List(
         licenseFilter,
@@ -198,6 +199,7 @@ trait MultiDraftSearchService {
         taxonomyTopicFilter,
         taxonomyResourceTypesFilter,
         taxonomyContextFilter,
+        taxonomyContextActiveFilter,
         supportedLanguageFilter,
         taxonomyRelevanceFilter,
         statusFilter,

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/MultiSearchService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/MultiSearchService.scala
@@ -23,6 +23,7 @@ import no.ndla.searchapi.model.search.SearchType
 import no.ndla.searchapi.model.search.settings.SearchSettings
 
 import java.util.concurrent.Executors
+import scala.collection.immutable.List
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutor, Future}
 import scala.util.{Failure, Success, Try}
 
@@ -117,7 +118,7 @@ trait MultiSearchService {
 
         e4sClient.execute(searchWithScroll) match {
           case Success(response) =>
-            getHits(response.result, settings.language).map(hits => {
+            getHits(response.result, settings.language, settings.filterInactive).map(hits => {
               SearchResult(
                 totalCount = response.result.totalHits,
                 page = Some(settings.page),
@@ -168,8 +169,9 @@ trait MultiSearchService {
       )
       val taxonomyContextTypeFilter   = contextTypeFilter(settings.learningResourceTypes)
       val taxonomyResourceTypesFilter = resourceTypeFilter(settings.resourceTypes, settings.filterByNoResourceType)
-      val taxonomySubjectFilter       = subjectFilter(settings.subjects)
+      val taxonomySubjectFilter       = subjectFilter(settings.subjects, settings.filterInactive)
       val taxonomyRelevanceFilter     = relevanceFilter(settings.relevanceIds, settings.subjects)
+      val taxonomyContextActiveFilter = contextActiveFilter(settings.filterInactive)
 
       val supportedLanguageFilter = supportedLanguagesFilter(settings.supportedLanguages)
 
@@ -188,6 +190,7 @@ trait MultiSearchService {
         taxonomyContextTypeFilter,
         supportedLanguageFilter,
         taxonomyRelevanceFilter,
+        taxonomyContextActiveFilter,
         grepCodesFilter,
         embedResourceAndIdFilter,
         availabilityFilter

--- a/search-api/src/test/scala/no/ndla/searchapi/TestData.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/TestData.scala
@@ -47,9 +47,9 @@ object TestData {
     Copyright("copyrighted", "New York", List(Author("Writer", "Clark Kent")), List(), List(), None, None, None)
   val today: LocalDateTime = LocalDateTime.now().withNano(0)
 
-  val sampleArticleTitle         = ArticleApiTitle("tittell", "nb")
-  val sampleArticleVisualElement = ArticleApiVisualElement(s"""<$EmbedTagName data-resource="image">""", "nb")
-  val sampleArticleIntro         = ArticleApiIntro("intro", "nb")
+  val sampleArticleTitle: ArticleApiTitle = ArticleApiTitle("tittell", "nb")
+  val sampleArticleVisualElement          = ArticleApiVisualElement(s"""<$EmbedTagName data-resource="image">""", "nb")
+  val sampleArticleIntro                  = ArticleApiIntro("intro", "nb")
 
   val sampleArticleSearch = ArticleApiSearchResults(
     totalCount = 2,
@@ -1018,7 +1018,8 @@ object TestData {
       contextType: Option[String],
       relevance: Option[Relevance],
       isPrimary: Boolean,
-      isVisible: Boolean
+      isVisible: Boolean,
+      isActive: Boolean
   ): List[TaxonomyContext] = {
     parent.contexts.map(context => {
       TaxonomyContext(
@@ -1038,7 +1039,8 @@ object TestData {
         parentIds = context.parentIds :+ parent.id,
         isPrimary = isPrimary,
         contextId = RandomStringUtils.randomAlphabetic(12),
-        isVisible = parent.metadata.map(m => m.visible && isVisible).getOrElse(isVisible)
+        isVisible = parent.metadata.map(m => m.visible && isVisible).getOrElse(isVisible),
+        isActive = isActive
       )
     })
   }
@@ -1065,7 +1067,8 @@ object TestData {
         parentIds = List.empty,
         isPrimary = true,
         contextId = "",
-        isVisible = true
+        isVisible = true,
+        isActive = true
       )
     )
   )
@@ -1091,7 +1094,8 @@ object TestData {
         parentIds = List.empty,
         isPrimary = true,
         contextId = "",
-        isVisible = true
+        isVisible = true,
+        isActive = true
       )
     )
   )
@@ -1117,7 +1121,8 @@ object TestData {
         parentIds = List.empty,
         isPrimary = true,
         contextId = "",
-        isVisible = false
+        isVisible = false,
+        isActive = true
       )
     )
   )
@@ -1132,7 +1137,7 @@ object TestData {
     List.empty
   )
   topic_1.contexts =
-    generateContexts(topic_1, subject_1, subject_1, List.empty, Some("topic-article"), Some(core), true, true)
+    generateContexts(topic_1, subject_1, subject_1, List.empty, Some("topic-article"), Some(core), true, true, true)
   val topic_2: Node = Node(
     "urn:topic:2",
     article9.title.head.title,
@@ -1144,7 +1149,7 @@ object TestData {
     List.empty
   )
   topic_2.contexts =
-    generateContexts(topic_2, subject_1, topic_1, List.empty, Some("topic-article"), Some(core), true, true)
+    generateContexts(topic_2, subject_1, topic_1, List.empty, Some("topic-article"), Some(core), true, true, true)
   val topic_3: Node = Node(
     "urn:topic:3",
     article10.title.head.title,
@@ -1156,7 +1161,7 @@ object TestData {
     List.empty
   )
   topic_3.contexts =
-    generateContexts(topic_3, subject_1, subject_1, List.empty, Some("topic-article"), Some(core), true, true)
+    generateContexts(topic_3, subject_1, subject_1, List.empty, Some("topic-article"), Some(core), true, true, true)
   val topic_4: Node = Node(
     "urn:topic:4",
     article11.title.head.title,
@@ -1168,7 +1173,7 @@ object TestData {
     List.empty
   )
   topic_4.contexts =
-    generateContexts(topic_4, subject_2, subject_2, List.empty, Some("topic-article"), Some(core), true, true)
+    generateContexts(topic_4, subject_2, subject_2, List.empty, Some("topic-article"), Some(core), true, true, true)
   val topic_5: Node = Node(
     "urn:topic:5",
     draft15.title.head.title,
@@ -1180,7 +1185,7 @@ object TestData {
     List.empty
   )
   topic_5.contexts =
-    generateContexts(topic_5, subject_3, subject_3, List.empty, Some("topic-article"), Some(supp), true, true)
+    generateContexts(topic_5, subject_3, subject_3, List.empty, Some("topic-article"), Some(supp), true, true, true)
   val resource_1: Node = Node(
     "urn:resource:1",
     article1.title.head.title,
@@ -1199,10 +1204,31 @@ object TestData {
     Some("standard"),
     Some(core),
     true,
+    true,
     true
   ) ++
-    generateContexts(resource_1, subject_1, topic_1, List(subjectMaterial), Some("standard"), Some(core), true, true) ++
-    generateContexts(resource_1, subject_2, topic_4, List(subjectMaterial), Some("standard"), Some(core), true, true)
+    generateContexts(
+      resource_1,
+      subject_1,
+      topic_1,
+      List(subjectMaterial),
+      Some("standard"),
+      Some(core),
+      true,
+      true,
+      true
+    ) ++
+    generateContexts(
+      resource_1,
+      subject_2,
+      topic_4,
+      List(subjectMaterial),
+      Some("standard"),
+      Some(core),
+      true,
+      true,
+      false
+    )
   val resource_2: Node = Node(
     "urn:resource:2",
     article2.title.head.title,
@@ -1221,6 +1247,7 @@ object TestData {
     Some("standard"),
     Some(supp),
     true,
+    true,
     true
   )
   val resource_3: Node = Node(
@@ -1233,8 +1260,17 @@ object TestData {
     NodeType.RESOURCE,
     List.empty
   )
-  resource_3.contexts =
-    generateContexts(resource_3, subject_1, topic_3, List(subjectMaterial), Some("standard"), Some(supp), true, true)
+  resource_3.contexts = generateContexts(
+    resource_3,
+    subject_1,
+    topic_3,
+    List(subjectMaterial),
+    Some("standard"),
+    Some(supp),
+    true,
+    true,
+    true
+  )
   val resource_4: Node = Node(
     "urn:resource:4",
     article4.title.head.title,
@@ -1245,8 +1281,17 @@ object TestData {
     NodeType.RESOURCE,
     List.empty
   )
-  resource_4.contexts =
-    generateContexts(resource_4, subject_1, topic_2, List(subjectMaterial), Some("standard"), Some(supp), true, true)
+  resource_4.contexts = generateContexts(
+    resource_4,
+    subject_1,
+    topic_2,
+    List(subjectMaterial),
+    Some("standard"),
+    Some(supp),
+    true,
+    true,
+    true
+  )
   val resource_5: Node = Node(
     "urn:resource:5",
     article5.title.head.title,
@@ -1265,7 +1310,8 @@ object TestData {
     Some("standard"),
     Some(core),
     true,
-    true
+    true,
+    false
   ) ++
     generateContexts(
       resource_5,
@@ -1274,6 +1320,7 @@ object TestData {
       List(academicArticle, subjectMaterial),
       Some("standard"),
       Some(core),
+      true,
       true,
       true
     )
@@ -1287,8 +1334,17 @@ object TestData {
     NodeType.RESOURCE,
     List.empty
   )
-  resource_6.contexts =
-    generateContexts(resource_6, subject_2, topic_4, List(subjectMaterial), Some("standard"), Some(core), true, true)
+  resource_6.contexts = generateContexts(
+    resource_6,
+    subject_2,
+    topic_4,
+    List(subjectMaterial),
+    Some("standard"),
+    Some(core),
+    true,
+    true,
+    true
+  )
   val resource_7: Node = Node(
     "urn:resource:7",
     article7.title.head.title,
@@ -1307,7 +1363,8 @@ object TestData {
     Some("standard"),
     Some(core),
     true,
-    true
+    true,
+    false
   )
   val resource_8: Node = Node(
     "urn:resource:8",
@@ -1319,8 +1376,17 @@ object TestData {
     NodeType.RESOURCE,
     List.empty
   )
-  resource_8.contexts =
-    generateContexts(resource_8, subject_1, topic_1, List(rtLearningpath), Some("learningpath"), Some(supp), true, true)
+  resource_8.contexts = generateContexts(
+    resource_8,
+    subject_1,
+    topic_1,
+    List(rtLearningpath),
+    Some("learningpath"),
+    Some(supp),
+    true,
+    true,
+    true
+  )
   val resource_9: Node = Node(
     "urn:resource:9",
     learningPath2.title.head.title,
@@ -1331,8 +1397,17 @@ object TestData {
     NodeType.RESOURCE,
     List.empty
   )
-  resource_9.contexts =
-    generateContexts(resource_9, subject_1, topic_1, List(rtLearningpath), Some("learningpath"), Some(core), true, true)
+  resource_9.contexts = generateContexts(
+    resource_9,
+    subject_1,
+    topic_1,
+    List(rtLearningpath),
+    Some("learningpath"),
+    Some(core),
+    true,
+    true,
+    true
+  )
   val resource_10: Node = Node(
     "urn:resource:10",
     learningPath3.title.head.title,
@@ -1350,6 +1425,7 @@ object TestData {
     List(rtLearningpath),
     Some("learningpath"),
     Some(core),
+    true,
     true,
     true
   )
@@ -1371,6 +1447,7 @@ object TestData {
     Some("learningpath"),
     Some(supp),
     true,
+    true,
     true
   )
   val resource_12: Node = Node(
@@ -1390,6 +1467,7 @@ object TestData {
     List(rtLearningpath),
     Some("learningpath"),
     Some(supp),
+    true,
     true,
     true
   )
@@ -1411,9 +1489,20 @@ object TestData {
     Some("standard"),
     Some(core),
     true,
+    true,
     true
   ) ++
-    generateContexts(resource_13, subject_2, topic_4, List(subjectMaterial), Some("standard"), Some(supp), true, true)
+    generateContexts(
+      resource_13,
+      subject_2,
+      topic_4,
+      List(subjectMaterial),
+      Some("standard"),
+      Some(supp),
+      true,
+      true,
+      true
+    )
 
   val nodes = List(
     subject_1,
@@ -1482,7 +1571,8 @@ object TestData {
     embedResource = List.empty,
     embedId = None,
     availability = List.empty,
-    articleTypes = List.empty
+    articleTypes = List.empty,
+    filterInactive = false
   )
 
   val multiDraftSearchSettings: MultiDraftSearchSettings = MultiDraftSearchSettings(
@@ -1514,7 +1604,8 @@ object TestData {
     revisionDateFilterTo = None,
     excludeRevisionHistory = false,
     responsibleIdFilter = List.empty,
-    articleTypes = List.empty
+    articleTypes = List.empty,
+    filterInactive = false
   )
 
   val searchableResourceTypes = List(
@@ -1530,9 +1621,9 @@ object TestData {
 
   val singleSearchableTaxonomyContext =
     SearchableTaxonomyContext(
-      id = "urn:resource:101",
-      subjectId = "urn:subject:1",
-      subject = SearchableLanguageValues(Seq(LanguageValue("nb", "Matte"))),
+      publicId = "urn:resource:101",
+      rootId = "urn:subject:1",
+      root = SearchableLanguageValues(Seq(LanguageValue("nb", "Matte"))),
       path = "/subject:3/topic:1/topic:151/resource:101",
       breadcrumbs = SearchableLanguageList(
         Seq(
@@ -1543,8 +1634,9 @@ object TestData {
       relevanceId = Some("urn:relevance:core"),
       relevance = SearchableLanguageValues(Seq(LanguageValue("nb", "Kjernestoff"))),
       resourceTypes = searchableResourceTypes,
-      parentTopicIds = List("urn:topic:1"),
-      isPrimaryConnection = true
+      parentIds = List("urn:topic:1"),
+      isPrimary = true,
+      isActive = true
     )
 
   val searchableTaxonomyContexts = List(

--- a/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceAtomicTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceAtomicTest.scala
@@ -549,7 +549,8 @@ class MultiDraftSearchServiceAtomicTest
           parentIds = List.empty,
           isPrimary = true,
           contextId = "",
-          isVisible = true
+          isVisible = true,
+          isActive = true
         )
       )
     )
@@ -563,8 +564,17 @@ class MultiDraftSearchServiceAtomicTest
       NodeType.TOPIC,
       List.empty
     )
-    topic_1.contexts =
-      generateContexts(topic_1, subject_1, subject_1, List.empty, None, Some(core), isPrimary = true, isVisible = true)
+    topic_1.contexts = generateContexts(
+      topic_1,
+      subject_1,
+      subject_1,
+      List.empty,
+      None,
+      Some(core),
+      isPrimary = true,
+      isVisible = true,
+      isActive = true
+    )
     val topic_2 = Node(
       "urn:topic:2",
       "T2",
@@ -575,8 +585,17 @@ class MultiDraftSearchServiceAtomicTest
       NodeType.TOPIC,
       List.empty
     )
-    topic_2.contexts =
-      generateContexts(topic_2, subject_1, subject_1, List.empty, None, Some(core), isPrimary = true, isVisible = true)
+    topic_2.contexts = generateContexts(
+      topic_2,
+      subject_1,
+      subject_1,
+      List.empty,
+      None,
+      Some(core),
+      isPrimary = true,
+      isVisible = true,
+      isActive = true
+    )
     val topic_3 = Node(
       "urn:topic:3",
       "T3",
@@ -587,8 +606,17 @@ class MultiDraftSearchServiceAtomicTest
       NodeType.TOPIC,
       List.empty
     )
-    topic_3.contexts =
-      generateContexts(topic_3, subject_1, topic_1, List.empty, None, Some(core), isPrimary = true, isVisible = true)
+    topic_3.contexts = generateContexts(
+      topic_3,
+      subject_1,
+      topic_1,
+      List.empty,
+      None,
+      Some(core),
+      isPrimary = true,
+      isVisible = true,
+      isActive = true
+    )
     val topic_4 = Node(
       "urn:topic:4",
       "T4",
@@ -599,8 +627,17 @@ class MultiDraftSearchServiceAtomicTest
       NodeType.TOPIC,
       List.empty
     )
-    topic_4.contexts =
-      generateContexts(topic_4, subject_1, topic_1, List.empty, None, Some(core), isPrimary = true, isVisible = true)
+    topic_4.contexts = generateContexts(
+      topic_4,
+      subject_1,
+      topic_1,
+      List.empty,
+      None,
+      Some(core),
+      isPrimary = true,
+      isVisible = true,
+      isActive = true
+    )
     val resource_5 = Node(
       "urn:resource:5",
       "R5",
@@ -619,7 +656,8 @@ class MultiDraftSearchServiceAtomicTest
       None,
       Some(core),
       isPrimary = true,
-      isVisible = true
+      isVisible = true,
+      isActive = true
     ) ++
       generateContexts(
         resource_5,
@@ -629,7 +667,8 @@ class MultiDraftSearchServiceAtomicTest
         None,
         Some(core),
         isPrimary = false,
-        isVisible = true
+        isVisible = true,
+        isActive = true
       )
     val resource_6 = Node(
       "urn:resource:6",
@@ -641,8 +680,17 @@ class MultiDraftSearchServiceAtomicTest
       NodeType.RESOURCE,
       List.empty
     )
-    resource_6.contexts =
-      generateContexts(resource_6, subject_1, topic_3, List.empty, None, Some(core), isPrimary = true, isVisible = true)
+    resource_6.contexts = generateContexts(
+      resource_6,
+      subject_1,
+      topic_3,
+      List.empty,
+      None,
+      Some(core),
+      isPrimary = true,
+      isVisible = true,
+      isActive = true
+    )
 
     val taxonomyBundle = {
       TaxonomyBundle(nodes =

--- a/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceAtomicTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceAtomicTest.scala
@@ -141,7 +141,8 @@ class MultiSearchServiceAtomicTest extends IntegrationSuite(EnableElasticsearchC
             parentIds = List.empty,
             isPrimary = true,
             contextId = "",
-            isVisible = true
+            isVisible = true,
+            isActive = true
           )
         )
       )
@@ -164,7 +165,8 @@ class MultiSearchServiceAtomicTest extends IntegrationSuite(EnableElasticsearchC
         None,
         Some(core),
         isPrimary = true,
-        isVisible = false
+        isVisible = false,
+        isActive = true
       )
       // Visible subtopic
       val topic_2 = Node(
@@ -177,8 +179,17 @@ class MultiSearchServiceAtomicTest extends IntegrationSuite(EnableElasticsearchC
         NodeType.TOPIC,
         List.empty
       )
-      topic_2.contexts =
-        generateContexts(topic_2, subject_1, topic_1, List.empty, None, Some(core), isPrimary = true, isVisible = false)
+      topic_2.contexts = generateContexts(
+        topic_2,
+        subject_1,
+        topic_1,
+        List.empty,
+        None,
+        Some(core),
+        isPrimary = true,
+        isVisible = false,
+        isActive = true
+      )
       // Visible topic
       val topic_3 = Node(
         "urn:topic:3",
@@ -198,7 +209,8 @@ class MultiSearchServiceAtomicTest extends IntegrationSuite(EnableElasticsearchC
         None,
         Some(core),
         isPrimary = true,
-        isVisible = true
+        isVisible = true,
+        isActive = true
       )
       // Visible resource with hidden parent topic
       val resource_1 = Node(
@@ -219,7 +231,8 @@ class MultiSearchServiceAtomicTest extends IntegrationSuite(EnableElasticsearchC
         None,
         Some(core),
         isPrimary = true,
-        isVisible = false
+        isVisible = false,
+        isActive = true
       )
       // Visible resource with visible parent topic
       val resource_2 = Node(
@@ -240,7 +253,8 @@ class MultiSearchServiceAtomicTest extends IntegrationSuite(EnableElasticsearchC
         None,
         Some(core),
         isPrimary = true,
-        isVisible = true
+        isVisible = true,
+        isActive = true
       )
 
       val nodes = List(
@@ -301,7 +315,8 @@ class MultiSearchServiceAtomicTest extends IntegrationSuite(EnableElasticsearchC
             parentIds = List.empty,
             isPrimary = true,
             contextId = "",
-            isVisible = true
+            isVisible = true,
+            isActive = true
           )
         )
       )
@@ -324,7 +339,8 @@ class MultiSearchServiceAtomicTest extends IntegrationSuite(EnableElasticsearchC
         None,
         Some(core),
         isPrimary = true,
-        isVisible = false
+        isVisible = false,
+        isActive = true
       ) // TODO: use visible from node also
       // Visible subtopic
       val topic_2 = Node(
@@ -337,8 +353,17 @@ class MultiSearchServiceAtomicTest extends IntegrationSuite(EnableElasticsearchC
         NodeType.TOPIC,
         List.empty
       )
-      topic_2.contexts =
-        generateContexts(topic_2, subject_1, topic_1, List.empty, None, Some(core), isPrimary = true, isVisible = true)
+      topic_2.contexts = generateContexts(
+        topic_2,
+        subject_1,
+        topic_1,
+        List.empty,
+        None,
+        Some(core),
+        isPrimary = true,
+        isVisible = true,
+        isActive = true
+      )
       // Visible topic
       val topic_3 = Node(
         "urn:topic:3",
@@ -358,7 +383,8 @@ class MultiSearchServiceAtomicTest extends IntegrationSuite(EnableElasticsearchC
         None,
         Some(core),
         isPrimary = true,
-        isVisible = true
+        isVisible = true,
+        isActive = true
       )
 
       val nodes = List(

--- a/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceTest.scala
@@ -500,6 +500,30 @@ class MultiSearchServiceTest
     )
   }
 
+  test("That filtering out inactive contexts works as expected") {
+    val Success(search) = multiSearchService.matchingQuery(
+      searchSettings.copy(
+        language = "*",
+        filterInactive = false
+      )
+    )
+
+    val totalCount = search.totalCount
+    val ids = search.results.map(_.id).length
+    val contextCount = search.results.flatMap(_.contexts).toList.length
+
+    val Success(search2) = multiSearchService.matchingQuery(
+      searchSettings.copy(
+        language = "*",
+        filterInactive = true
+      )
+    )
+
+    totalCount should be > search2.totalCount
+    ids should be > search2.results.map(_.id).length
+    contextCount should be > search2.results.flatMap(_.contexts).toList.length
+  }
+
   test("That filtering on supportedLanguages works") {
     val Success(search) =
       multiSearchService.matchingQuery(searchSettings.copy(language = "*", supportedLanguages = List("en")))

--- a/search-api/src/test/scala/no/ndla/searchapi/service/search/SearchConverterServiceTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/service/search/SearchConverterServiceTest.scala
@@ -260,13 +260,13 @@ class SearchConverterServiceTest extends UnitSuite with TestEnvironment {
       )
 
     searchable1.contexts.size should be(2)
-    searchable1.contexts.map(_.subject.languageValues.map(_.value)) should be(Seq(Seq("Matte"), Seq("Historie")))
+    searchable1.contexts.map(_.root.languageValues.map(_.value)) should be(Seq(Seq("Matte"), Seq("Historie")))
 
     searchable4.contexts.size should be(1)
-    searchable4.contexts.head.subject.languageValues.map(_.value) should be(Seq("Matte"))
+    searchable4.contexts.head.root.languageValues.map(_.value) should be(Seq("Matte"))
 
     searchable5.contexts.size should be(2)
-    searchable5.contexts.map(_.subject.languageValues.map(_.value)) should be(Seq(Seq("Historie"), Seq("Matte")))
+    searchable5.contexts.map(_.root.languageValues.map(_.value)) should be(Seq(Seq("Historie"), Seq("Matte")))
   }
 
   test("That invisible contexts are not indexed") {


### PR DESCRIPTION
Rename some fields in index.

Benytter isActive-flagget fra taksonomikontekst for å legge til filterering av kontekster.
Dersom filter-inactive sendes til søk så må alle treff ha contexts.isActive. I tillegg filtreres inaktive kontekster ut fra søkeresultatet.