### PR TITLE
Set request context manually in side-effect `IO`

### DIFF
--- a/concept-api/src/main/scala/no/ndla/conceptapi/service/StateTransitionRules.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/service/StateTransitionRules.scala
@@ -166,6 +166,9 @@ trait StateTransitionRules {
       val requestInfo                     = RequestInfo.fromThreadContext()
       requestInfo.setRequestInfo() >>
         IO {
+          // TODO: This can be removed once the `IO` is returned all the way to the runtime so IOLocal context works
+          requestInfo.setThreadContextRequestInfo()
+
           convertedArticle.flatMap(conceptBeforeSideEffect => {
             sideEffects.foldLeft(Try(conceptBeforeSideEffect))((accumulatedConcept, sideEffect) => {
               accumulatedConcept.flatMap(c => sideEffect(c, user))

--- a/draft-api/src/main/scala/no/ndla/draftapi/service/StateTransitionRules.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/service/StateTransitionRules.scala
@@ -278,6 +278,8 @@ trait StateTransitionRules {
       val requestInfo                     = RequestInfo.fromThreadContext()
       requestInfo.setRequestInfo() >>
         IO {
+          // TODO: This can be removed once the `IO` is returned all the way to the runtime so IOLocal context works
+          requestInfo.setThreadContextRequestInfo()
           convertedArticle.flatMap(articleBeforeSideEffect => {
             sideEffects
               .foldLeft(Try(articleBeforeSideEffect))((accumulatedArticle, sideEffect) => {


### PR DESCRIPTION
Quickfix frem til conteksten kan bli håndtert med `IOLocal`