### PR TITLE
No timeout for tapir requests

### DIFF
--- a/network/src/main/scala/no/ndla/network/tapir/TapirServer.scala
+++ b/network/src/main/scala/no/ndla/network/tapir/TapirServer.scala
@@ -14,6 +14,7 @@ import org.http4s.jetty.server.JettyBuilder
 import org.log4s.{Logger, getLogger}
 
 import javax.servlet.DispatcherType
+import scala.concurrent.duration.Duration
 
 case class TapirServer(name: String, serverPort: Int, app: HttpApp[IO], enableMelody: Boolean)(onReady: => Unit = {}) {
   val logger: Logger      = getLogger
@@ -39,6 +40,8 @@ case class TapirServer(name: String, serverPort: Int, app: HttpApp[IO], enableMe
     .mountHttpApp(app, "/")
     .bindHttp(serverPort, "0.0.0.0")
     .setupMelody(enableMelody)
+    .withIdleTimeout(Duration.Inf)
+    .withAsyncTimeout(Duration.Inf)
 
   val server: IO[Nothing] = builder.resource
     .use(server => {


### PR DESCRIPTION
Defaulten her viste seg å være veldig lav (30s idle og 60s async).
Vet ikke om det er dumt å ikke ha timeouts, men det er det vi er vant til fra scalatra i alle fall :shrug: