### PR TITLE
search-api: Fix non-existing aggregation path running forever

### DIFF
--- a/search-api/src/test/scala/no/ndla/searchapi/service/search/SearchServiceTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/service/search/SearchServiceTest.scala
@@ -105,4 +105,9 @@ class SearchServiceTest extends UnitSuite with TestEnvironment {
     res1 should be(Seq.empty)
   }
 
+  test("that passing in a path that doesn't exist doesn't run forever") {
+    val res1 = service.buildTermsAggregation(Seq("contexts.someFieldThatDoesntExist"))
+    res1 should be(Seq.empty)
+  }
+
 }


### PR DESCRIPTION
Brukte litt tid på å finne ut hvorfor aggregeringer med paths som ikke finnes ikke returnerte og fant ut at vi ikke hadde noen "exit-path" i rekursjonen i denne contexten.

La til en og refaktorerte koden så den ble kanskje litt mer lesbar :smile: 