### PR TITLE
draft-api, concept-api: Automatically set responsible on status change

### DIFF
--- a/concept-api/src/main/scala/no/ndla/conceptapi/model/domain/SideEffect.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/model/domain/SideEffect.scala
@@ -7,10 +7,12 @@
 
 package no.ndla.conceptapi.model.domain
 
+import no.ndla.conceptapi.auth.UserInfo
+
 import scala.util.{Success, Try}
 
 object SideEffect {
-  type SideEffect = (Concept) => Try[Concept]
-  def none: SideEffect                             = (concept) => Success(concept)
-  def fromOutput(output: Try[Concept]): SideEffect = _ => output
+  type SideEffect = (Concept, UserInfo) => Try[Concept]
+  def none: SideEffect                             = (concept, _) => Success(concept)
+  def fromOutput(output: Try[Concept]): SideEffect = (_, _) => output
 }

--- a/concept-api/src/main/scala/no/ndla/conceptapi/service/StateTransitionRules.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/service/StateTransitionRules.scala
@@ -74,7 +74,7 @@ trait StateTransitionRules {
       (QUALITY_ASSURANCE  -> PUBLISHED)           keepStates Set() require UserInfo.PublishRoles withSideEffect publishConcept withSideEffect resetResponsible,
       (QUALITY_ASSURANCE  -> IN_PROGRESS)         keepStates Set(PUBLISHED),
       (QUALITY_ASSURANCE  -> INTERNAL_REVIEW)     keepStates Set(PUBLISHED),
-      (PUBLISHED          -> IN_PROGRESS)         withSideEffect addResponsible,
+      (PUBLISHED          -> IN_PROGRESS)         withSideEffect addResponsible keepCurrentOnTransition,
       (PUBLISHED          -> UNPUBLISHED)         keepStates Set() require UserInfo.PublishRoles withSideEffect unpublishConcept withSideEffect resetResponsible,
        UNPUBLISHED        -> UNPUBLISHED          withSideEffect resetResponsible,
       (UNPUBLISHED        -> PUBLISHED)           keepStates Set() require UserInfo.PublishRoles withSideEffect publishConcept withSideEffect resetResponsible,

--- a/concept-api/src/main/scala/no/ndla/conceptapi/service/StateTransitionRules.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/service/StateTransitionRules.scala
@@ -47,7 +47,8 @@ trait StateTransitionRules {
     private val resetResponsible: SideEffect = (concept: domain.Concept, _: UserInfo) =>
       Success(concept.copy(responsible = None))
     private val addResponsible: SideEffect = (concept: domain.Concept, user: UserInfo) => {
-      Success(concept.copy(responsible = Some(Responsible(user.id, clock.now()))))
+      val responsible = concept.responsible.getOrElse(Responsible(user.id, clock.now()))
+      Success(concept.copy(responsible = Some(responsible)))
     }
 
     import StateTransition._

--- a/concept-api/src/main/scala/no/ndla/conceptapi/service/StateTransitionRules.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/service/StateTransitionRules.scala
@@ -108,8 +108,9 @@ trait StateTransitionRules {
         .filter(t => user.hasRoles(t.requiredRoles))
 
     private def validateTransition(current: domain.Concept, transition: StateTransition): Try[Unit] = {
-      val statusRequiresResponsible       = ConceptStatus.thatRequiresResponsible.contains(transition.to)
-      val statusFromPublishedToInProgress = current.status.current != transition.to
+      val statusRequiresResponsible = ConceptStatus.thatRequiresResponsible.contains(transition.to)
+      val statusFromPublishedToInProgress =
+        current.status.current == PUBLISHED && transition.to == IN_PROGRESS
       if (statusRequiresResponsible && current.responsible.isEmpty && !statusFromPublishedToInProgress) {
         return Failure(
           IllegalStatusStateTransition(

--- a/concept-api/src/main/scala/no/ndla/conceptapi/service/StateTransitionRules.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/service/StateTransitionRules.scala
@@ -8,6 +8,7 @@
 package no.ndla.conceptapi.service
 
 import cats.effect.IO
+import no.ndla.common.model.domain.Responsible
 import no.ndla.conceptapi.auth.UserInfo
 import no.ndla.conceptapi.model.api.ErrorHelpers
 import no.ndla.conceptapi.model.domain
@@ -18,6 +19,7 @@ import no.ndla.conceptapi.repository.{DraftConceptRepository, PublishedConceptRe
 import no.ndla.conceptapi.service.search.DraftConceptIndexService
 import no.ndla.conceptapi.validation.ContentValidator
 import no.ndla.network.model.RequestInfo
+import no.ndla.common.Clock
 
 import scala.language.postfixOps
 import scala.util.{Failure, Success, Try}
@@ -31,17 +33,22 @@ trait StateTransitionRules {
     with ContentValidator
     with DraftConceptIndexService
     with PublishedConceptRepository
-    with ErrorHelpers =>
+    with ErrorHelpers
+    with Clock =>
 
   object StateTransitionRules {
 
     private[service] val unpublishConcept: SideEffect =
-      (concept: domain.Concept) => writeService.unpublishConcept(concept)
+      (concept: domain.Concept, _: UserInfo) => writeService.unpublishConcept(concept)
 
     private[service] val publishConcept: SideEffect =
-      (concept: domain.Concept) => writeService.publishConcept(concept)
+      (concept: domain.Concept, _: UserInfo) => writeService.publishConcept(concept)
 
-    private val resetResponsible: SideEffect = (concept: domain.Concept) => Success(concept.copy(responsible = None))
+    private val resetResponsible: SideEffect = (concept: domain.Concept, _: UserInfo) =>
+      Success(concept.copy(responsible = None))
+    private val addResponsible: SideEffect = (concept: domain.Concept, user: UserInfo) => {
+      Success(concept.copy(responsible = Some(Responsible(user.id, clock.now()))))
+    }
 
     import StateTransition._
 
@@ -67,7 +74,7 @@ trait StateTransitionRules {
       (QUALITY_ASSURANCE  -> PUBLISHED)           keepStates Set() require UserInfo.PublishRoles withSideEffect publishConcept withSideEffect resetResponsible,
       (QUALITY_ASSURANCE  -> IN_PROGRESS)         keepStates Set(PUBLISHED),
       (QUALITY_ASSURANCE  -> INTERNAL_REVIEW)     keepStates Set(PUBLISHED),
-      (PUBLISHED          -> IN_PROGRESS)         keepCurrentOnTransition,
+      (PUBLISHED          -> IN_PROGRESS)         withSideEffect addResponsible,
       (PUBLISHED          -> UNPUBLISHED)         keepStates Set() require UserInfo.PublishRoles withSideEffect unpublishConcept withSideEffect resetResponsible,
        UNPUBLISHED        -> UNPUBLISHED          withSideEffect resetResponsible,
       (UNPUBLISHED        -> PUBLISHED)           keepStates Set() require UserInfo.PublishRoles withSideEffect publishConcept withSideEffect resetResponsible,
@@ -101,8 +108,9 @@ trait StateTransitionRules {
         .filter(t => user.hasRoles(t.requiredRoles))
 
     private def validateTransition(current: domain.Concept, transition: StateTransition): Try[Unit] = {
-      val statusRequiresResponsible = ConceptStatus.thatRequiresResponsible.contains(transition.to)
-      if (statusRequiresResponsible && current.responsible.isEmpty) {
+      val statusRequiresResponsible       = ConceptStatus.thatRequiresResponsible.contains(transition.to)
+      val statusFromPublishedToInProgress = current.status.current != transition.to
+      if (statusRequiresResponsible && current.responsible.isEmpty && !statusFromPublishedToInProgress) {
         return Failure(
           IllegalStatusStateTransition(
             s"The action triggered a state transition to ${transition.to}, this is invalid without setting new responsible."
@@ -158,7 +166,7 @@ trait StateTransitionRules {
         requestInfo.setRequestInfo()
         convertedArticle.flatMap(conceptBeforeSideEffect => {
           sideEffects.foldLeft(Try(conceptBeforeSideEffect))((accumulatedConcept, sideEffect) => {
-            accumulatedConcept.flatMap(c => sideEffect(c))
+            accumulatedConcept.flatMap(c => sideEffect(c, user))
           })
         })
       }

--- a/concept-api/src/test/scala/no/ndla/conceptapi/service/StateTransitionRulesTest.scala
+++ b/concept-api/src/test/scala/no/ndla/conceptapi/service/StateTransitionRulesTest.scala
@@ -5,7 +5,7 @@ import no.ndla.common.model.domain.draft.Copyright
 import no.ndla.common.model.domain.{Author, Responsible, Tag, Title}
 import no.ndla.conceptapi.{TestData, TestEnvironment, UnitSuite}
 import no.ndla.conceptapi.model.domain
-import no.ndla.conceptapi.model.domain.{ConceptContent, ConceptStatus, Status}
+import no.ndla.conceptapi.model.domain.{ConceptContent, ConceptStatus, StateTransition, Status}
 import org.mockito.invocation.InvocationOnMock
 
 import scala.util.Success
@@ -163,5 +163,51 @@ class StateTransitionRulesTest extends UnitSuite with TestEnvironment {
       }
     }
   }
+  test("That responsibleId is updated at status change from published to in progress") {
+    val concept = domain.Concept(
+      id = Some(1L),
+      revision = Some(1),
+      title = Seq(Title("tittel", "nb")),
+      content = Seq(ConceptContent("content", "nb")),
+      copyright = Some(
+        Copyright(
+          license = Some("CC-BY-4.0"),
+          origin = None,
+          creators = Seq(Author("writer", "Katronk")),
+          processors = Seq.empty,
+          rightsholders = Seq.empty,
+          agreementId = None,
+          validFrom = None,
+          validTo = None
+        )
+      ),
+      source = None,
+      created = TestData.today,
+      updated = TestData.today,
+      updatedBy = Seq("user"),
+      metaImage = Seq.empty,
+      tags = Seq(Tag(Seq("Hei", "hå"), "nb")),
+      subjectIds = Set.empty,
+      articleIds = Seq.empty,
+      status = Status(ConceptStatus.PUBLISHED, Set.empty),
+      visualElement = Seq.empty,
+      responsible = None
+    )
+    val status                            = domain.Status(ConceptStatus.PUBLISHED, Set.empty)
+    val transitionToTest: StateTransition = ConceptStatus.PUBLISHED -> ConceptStatus.IN_PROGRESS
+    val expected                          = TestData.userWithWriteAndPublishAccess.id
+    when(writeService.publishConcept(any)).thenAnswer((i: InvocationOnMock) =>
+      Success(i.getArgument[domain.Concept](0))
+    )
+    when(writeService.unpublishConcept(any)).thenAnswer((i: InvocationOnMock) =>
+      Success(i.getArgument[domain.Concept](0))
+    )
 
+    val fromConcept = concept.copy(status = status.copy(current = transitionToTest.from))
+    val result = StateTransitionRules
+      .doTransition(fromConcept, ConceptStatus.IN_PROGRESS, TestData.userWithWriteAndPublishAccess)
+      .unsafeRunSync()
+
+    result.get.responsible.get.responsibleId should be(expected)
+  }
 }

--- a/draft-api/src/main/scala/no/ndla/draftapi/service/SideEffect.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/service/SideEffect.scala
@@ -8,19 +8,20 @@
 package no.ndla.draftapi.service
 
 import no.ndla.common.model.domain.draft.Draft
+import no.ndla.draftapi.auth.UserInfo
 
 import scala.util.{Success, Try}
 import scala.language.implicitConversions
 
 object SideEffect {
-  type SideEffect = (Draft, Boolean) => Try[Draft]
-  def none: SideEffect                           = (article, isImported) => Success(article)
-  def fromOutput(output: Try[Draft]): SideEffect = (_, _) => output
+  type SideEffect = (Draft, Boolean, UserInfo) => Try[Draft]
+  def none: SideEffect                           = (article, isImported, _) => Success(article)
+  def fromOutput(output: Try[Draft]): SideEffect = (_, _, _) => output
 
   /** Implicits used to simplify creating a [[SideEffect]] which doesn't need all the parameters */
   object implicits {
     implicit def toSideEffect(func: Draft => Try[Draft]): SideEffect =
-      (article: Draft, _: Boolean) => {
+      (article: Draft, _: Boolean, _: UserInfo) => {
         func(article)
       }
   }

--- a/draft-api/src/main/scala/no/ndla/draftapi/service/StateTransitionRules.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/service/StateTransitionRules.scala
@@ -201,8 +201,9 @@ trait StateTransitionRules {
     }
 
     private def validateTransition(draft: Draft, transition: StateTransition): Try[Unit] = {
-      val statusRequiresResponsible       = DraftStatus.thatRequiresResponsible.contains(transition.to)
-      val statusFromPublishedToInProgress = draft.status.current != transition.to
+      val statusRequiresResponsible = DraftStatus.thatRequiresResponsible.contains(transition.to)
+      val statusFromPublishedToInProgress =
+        draft.status.current == PUBLISHED && transition.to == IN_PROGRESS
       if (statusRequiresResponsible && draft.responsible.isEmpty && !statusFromPublishedToInProgress) {
         return Failure(
           IllegalStatusStateTransition(

--- a/draft-api/src/main/scala/no/ndla/draftapi/service/StateTransitionRules.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/service/StateTransitionRules.scala
@@ -60,7 +60,8 @@ trait StateTransitionRules {
     }
 
     private val addResponsible: SideEffect = (article: Draft, _: Boolean, user: UserInfo) => {
-      Success(article.copy(responsible = Some(Responsible(user.id, clock.now()))))
+      val responsible = article.responsible.getOrElse(Responsible(user.id, clock.now()))
+      Success(article.copy(responsible = Some(responsible)))
     }
 
     private[service] val unpublishArticle: SideEffect = (article: Draft) =>

--- a/draft-api/src/main/scala/no/ndla/draftapi/service/StateTransitionRules.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/service/StateTransitionRules.scala
@@ -179,7 +179,7 @@ trait StateTransitionRules {
        PUBLISH_DELAYED       -> PUBLISH_DELAYED,
       (PUBLISH_DELAYED       -> PUBLISHED)             require DirectPublishRoles withSideEffect publishArticle withSideEffect resetResponsible,
       (PUBLISH_DELAYED       -> ARCHIVED)              .require(PublishRoles, articleHasNotBeenPublished) withIllegalStatuses Set(PUBLISHED) withSideEffect resetResponsible,
-      (PUBLISHED             -> IN_PROGRESS)           keepStates Set(PUBLISHED) withSideEffect addResponsible,
+      (PUBLISHED             -> IN_PROGRESS)           keepStates Set(PUBLISHED) withSideEffect addResponsible keepCurrentOnTransition,
       (PUBLISHED             -> UNPUBLISHED)           keepStates Set.empty require DirectPublishRoles withSideEffect unpublishArticle withSideEffect resetResponsible,
       (PUBLISHED             -> ARCHIVED)              .require(PublishRoles, articleHasNotBeenPublished) withIllegalStatuses Set(PUBLISHED) withSideEffect unpublishArticle withSideEffect resetResponsible,
        UNPUBLISHED           -> UNPUBLISHED            withSideEffect resetResponsible,

--- a/draft-api/src/test/scala/no/ndla/draftapi/service/StateTransitionRulesTest.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/service/StateTransitionRulesTest.scala
@@ -168,7 +168,7 @@ class StateTransitionRulesTest extends UnitSuite with TestEnvironment {
 
     val (Success(res), sideEffect) =
       doTransitionWithoutSideEffect(InProcessArticle, PUBLISHED, TestData.userWithAdminAccess, false)
-    sideEffect.map(sf => sf(res, false).get.status should equal(expectedStatus))
+    sideEffect.map(sf => sf(res, false, TestData.userWithAdminAccess).get.status should equal(expectedStatus))
 
     val captor = ArgumentCaptor.forClass(classOf[Draft])
     verify(articleApiClient, times(1))
@@ -193,7 +193,7 @@ class StateTransitionRulesTest extends UnitSuite with TestEnvironment {
 
     val (Success(res), sideEffect) =
       doTransitionWithoutSideEffect(PublishedArticle, UNPUBLISHED, TestData.userWithAdminAccess, false)
-    sideEffect.map(sf => sf(res, false).get.status should equal(expectedStatus))
+    sideEffect.map(sf => sf(res, false, TestData.userWithAdminAccess).get.status should equal(expectedStatus))
 
     val captor = ArgumentCaptor.forClass(classOf[Draft])
 
@@ -212,7 +212,7 @@ class StateTransitionRulesTest extends UnitSuite with TestEnvironment {
 
     val (Success(res), sideEffect) =
       doTransitionWithoutSideEffect(UnpublishedArticle, ARCHIVED, TestData.userWithPublishAccess, false)
-    sideEffect.map(sf => sf(res, false).get.status should equal(expectedStatus))
+    sideEffect.map(sf => sf(res, false, TestData.userWithAdminAccess).get.status should equal(expectedStatus))
 
     verify(articleIndexService, times(0))
       .deleteDocument(UnpublishedArticle.id.get)
@@ -240,7 +240,7 @@ class StateTransitionRulesTest extends UnitSuite with TestEnvironment {
     val learningPath    = TestData.sampleLearningPath
     when(learningpathApiClient.getLearningpathsWithId(any[Long])).thenReturn(Success(Seq(learningPath)))
 
-    val res = StateTransitionRules.unpublishArticle(article, false)
+    val res = StateTransitionRules.unpublishArticle(article, false, TestData.userWithAdminAccess)
     res.isFailure should be(true)
   }
 
@@ -253,7 +253,8 @@ class StateTransitionRulesTest extends UnitSuite with TestEnvironment {
     when(searchApiClient.draftsWhereUsed(any[Long])).thenReturn(Seq(SearchHit(1, Title("Title", "nb"))))
     when(searchApiClient.publishedWhereUsed(any[Long])).thenReturn(Seq(SearchHit(1, Title("Title", "nb"))))
 
-    val Failure(res: ValidationException) = StateTransitionRules.checkIfArticleIsInUse(article, false)
+    val Failure(res: ValidationException) =
+      StateTransitionRules.checkIfArticleIsInUse(article, false, TestData.userWithAdminAccess)
     res.errors should equal(
       Seq(
         ValidationMessage("status.current", "Article is in use in these draft(s) 1 (Title)"),
@@ -269,7 +270,7 @@ class StateTransitionRulesTest extends UnitSuite with TestEnvironment {
     when(learningpathApiClient.getLearningpathsWithId(articleId)).thenReturn(Success(Seq(learningPath)))
     when(draftRepository.getIdFromExternalId(any[String])(any[DBSession])).thenReturn(Some(articleId.toLong))
 
-    val res = StateTransitionRules.unpublishArticle(article, false)
+    val res = StateTransitionRules.unpublishArticle(article, false, TestData.userWithAdminAccess)
     res.isFailure should be(true)
   }
 
@@ -284,7 +285,7 @@ class StateTransitionRulesTest extends UnitSuite with TestEnvironment {
     when(searchApiClient.draftsWhereUsed(any[Long])).thenReturn(Seq.empty)
     when(searchApiClient.publishedWhereUsed(any[Long])).thenReturn(Seq.empty)
 
-    val res = StateTransitionRules.unpublishArticle(article, false)
+    val res = StateTransitionRules.unpublishArticle(article, false, TestData.userWithAdminAccess)
     res.isSuccess should be(true)
     verify(articleApiClient, times(1)).unpublishArticle(article)
   }
@@ -297,7 +298,8 @@ class StateTransitionRulesTest extends UnitSuite with TestEnvironment {
     when(taxonomyApiClient.queryResource(articleId)).thenReturn(Success(List.empty))
     when(taxonomyApiClient.queryTopic(articleId)).thenReturn(Success(List.empty))
 
-    val Failure(res: ValidationException) = StateTransitionRules.checkIfArticleIsInUse(article, false)
+    val Failure(res: ValidationException) =
+      StateTransitionRules.checkIfArticleIsInUse(article, false, TestData.userWithAdminAccess)
     res.errors.head.message should equal("Learningpath(s) 1 (Title) contains a learning step that uses this article")
   }
 
@@ -308,7 +310,8 @@ class StateTransitionRulesTest extends UnitSuite with TestEnvironment {
     when(learningpathApiClient.getLearningpathsWithId(articleId)).thenReturn(Success(Seq(learningPath)))
     when(draftRepository.getIdFromExternalId(any[String])(any[DBSession])).thenReturn(Some(articleId.toLong))
 
-    val Failure(res: ValidationException) = StateTransitionRules.checkIfArticleIsInUse(article, false)
+    val Failure(res: ValidationException) =
+      StateTransitionRules.checkIfArticleIsInUse(article, false, TestData.userWithAdminAccess)
     res.errors.head.message should equal("Learningpath(s) 1 (Title) contains a learning step that uses this article")
   }
 
@@ -321,7 +324,7 @@ class StateTransitionRulesTest extends UnitSuite with TestEnvironment {
     when(taxonomyApiClient.queryResource(articleId)).thenReturn(Success(List.empty))
     when(taxonomyApiClient.queryTopic(articleId)).thenReturn(Success(List.empty))
 
-    val res = StateTransitionRules.checkIfArticleIsInUse(article, false)
+    val res = StateTransitionRules.checkIfArticleIsInUse(article, false, TestData.userWithAdminAccess)
     res.isSuccess should be(true)
   }
 
@@ -433,7 +436,7 @@ class StateTransitionRulesTest extends UnitSuite with TestEnvironment {
 
     val (Success(res), sideEffect) =
       doTransitionWithoutSideEffect(InProcessArticle, PUBLISHED, TestData.userWithAdminAccess, false)
-    sideEffect.map(sf => sf(res, false).get.status should equal(expectedStatus))
+    sideEffect.map(sf => sf(res, false, TestData.userWithAdminAccess).get.status should equal(expectedStatus))
 
     val captor = ArgumentCaptor.forClass(classOf[Draft])
     verify(articleApiClient, times(1))

--- a/draft-api/src/test/scala/no/ndla/draftapi/service/StateTransitionRulesTest.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/service/StateTransitionRulesTest.scala
@@ -14,6 +14,7 @@ import no.ndla.common.model.domain.draft.Draft
 import no.ndla.common.model.domain.draft.DraftStatus._
 import no.ndla.common.model.{domain => common}
 import no.ndla.draftapi.integration.{ConceptStatus, DraftConcept, SearchHit, Title}
+import no.ndla.draftapi.model.domain.StateTransition
 import no.ndla.draftapi.{TestData, TestEnvironment, UnitSuite}
 import no.ndla.mapping.License.CC_BY
 import org.mockito.ArgumentCaptor
@@ -634,6 +635,7 @@ class StateTransitionRulesTest extends UnitSuite with TestEnvironment {
     when(articleApiClient.unpublishArticle(any)).thenAnswer((i: InvocationOnMock) => Success(i.getArgument[Draft](0)))
     when(searchApiClient.draftsWhereUsed(100L)).thenReturn(Seq())
     when(searchApiClient.publishedWhereUsed(100L)).thenReturn(Seq())
+
     for (t <- transitionsToTest) {
       val fromDraft = draft.copy(status = status.copy(current = t.from), responsible = Some(beforeResponsible))
       val result = StateTransitionRules
@@ -644,6 +646,71 @@ class StateTransitionRulesTest extends UnitSuite with TestEnvironment {
         fail(s"${t.from} -> ${t.to} did not reset responsible >:( Look at the sideeffects in `StateTransitionRules`")
       }
     }
+  }
+
+  test("That responsibleId is updated at status change from published to in progress") {
+    val articleId = 100L
+    val draft = Draft(
+      id = Some(articleId),
+      revision = None,
+      status = common.Status(PUBLISHED, Set.empty),
+      title = Seq.empty,
+      content = Seq.empty,
+      copyright = Some(
+        common.draft.Copyright(
+          Some(CC_BY.toString),
+          Some(""),
+          Seq.empty,
+          Seq.empty,
+          Seq.empty,
+          None,
+          None,
+          None
+        )
+      ),
+      tags = Seq.empty,
+      requiredLibraries = Seq.empty,
+      visualElement = Seq.empty,
+      introduction = Seq.empty,
+      metaDescription = Seq.empty,
+      metaImage = Seq.empty,
+      created = clock.now(),
+      updated = clock.now(),
+      updatedBy = "updated",
+      published = clock.now(),
+      articleType = common.ArticleType.Standard,
+      notes = Seq.empty,
+      previousVersionsNotes = Seq.empty,
+      editorLabels = Seq.empty,
+      grepCodes = Seq.empty,
+      conceptIds = Seq.empty,
+      availability = common.Availability.everyone,
+      relatedContent = Seq.empty,
+      revisionMeta = Seq.empty,
+      responsible = None,
+      slug = None,
+      comments = Seq.empty
+    )
+    val status                            = common.Status(PUBLISHED, Set.empty)
+    val transitionToTest: StateTransition = PUBLISHED -> IN_PROGRESS
+    val expected                          = TestData.userWithAdminAccess.id
+    when(draftRepository.getExternalIdsFromId(any[Long])(any[DBSession])).thenReturn(List.empty)
+    when(articleApiClient.updateArticle(any, any, any, any, any)).thenAnswer((i: InvocationOnMock) => {
+      val x = i.getArgument[Draft](1)
+      Success(x)
+    })
+    when(taxonomyApiClient.queryTopic(100L)).thenReturn(Success(List()))
+    when(taxonomyApiClient.queryResource(100L)).thenReturn(Success(List()))
+    when(articleApiClient.unpublishArticle(any)).thenAnswer((i: InvocationOnMock) => Success(i.getArgument[Draft](0)))
+    when(searchApiClient.draftsWhereUsed(100L)).thenReturn(Seq())
+    when(searchApiClient.publishedWhereUsed(100L)).thenReturn(Seq())
+
+    val fromDraft = draft.copy(status = status.copy(current = transitionToTest.from))
+    val result = StateTransitionRules
+      .doTransition(fromDraft, IN_PROGRESS, TestData.userWithAdminAccess, isImported = false)
+      .unsafeRunSync()
+
+    result.get.responsible.get.responsibleId should be(expected)
   }
 
 }


### PR DESCRIPTION
fixes https://trello.com/c/qmrJUVWW/59-automatisk-sette-seg-selv-som-ansvarlig-p%C3%A5-statusendring-publisert-i-arbeid

Setter seg selv som responsible automatisk på statusskifte fra PUBLISHED -> IN_PROGRESS. Oppdatert både i draft-api og i concept-api.