### PR TITLE
Move generic error to `TapirErrorHelpers`

### DIFF
--- a/audio-api/src/main/scala/no/ndla/audioapi/controller/AudioController.scala
+++ b/audio-api/src/main/scala/no/ndla/audioapi/controller/AudioController.scala
@@ -223,10 +223,7 @@ trait AudioController {
       .serverSecurityLogicPure(requireScope(AUDIO_API_WRITE))
       .serverLogic { user => formData =>
         val fileBytes = getBytesAndDeleteFile(formData.file)
-        writeService.storeNewAudio(formData.metadata.body, fileBytes, user) match {
-          case Success(audioMeta) => IO(Right(audioMeta))
-          case Failure(e)         => returnError(e).map(_.asLeft)
-        }
+        writeService.storeNewAudio(formData.metadata.body, fileBytes, user).handleErrorsOrOk
       }
 
     val putUpdateAudio: ServerEndpoint[Any, IO] = endpoint.put
@@ -241,10 +238,7 @@ trait AudioController {
       .serverLogic { user => input =>
         val (id, formData) = input
         val fileBytes      = formData.file.map(getBytesAndDeleteFile)
-        writeService.updateAudio(id, formData.metadata.body, fileBytes, user) match {
-          case Success(audioMeta) => IO(audioMeta.asRight)
-          case Failure(e)         => returnError(e).map(_.asLeft)
-        }
+        writeService.updateAudio(id, formData.metadata.body, fileBytes, user).handleErrorsOrOk
       }
 
     val tagSearch: ServerEndpoint[Any, IO] = endpoint.get
@@ -269,10 +263,7 @@ trait AudioController {
 
         val language = lang.getOrElse(Language.AllLanguages)
 
-        readService.getAllTags(query.underlyingOrElse(""), pageSize, pageNo, language) match {
-          case Failure(ex)     => returnError(ex).map(_.asLeft)
-          case Success(result) => IO(result.asRight)
-        }
+        readService.getAllTags(query.underlyingOrElse(""), pageSize, pageNo, language).handleErrorsOrOk
       }
 
     override val endpoints: List[ServerEndpoint[Any, IO]] = List(

--- a/frontpage-api/src/main/scala/no/ndla/frontpageapi/controller/InternController.scala
+++ b/frontpage-api/src/main/scala/no/ndla/frontpageapi/controller/InternController.scala
@@ -40,7 +40,7 @@ trait InternController {
           readService.getIdFromExternalId(nid) match {
             case Success(Some(id)) => IO(id.asRight)
             case Success(None)     => IO(ErrorHelpers.notFound.asLeft)
-            case Failure(ex)       => returnError(ex).map(_.asLeft)
+            case Failure(ex)       => returnLeftError(ex)
           }
         },
       endpoint.post

--- a/frontpage-api/src/main/scala/no/ndla/frontpageapi/model/api/ErrorHelpers.scala
+++ b/frontpage-api/src/main/scala/no/ndla/frontpageapi/model/api/ErrorHelpers.scala
@@ -24,12 +24,11 @@ trait ErrorHelpers extends TapirErrorHelpers with FLogging {
 
   import ErrorHelpers._
 
-  override def returnError(throwable: Throwable): IO[ErrorBody] = throwable match {
+  override def handleErrors: PartialFunction[Throwable, IO[ErrorBody]] = {
     case ex: ValidationException          => IO(badRequest(ex.getMessage))
     case ex: SubjectPageNotFoundException => IO(notFoundWithMsg(ex.getMessage))
     case ex: NotFoundException            => IO(notFoundWithMsg(ex.getMessage))
     case ex: LanguageNotFoundException    => IO(notFoundWithMsg(ex.getMessage))
-    case ex                               => logger.error(ex)(s"Internal error: ${ex.getMessage}").as(generic)
   }
 
 }

--- a/oembed-proxy/src/main/scala/no/ndla/oembedproxy/model/NDLAErrors.scala
+++ b/oembed-proxy/src/main/scala/no/ndla/oembedproxy/model/NDLAErrors.scala
@@ -20,7 +20,7 @@ trait ErrorHelpers extends TapirErrorHelpers with FLogging {
 
   import ErrorHelpers._
 
-  override def returnError(ex: Throwable): IO[ErrorBody] = ex match {
+  override def handleErrors: PartialFunction[Throwable, IO[ErrorBody]] = {
     case pnse: ProviderNotSupportedException =>
       IO(ErrorBody(PROVIDER_NOT_SUPPORTED, pnse.getMessage, clock.now(), 501))
     case hre: HttpRequestException if hre.is404 =>
@@ -33,9 +33,6 @@ trait ErrorHelpers extends TapirErrorHelpers with FLogging {
       )
       logger.error(hre)(s"Could not fetch remote: '${hre.getMessage}'${msg.getOrElse("")}") >>
         IO(ErrorBody(REMOTE_ERROR, hre.getMessage, clock.now(), 502))
-    case t: Throwable =>
-      logger.error(t)(t.getMessage) >>
-        IO(generic)
   }
 }
 


### PR DESCRIPTION
Etter jeg og @N4G1 brukte lengere tid enn jeg drømte om for å finne ut hvorfor en serialisering feilet i en test så har jeg litt lyst at disse stacktracene skal bli med i tester.

Løser det med å bruke `ex.printStackTrace()` istedet for å passe selve exceptionen til loggeren.
Gjør det samtidig generisk ved å flytte fallback-casen til `TapirErrorHelpers` og la api'ene override `handleError` istedet.