### PR TITLE
search-api: Fix search-aggregation regression

### DIFF
--- a/search-api/src/main/scala/no/ndla/searchapi/model/api/MultiSearchTermsAggregation.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/model/api/MultiSearchTermsAggregation.scala
@@ -15,7 +15,7 @@ import scala.annotation.meta.field
 @ApiModel(description = "Value that appears in the search aggregation")
 case class TermValue(
     @(ApiModelProperty @field)(description = "Value that appeared in result") value: String,
-    @(ApiModelProperty @field)(description = "Number of times the value appeared in result") count: Long
+    @(ApiModelProperty @field)(description = "Number of times the value appeared in result") count: Int
 )
 
 @ApiModel(description = "Information about search aggregation on `field`")

--- a/search-api/src/main/scala/no/ndla/searchapi/model/domain/TermAggregation.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/model/domain/TermAggregation.scala
@@ -7,7 +7,7 @@
 
 package no.ndla.searchapi.model.domain
 
-case class Bucket(value: String, count: Long)
+case class Bucket(value: String, count: Int)
 case class TermAggregation(
     field: Seq[String],
     sumOtherDocCount: Int,

--- a/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceAtomicTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceAtomicTest.scala
@@ -12,6 +12,7 @@ import no.ndla.common.model.domain.ArticleContent
 import no.ndla.scalatestsuite.IntegrationSuite
 import no.ndla.search.model.{LanguageValue, SearchableLanguageList, SearchableLanguageValues}
 import no.ndla.searchapi.TestData.{core, generateContexts, subjectMaterial}
+import no.ndla.searchapi.model.domain.{Bucket, TermAggregation}
 import no.ndla.searchapi.model.taxonomy._
 import no.ndla.searchapi.{TestData, TestEnvironment}
 import org.scalatest.Outcome
@@ -410,5 +411,216 @@ class MultiSearchServiceAtomicTest extends IntegrationSuite(EnableElasticsearchC
       .get
 
     result.results.head.contexts.map(_.id) should be(Seq("urn:topic:3"))
+  }
+  test("That aggregating rootId works as expected") {
+    val article1 = TestData.article1.copy(id = Some(1))
+    val article2 = TestData.article1.copy(id = Some(2))
+    val article3 = TestData.article1.copy(id = Some(3))
+    val article4 = TestData.article1.copy(id = Some(4))
+    val article5 = TestData.article1.copy(id = Some(5))
+
+    val taxonomyBundle = {
+      val visibleMeta = Some(Metadata(List.empty, visible = true, Map.empty))
+      val hiddenMeta  = Some(Metadata(List.empty, visible = false, Map.empty))
+
+      val subject_1 = Node(
+        "urn:subject:1",
+        "Sub1",
+        None,
+        Some("/subject:1"),
+        visibleMeta,
+        List.empty,
+        NodeType.SUBJECT,
+        List(
+          TaxonomyContext(
+            publicId = "urn:subject:1",
+            rootId = "urn:subject:1",
+            root = SearchableLanguageValues(Seq(LanguageValue("nb", "Sub1"))),
+            path = "/subject:1",
+            breadcrumbs = SearchableLanguageList(Seq(LanguageValue("nb", Seq.empty))),
+            contextType = None,
+            relevanceId = None,
+            relevance = SearchableLanguageValues(Seq.empty),
+            resourceTypes = List.empty,
+            parentIds = List.empty,
+            isPrimary = true,
+            contextId = "",
+            isVisible = true,
+            isActive = true
+          )
+        )
+      )
+      val subject_2 = Node(
+        "urn:subject:2",
+        "Sub2",
+        None,
+        Some("/subject:2"),
+        visibleMeta,
+        List.empty,
+        NodeType.SUBJECT,
+        List(
+          TaxonomyContext(
+            publicId = "urn:subject:2",
+            rootId = "urn:subject:2",
+            root = SearchableLanguageValues(Seq(LanguageValue("nb", "Sub2"))),
+            path = "/subject:2",
+            breadcrumbs = SearchableLanguageList(Seq(LanguageValue("nb", Seq.empty))),
+            contextType = None,
+            relevanceId = None,
+            relevance = SearchableLanguageValues(Seq.empty),
+            resourceTypes = List.empty,
+            parentIds = List.empty,
+            isPrimary = true,
+            contextId = "",
+            isVisible = true,
+            isActive = true
+          )
+        )
+      )
+      val topic_1 = Node(
+        "urn:topic:1",
+        "Top1",
+        Some(s"urn:article:${article1.id.get}"),
+        Some(s"${subject_1.path.get}/topic:1"),
+        hiddenMeta,
+        List.empty,
+        NodeType.TOPIC,
+        List.empty
+      )
+      topic_1.contexts = generateContexts(
+        topic_1,
+        subject_1,
+        subject_1,
+        List.empty,
+        None,
+        Some(core),
+        isPrimary = true,
+        isVisible = true,
+        isActive = true
+      )
+      val topic_2 = Node(
+        "urn:topic:2",
+        "Top2",
+        Some(s"urn:article:${article2.id.get}"),
+        Some(s"${subject_1.path.get}/topic:2"),
+        hiddenMeta,
+        List.empty,
+        NodeType.TOPIC,
+        List.empty
+      )
+      topic_2.contexts = generateContexts(
+        topic_2,
+        subject_1,
+        subject_1,
+        List.empty,
+        None,
+        Some(core),
+        isPrimary = true,
+        isVisible = true,
+        isActive = true
+      )
+      val topic_3 = Node(
+        "urn:topic:3",
+        "Top3",
+        Some(s"urn:article:${article3.id.get}"),
+        Some(s"${subject_1.path.get}/topic:3"),
+        hiddenMeta,
+        List.empty,
+        NodeType.TOPIC,
+        List.empty
+      )
+      topic_3.contexts = generateContexts(
+        topic_3,
+        subject_1,
+        subject_1,
+        List.empty,
+        None,
+        Some(core),
+        isPrimary = true,
+        isVisible = true,
+        isActive = true
+      )
+      val topic_4 = Node(
+        "urn:topic:4",
+        "Top4",
+        Some(s"urn:article:${article4.id.get}"),
+        Some(s"${subject_2.path.get}/topic:4"),
+        hiddenMeta,
+        List.empty,
+        NodeType.TOPIC,
+        List.empty
+      )
+      topic_4.contexts = generateContexts(
+        topic_4,
+        subject_2,
+        subject_2,
+        List.empty,
+        None,
+        Some(core),
+        isPrimary = true,
+        isVisible = true,
+        isActive = true
+      )
+      val topic_5 = Node(
+        "urn:topic:5",
+        "Top5",
+        Some(s"urn:article:${article5.id.get}"),
+        Some(s"${subject_2.path.get}/topic:5"),
+        hiddenMeta,
+        List.empty,
+        NodeType.TOPIC,
+        List.empty
+      )
+      topic_5.contexts = generateContexts(
+        topic_5,
+        subject_2,
+        subject_2,
+        List.empty,
+        None,
+        Some(core),
+        isPrimary = true,
+        isVisible = true,
+        isActive = true
+      )
+
+      val nodes = List(
+        topic_1,
+        topic_2,
+        topic_3,
+        topic_4,
+        topic_5,
+        subject_1,
+        subject_2
+      )
+
+      TaxonomyBundle(nodes = nodes)
+    }
+
+    articleIndexService.indexDocument(article1, Some(taxonomyBundle), Some(TestData.grepBundle)).get
+    articleIndexService.indexDocument(article2, Some(taxonomyBundle), Some(TestData.grepBundle)).get
+    articleIndexService.indexDocument(article3, Some(taxonomyBundle), Some(TestData.grepBundle)).get
+    articleIndexService.indexDocument(article4, Some(taxonomyBundle), Some(TestData.grepBundle)).get
+    articleIndexService.indexDocument(article5, Some(taxonomyBundle), Some(TestData.grepBundle)).get
+
+    blockUntil(() => {
+      articleIndexService.countDocuments == 5
+    })
+
+    val result = multiSearchService
+      .matchingQuery(
+        TestData.searchSettings.copy(
+          aggregatePaths = List("contexts.rootId")
+        )
+      )
+      .get
+
+    val expectedAggs =
+      TermAggregation(
+        field = List("contexts", "rootId"),
+        sumOtherDocCount = 0,
+        docCountErrorUpperBound = 0,
+        buckets = List(Bucket("urn:subject:1", 3), Bucket("urn:subject:2", 2))
+      )
+    result.aggregations should be(Seq(expectedAggs))
   }
 }

--- a/search/src/main/scala/no/ndla/search/Elastic4sClient.scala
+++ b/search/src/main/scala/no/ndla/search/Elastic4sClient.scala
@@ -28,6 +28,8 @@ trait Elastic4sClient {
     private def recreateClient(): Unit = client = Elastic4sClientFactory.getNonSigningClient(searchServer)
     private val elasticTimeout         = 10.minutes
 
+    def showQuery[T](t: T)(implicit handler: Handler[T, _]): String = client.show(t)
+
     private val clientExecutionContext: ExecutionContextExecutor =
       ExecutionContext.fromExecutor(Executors.newWorkStealingPool(props.MAX_SEARCH_THREADS))
 


### PR DESCRIPTION
Fixing the linting to not do implicit widening of Int->Long made the
cast in `handleBucketResult` fail.

This patch fixes that and also introduces a test that would catch this
in case of regressions :^)