### PR TITLE
Flipped validation test 

### DIFF
--- a/validation/src/main/resources/embed-tag-rules.json
+++ b/validation/src/main/resources/embed-tag-rules.json
@@ -297,12 +297,7 @@
         "data-image-id",
         "data-title",
         "data-subtitle"
-     ],
-      "optional": [
-        ["data-columns"],
-        ["data-border"],
-        ["data-background"]
-      ]
+     ]
     },
     "campaign-block" : {
       "required": [

--- a/validation/src/main/resources/html-rules.json
+++ b/validation/src/main/resources/html-rules.json
@@ -50,6 +50,9 @@
         ],
         [
           "data-size"
+        ],
+        [
+          "data-parallax-cell"
         ]
       ]
     },

--- a/validation/src/main/scala/no/ndla/validation/TagRules.scala
+++ b/validation/src/main/scala/no/ndla/validation/TagRules.scala
@@ -115,6 +115,7 @@ object TagAttributes extends Enumeration {
   val DataUrlText: TagAttributes.Value             = Value("data-url-text")
   val DataImageBeforeId: TagAttributes.Value       = Value("data-image-before-id")
   val DataImageAfterid: TagAttributes.Value        = Value("data-image-after-id")
+  val DataParallaxCell: TagAttributes.Value        = Value("data-parallax-cell")
   val XMLNsAttribute: TagAttributes.Value          = Value("xmlns")
 
   val Href: TagAttributes.Value    = Value("href")

--- a/validation/src/test/scala/no/ndla/validation/HtmlTagRulesTest.scala
+++ b/validation/src/test/scala/no/ndla/validation/HtmlTagRulesTest.scala
@@ -14,9 +14,9 @@ class HtmlTagRulesTest extends UnitSuite {
   test("embed tag should be an allowed tag and contain data attributes") {
     HtmlTagRules.isTagValid("embed")
     val dataAttrs =
-      TagAttributes.values.map(_.toString).filter(x => x.startsWith("data-") && x != TagAttributes.DataType.toString)
+      TagAttributes.values.map(_.toString).filter(x => x.startsWith("data-"))
     val legalEmbedAttrs = HtmlTagRules.legalAttributesForTag(EmbedTagName)
-    dataAttrs.foreach(x => legalEmbedAttrs should contain(x))
+    legalEmbedAttrs.foreach(x => dataAttrs should contain(x))
   }
 
   test("That isAttributeKeyValid returns false for illegal attributes") {

--- a/validation/src/test/scala/no/ndla/validation/HtmlTagRulesTest.scala
+++ b/validation/src/test/scala/no/ndla/validation/HtmlTagRulesTest.scala
@@ -12,7 +12,7 @@ import no.ndla.mapping.UnitSuite
 
 class HtmlTagRulesTest extends UnitSuite {
   test("embed tag should be an allowed tag and contain data attributes") {
-    HtmlTagRules.isTagValid("embed")
+    HtmlTagRules.isTagValid("ndlaembed") should equal(true)
     val dataAttrs =
       TagAttributes.values.map(_.toString).filter(x => x.startsWith("data-"))
     val legalEmbedAttrs = HtmlTagRules.legalAttributesForTag(EmbedTagName)


### PR DESCRIPTION
Rewrote test to check for valid data-attributes. Added parallax-attribute

Tror testen fungerer på tilnærmet lik måte. Sjekker heller nå at alle legalEmbedattributes finnes i haugen av data attributter