### PR TITLE
article-api: Make `/ids` endpoint not being parsed as slug

### DIFF
--- a/article-api/src/main/scala/no/ndla/articleapi/controller/ArticleControllerV2.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/controller/ArticleControllerV2.scala
@@ -403,8 +403,8 @@ trait ArticleControllerV2 {
 
     override val endpoints: List[ServerEndpoint[Any, IO]] = List(
       tagSearch,
-      getSingle,
       getByIds,
+      getSingle,
       getSearch,
       postSearch,
       getRevisions,

--- a/article-api/src/test/scala/no/ndla/articleapi/controller/ArticleControllerV2Test.scala
+++ b/article-api/src/test/scala/no/ndla/articleapi/controller/ArticleControllerV2Test.scala
@@ -268,4 +268,19 @@ class ArticleControllerV2Test extends UnitSuite with TestEnvironment {
     verify(articleSearchService, times(0)).scroll(any[String], any[String])
   }
 
+  test("that /ids/ works, and isnt a slug") {
+    reset(readService)
+    when(readService.getArticlesByIds(any, any, any, any, any, any)).thenReturn(Success(Seq.empty))
+
+    val response = simpleHttpClient
+      .send(
+        quickRequest
+          .get(uri"http://localhost:$serverPort/article-api/v2/articles/ids/?ids=1,2,3")
+      )
+    verify(readService, times(1)).getArticlesByIds(eqTo(List(1L, 2L, 3L)), any, any, any, any, any)
+    verify(readService, never).getArticleBySlug(any, any, any)
+    verify(readService, never).withIdV2(any, any, any, any, any)
+    response.code.code should be(200)
+  }
+
 }


### PR DESCRIPTION
Bug fra tapir omskrivningen. Rekkefølgen gjorde at `/ids` ble parset som en slug og det gir jo ikke helt mening :smile:

Kan testes ved å sjekke at `/ids/` endepunktet fungerer som det skal :^)