### PR TITLE
`NDLADate` typescript types & json4s serialization fix

### DIFF
--- a/common/src/main/scala/no/ndla/common/model/NDLADate.scala
+++ b/common/src/main/scala/no/ndla/common/model/NDLADate.scala
@@ -7,6 +7,7 @@
 
 package no.ndla.common.model
 
+import com.scalatsi.TSType
 import io.circe.{Decoder, Encoder}
 import io.circe.syntax._
 import org.json4s.{CustomSerializer, JString, MappingException}
@@ -56,6 +57,9 @@ case class NDLADate(underlying: ZonedDateTime) extends Ordered[NDLADate] {
 }
 
 object NDLADate {
+
+  implicit val typescriptType = TSType.sameAs[NDLADate, String]
+
   case class NDLADateError(message: String) extends RuntimeException(message)
 
   private val baseFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")

--- a/common/src/test/scala/no/ndla/common/model/TestObjectWithDate.scala
+++ b/common/src/test/scala/no/ndla/common/model/TestObjectWithDate.scala
@@ -1,0 +1,11 @@
+/*
+ * Part of NDLA common.
+ * Copyright (C) 2023 NDLA
+ *
+ * See LICENSE
+ *
+ */
+
+package no.ndla.common.model
+
+case class TestObjectWithDate(date: NDLADate, unrelatedField: String)

--- a/common/src/test/scala/no/ndla/common/model/TestObjectWithOptionalDate.scala
+++ b/common/src/test/scala/no/ndla/common/model/TestObjectWithOptionalDate.scala
@@ -1,0 +1,11 @@
+/*
+ * Part of NDLA common.
+ * Copyright (C) 2023 NDLA
+ *
+ * See LICENSE
+ *
+ */
+
+package no.ndla.common.model
+
+case class TestObjectWithOptionalDate(optDate: Option[NDLADate])

--- a/image-api/src/test/scala/no/ndla/imageapi/service/ReadServiceTest.scala
+++ b/image-api/src/test/scala/no/ndla/imageapi/service/ReadServiceTest.scala
@@ -122,7 +122,7 @@ class ReadServiceTest extends UnitSuite with TestEnvironment {
     implicit val formats: Formats = DefaultFormats ++ JavaTimeSerializers.all + NDLADate.Json4sSerializer
     val testUrl                   = s"${props.Domain}/image-api/v2/images/1"
     val testRawUrl                = s"${props.Domain}/image-api/raw/Elg.jpg"
-    val dateString = TestData.updated().asString
+    val dateString                = TestData.updated().asString
     val expectedBody =
       s"""{"id":"1","metaUrl":"$testUrl","title":{"title":"Elg i busk","language":"nb"},"created":"$dateString","createdBy":"ndla124","modelRelease":"yes","alttext":{"alttext":"Elg i busk","language":"nb"},"imageUrl":"$testRawUrl","size":2865539,"contentType":"image/jpeg","copyright":{"license":{"license":"CC-BY-NC-SA-4.0","description":"Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International","url":"https://creativecommons.org/licenses/by-nc-sa/4.0/"}, "agreementId":1, "origin":"http://www.scanpix.no","creators":[{"type":"Fotograf","name":"Test Testesen"}],"processors":[{"type":"Redaksjonelt","name":"Kåre Knegg"}],"rightsholders":[{"type":"Leverandør","name":"Leverans Leveransensen"}]},"tags":{"tags":["rovdyr","elg"],"language":"nb"},"caption":{"caption":"Elg i busk","language":"nb"},"supportedLanguages":["nb"]}"""
     val expectedObject = JsonParser.parse(expectedBody).extract[api.ImageMetaInformationV2]

--- a/project/commonlib.scala
+++ b/project/commonlib.scala
@@ -16,6 +16,7 @@ object commonlib extends Module {
       enumeratumCirce,
       sttp,
       scalikejdbc,
+      scalaTsi,
       "org.json4s"       %% "json4s-native"     % Json4SV,
       "org.json4s"       %% "json4s-ext"        % Json4SV,
       "javax.servlet"     % "javax.servlet-api" % JavaxServletV,

--- a/typescript/article-api.ts
+++ b/typescript/article-api.ts
@@ -60,7 +60,7 @@ export interface IArticleSummaryV2 {
   url: string
   license: string
   articleType: string
-  lastUpdated: INDLADate
+  lastUpdated: string
   supportedLanguages: string[]
   grepCodes: string[]
   availability: string
@@ -89,17 +89,17 @@ export interface IArticleV2 {
   metaImage?: IArticleMetaImage
   introduction?: IArticleIntroduction
   metaDescription: IArticleMetaDescription
-  created: INDLADate
-  updated: INDLADate
+  created: string
+  updated: string
   updatedBy: string
-  published: INDLADate
+  published: string
   articleType: string
   supportedLanguages: string[]
   grepCodes: string[]
   conceptIds: number[]
   availability: string
   relatedContent: (IRelatedContentLink | number)[]
-  revisionDate?: INDLADate
+  revisionDate?: string
   slug?: string
 }
 
@@ -115,18 +115,14 @@ export interface ICopyright {
   processors: IAuthor[]
   rightsholders: IAuthor[]
   agreementId?: number
-  validFrom?: INDLADate
-  validTo?: INDLADate
+  validFrom?: string
+  validTo?: string
 }
 
 export interface ILicense {
   license: string
   description?: string
   url?: string
-}
-
-export interface INDLADate {
-  underlying: string
 }
 
 export interface IRelatedContentLink {

--- a/typescript/audio-api.ts
+++ b/typescript/audio-api.ts
@@ -19,8 +19,8 @@ export interface IAudioMetaInformation {
   podcastMeta?: IPodcastMeta
   series?: ISeries
   manuscript?: IManuscript
-  created: INDLADate
-  updated: INDLADate
+  created: string
+  updated: string
 }
 
 export interface IAudioSummary {
@@ -33,7 +33,7 @@ export interface IAudioSummary {
   manuscript?: IManuscript
   podcastMeta?: IPodcastMeta
   series?: ISeriesSummary
-  lastUpdated: INDLADate
+  lastUpdated: string
 }
 
 export interface IAudioSummarySearchResult {
@@ -56,8 +56,8 @@ export interface ICopyright {
   processors: IAuthor[]
   rightsholders: IAuthor[]
   agreementId?: number
-  validFrom?: INDLADate
-  validTo?: INDLADate
+  validFrom?: string
+  validTo?: string
 }
 
 export interface ICoverPhoto {
@@ -80,10 +80,6 @@ export interface ILicense {
 export interface IManuscript {
   manuscript: string
   language: string
-}
-
-export interface INDLADate {
-  underlying: string
 }
 
 export interface INewAudioMetaInformation {

--- a/typescript/concept-api.ts
+++ b/typescript/concept-api.ts
@@ -15,8 +15,8 @@ export interface IConcept {
   metaImage?: IConceptMetaImage
   tags?: IConceptTags
   subjectIds?: string[]
-  created: INDLADate
-  updated: INDLADate
+  created: string
+  updated: string
   updatedBy?: string[]
   supportedLanguages: string[]
   articleIds: number[]
@@ -40,7 +40,7 @@ export interface IConceptMetaImage {
 
 export interface IConceptResponsible {
   responsibleId: string
-  lastUpdated: INDLADate
+  lastUpdated: string
 }
 
 export interface IConceptSearchParams {
@@ -76,8 +76,8 @@ export interface IConceptSummary {
   tags?: IConceptTags
   subjectIds?: string[]
   supportedLanguages: string[]
-  lastUpdated: INDLADate
-  created: INDLADate
+  lastUpdated: string
+  created: string
   status: IStatus
   updatedBy: string[]
   license?: string
@@ -106,8 +106,8 @@ export interface ICopyright {
   processors: IAuthor[]
   rightsholders: IAuthor[]
   agreementId?: number
-  validFrom?: INDLADate
-  validTo?: INDLADate
+  validFrom?: string
+  validTo?: string
 }
 
 export interface IDraftConceptSearchParams {
@@ -147,10 +147,6 @@ export interface ILicense {
   license: string
   description?: string
   url?: string
-}
-
-export interface INDLADate {
-  underlying: string
 }
 
 export interface INewConcept {

--- a/typescript/draft-api.ts
+++ b/typescript/draft-api.ts
@@ -7,8 +7,8 @@ export interface IAgreement {
   title: string
   content: string
   copyright: ICopyright
-  created: INDLADate
-  updated: INDLADate
+  created: string
+  updated: string
   updatedBy: string
 }
 
@@ -40,10 +40,10 @@ export interface IArticle {
   introduction?: IArticleIntroduction
   metaDescription?: IArticleMetaDescription
   metaImage?: IArticleMetaImage
-  created: INDLADate
-  updated: INDLADate
+  created: string
+  updated: string
   updatedBy: string
-  published: INDLADate
+  published: string
   articleType: string
   supportedLanguages: string[]
   notes: IEditorNote[]
@@ -95,7 +95,7 @@ export interface IArticleSummary {
   users: string[]
   grepCodes: string[]
   status: IStatus
-  updated: INDLADate
+  updated: string
 }
 
 export interface IArticleTag {
@@ -116,8 +116,8 @@ export interface IAuthor {
 export interface IComment {
   id: string
   content: string
-  created: INDLADate
-  updated: INDLADate
+  created: string
+  updated: string
   isOpen: boolean
 }
 
@@ -128,20 +128,20 @@ export interface ICopyright {
   processors: IAuthor[]
   rightsholders: IAuthor[]
   agreementId?: number
-  validFrom?: INDLADate
-  validTo?: INDLADate
+  validFrom?: string
+  validTo?: string
 }
 
 export interface IDraftResponsible {
   responsibleId: string
-  lastUpdated: INDLADate
+  lastUpdated: string
 }
 
 export interface IEditorNote {
   note: string
   user: string
   status: IStatus
-  timestamp: INDLADate
+  timestamp: string
 }
 
 export interface IGrepCodesSearchResult {
@@ -155,10 +155,6 @@ export interface ILicense {
   license: string
   description?: string
   url?: string
-}
-
-export interface INDLADate {
-  underlying: string
 }
 
 export interface INewAgreement {
@@ -181,7 +177,7 @@ export interface INewAgreementCopyright {
 export interface INewArticle {
   language: string
   title: string
-  published?: INDLADate
+  published?: string
   content?: string
   tags: string[]
   introduction?: string
@@ -227,7 +223,7 @@ export interface IRequiredLibrary {
 
 export interface IRevisionMeta {
   id?: string
-  revisionDate: INDLADate
+  revisionDate: string
   note: string
   status: string
 }
@@ -264,7 +260,7 @@ export interface IUpdatedArticle {
   language?: string
   title?: string
   status?: string
-  published?: INDLADate
+  published?: string
   content?: string
   tags?: string[]
   introduction?: string

--- a/typescript/frontpage-api.ts
+++ b/typescript/frontpage-api.ts
@@ -23,7 +23,7 @@ export interface IBannerImage {
 export interface IErrorBody {
   code: string
   description: string
-  occurredAt: INDLADate
+  occurredAt: string
   statusCode: number
 }
 
@@ -54,10 +54,6 @@ export interface IMovieTheme {
 export interface IMovieThemeName {
   name: string
   language: string
-}
-
-export interface INDLADate {
-  underlying: string
 }
 
 export interface INewOrUpdateBannerImage {

--- a/typescript/image-api.ts
+++ b/typescript/image-api.ts
@@ -12,12 +12,12 @@ export interface ICopyright {
   processors: IAuthor[]
   rightsholders: IAuthor[]
   agreementId?: number
-  validFrom?: INDLADate
-  validTo?: INDLADate
+  validFrom?: string
+  validTo?: string
 }
 
 export interface IEditorNote {
-  timestamp: INDLADate
+  timestamp: string
   updatedBy: string
   note: string
 }
@@ -64,7 +64,7 @@ export interface IImageMetaInformationV2 {
   tags: IImageTag
   caption: IImageCaption
   supportedLanguages: string[]
-  created: INDLADate
+  created: string
   createdBy: string
   modelRelease: string
   editorNotes?: IEditorNote[]
@@ -80,7 +80,7 @@ export interface IImageMetaInformationV3 {
   tags: IImageTag
   caption: IImageCaption
   supportedLanguages: string[]
-  created: INDLADate
+  created: string
   createdBy: string
   modelRelease: string
   editorNotes?: IEditorNote[]
@@ -99,7 +99,7 @@ export interface IImageMetaSummary {
   supportedLanguages: string[]
   modelRelease?: string
   editorNotes?: string[]
-  lastUpdated: INDLADate
+  lastUpdated: string
   fileSize: number
   contentType: string
   imageDimensions?: IImageDimensions
@@ -119,10 +119,6 @@ export interface ILicense {
   license: string
   description: string
   url?: string
-}
-
-export interface INDLADate {
-  underlying: string
 }
 
 export interface INewImageMetaInformationV2 {

--- a/typescript/learningpath-api.ts
+++ b/typescript/learningpath-api.ts
@@ -13,7 +13,7 @@ export interface IBreadcrumb {
 export interface IConfigMeta {
   key: string
   value: string
-  updatedAt: INDLADate
+  updatedAt: string
   updatedBy: string
 }
 
@@ -57,9 +57,9 @@ export interface IFolder {
   subfolders: IFolderData[]
   resources: IResource[]
   rank?: number
-  created: INDLADate
-  updated: INDLADate
-  shared?: INDLADate
+  created: string
+  updated: string
+  shared?: string
   description?: string
 }
 
@@ -84,7 +84,7 @@ export interface ILearningPathSummaryV2 {
   coverPhotoUrl?: string
   duration?: number
   status: string
-  lastUpdated: INDLADate
+  lastUpdated: string
   tags: ILearningPathTags
   copyright: ICopyright
   supportedLanguages: string[]
@@ -116,7 +116,7 @@ export interface ILearningPathV2 {
   duration?: number
   status: string
   verificationStatus: string
-  lastUpdated: INDLADate
+  lastUpdated: string
   tags: ILearningPathTags
   copyright: ICopyright
   canEdit: boolean
@@ -171,7 +171,7 @@ export interface ILicense {
 
 export interface IMessage {
   message: string
-  date: INDLADate
+  date: string
 }
 
 export interface IMyNDLAUser {
@@ -179,10 +179,6 @@ export interface IMyNDLAUser {
   favoriteSubjects: string[]
   role: string
   organization: string
-}
-
-export interface INDLADate {
-  underlying: string
 }
 
 export interface INewFolder {
@@ -203,7 +199,7 @@ export interface IResource {
   id: string
   resourceType: string
   path: string
-  created: INDLADate
+  created: string
   tags: string[]
   resourceId: string
   rank?: number

--- a/typescript/search-api.ts
+++ b/typescript/search-api.ts
@@ -60,14 +60,14 @@ export interface IAudioResults {
 export interface IComment {
   id: string
   content: string
-  created: INDLADate
-  updated: INDLADate
+  created: string
+  updated: string
   isOpen: boolean
 }
 
 export interface IDraftResponsible {
   responsibleId: string
-  lastUpdated: INDLADate
+  lastUpdated: string
 }
 
 export interface IGroupSearchResult {
@@ -170,7 +170,7 @@ export interface IMultiSearchSummary {
   score: number
   highlights: IHighlightedField[]
   paths: string[]
-  lastUpdated: INDLADate
+  lastUpdated: string
   license?: string
   revisions: IRevisionMeta[]
   responsible?: IDraftResponsible
@@ -185,12 +185,8 @@ export interface IMultiSearchTermsAggregation {
   values: ITermValue[]
 }
 
-export interface INDLADate {
-  underlying: string
-}
-
 export interface IRevisionMeta {
-  revisionDate: INDLADate
+  revisionDate: string
   note: string
   status: string
 }


### PR DESCRIPTION
- Overså visst at `NDLADate` ville bli en type i typescript så fikser det blir strenger som tidligere.
- Gjør også at json4s "feiler" på samme måte som før dersom dato parsingen feiler.
	- Det gjør feilmeldingene litt bedre
	- Det gjør også at en feilende `Option[NDLADate]` vil bli til `None`
		- Liker ikke helt det, men det er sånn det var før, og feilmeldingene er sikkert verdt det. Syns vi burde prøve å unngå å bruke det though. Vil mest sannsynlig brekke når vi går over til en bedre parser (circe :smile:)