### PR TITLE
filter out context starting with subject

### DIFF
--- a/project/searchapi.scala
+++ b/project/searchapi.scala
@@ -55,7 +55,7 @@ object searchapi extends Module {
   ) ++
     commonSettings ++
     assemblySettings() ++
-    dockerSettings("-Xmx2G") ++
+    dockerSettings("-Xmx3G") ++
     tsSettings
 
   override lazy val plugins: Seq[sbt.Plugins] = Seq(

--- a/search-api/src/main/scala/no/ndla/searchapi/integration/TaxonomyApiClient.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/integration/TaxonomyApiClient.scala
@@ -46,13 +46,15 @@ trait TaxonomyApiClient {
     def getTaxonomyContext(
         contentUri: String,
         filterVisibles: Boolean,
+        filterContexts: Boolean,
         shouldUsePublishedTax: Boolean
     ): Try[List[TaxonomyContext]] = {
-      get[List[TaxonomyContext]](
+      val contexts = get[List[TaxonomyContext]](
         s"$TaxonomyApiEndpoint/queries/$contentUri",
         headers = getVersionHashHeader(shouldUsePublishedTax),
         params = "filterVisibles" -> filterVisibles.toString
       )
+      if (filterContexts) contexts.map(list => list.filter(c => c.rootId.contains("subject"))) else contexts
     }
 
     private def getVersionHashHeader(shouldUsePublishedTax: Boolean): Map[String, String] = {

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
@@ -211,6 +211,7 @@ trait SearchConverterService {
       val traits               = getArticleTraits(ai.content)
       val embedAttributes      = getAttributesToIndex(ai.content, ai.visualElement)
       val embedResourcesAndIds = getEmbedResourcesAndIdsToIndex(ai.content, ai.visualElement, ai.metaImage)
+      val subjectContexts      = taxonomyContexts.map(c => c.filter(ct => ct.rootId.contains("subject")))
 
       val articleWithAgreement = converterService.withAgreementCopyright(ai)
 
@@ -258,7 +259,7 @@ trait SearchConverterService {
           metaImage = articleWithAgreement.metaImage.toList,
           defaultTitle = defaultTitle.map(t => t.title),
           supportedLanguages = supportedLanguages,
-          contexts = asSearchableTaxonomyContexts(taxonomyContexts.getOrElse(List.empty)),
+          contexts = asSearchableTaxonomyContexts(subjectContexts.getOrElse(List.empty)),
           grepContexts = getGrepContexts(ai.grepCodes, grepBundle),
           traits = traits.toList.distinct,
           embedAttributes = embedAttributes,


### PR DESCRIPTION
Fant ut at i test så dukker path som starter med /programme opp i søket. Dette er fordi kontekster behandles likt uavhengig av rota, og siden programområde-kontekster endå er skjult så må disse filtreres ut.

Sjekk Testemne her https://test.ndla.no/search?query=test