### PR TITLE
frontpage-api: Fix encoding error with `api.FrontPage`

### DIFF
--- a/frontpage-api/src/main/scala/no/ndla/frontpageapi/model/api/FrontPage.scala
+++ b/frontpage-api/src/main/scala/no/ndla/frontpageapi/model/api/FrontPage.scala
@@ -10,7 +10,7 @@ package no.ndla.frontpageapi.model.api
 import cats.implicits.toFunctorOps
 import com.scalatsi.{TSIType, TSNamedType, TSType}
 import io.circe.{Decoder, Encoder}
-import io.circe.generic.auto._
+import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
 import io.circe.syntax.EncoderOps
 import sttp.tapir.Schema.annotations.description
 
@@ -29,8 +29,14 @@ case class FrontPage(
 )
 
 object Menu {
+  implicit val encodeMenu: Encoder[Menu] = deriveEncoder
+  implicit val decodeMenu: Decoder[Menu] = deriveDecoder
+
   implicit val encodeMenuData: Encoder[MenuData] = Encoder.instance { case menu: Menu => menu.asJson }
   implicit val decodeMenuData: Decoder[MenuData] = Decoder[Menu].widen
+
+  implicit val frontPageEncoder: Encoder[FrontPage] = deriveEncoder
+  implicit val frontPageDecoder: Decoder[FrontPage] = deriveDecoder
 
   implicit val menuTSI: TSIType[Menu] = {
     @unused

--- a/frontpage-api/src/test/scala/no/ndla/frontpageapi/controller/FrontPageControllerTest.scala
+++ b/frontpage-api/src/test/scala/no/ndla/frontpageapi/controller/FrontPageControllerTest.scala
@@ -43,26 +43,28 @@ class FrontPageControllerTest extends UnitSuite with TestEnvironment {
   val malformedNewFrontPage: String = """{"malformed": "x"}"""
 
   val sampleNewFrontPage: String =
-    """
-      |{
-      |	"articleId": 15,
-      |	"menu": [
-      |		{
-      |			"articleId": 1,
-      |			"menu": [
-      |				{
-      |					"Menu": {
-      |						"articleId": 2,
-      |						"menu": []
-      |					}
-      |				}
-      |			]
-      |		},
-      |		{
-      |			"articleId": 3,
-      |			"menu": []
-      |		}
-      |	]
+    """{
+      |  "articleId": 15,
+      |  "menu": [
+      |    {
+      |      "articleId": 1,
+      |      "menu": [
+      |        {
+      |          "articleId": 2,
+      |          "menu": [
+      |            {
+      |              "articleId": 4,
+      |              "menu": []
+      |            }
+      |          ]
+      |        }
+      |      ]
+      |    },
+      |    {
+      |      "articleId": 3,
+      |      "menu": []
+      |    }
+      |  ]
       |}
     """.stripMargin
 


### PR DESCRIPTION
Noe rart gjorde at denne encoderen ikke fungerte skikkelig.
Man fikk `JSON decoding to CNil should never happen at 'menu[0].menu[0]'` dersom man prøvde å poste en json struktur med nestet `menu`.

Kan testes ved å kjøre en request som ligner på denne og se at du får 200 og ikke 400

```http 
POST /frontpage-api/v1/frontpage
{
  "articleId": 38247,
  "menu": [
    {
      "articleId": 38253,
      "menu": [
        {
          "articleId": 38002,
          "menu": [
            {
              "articleId": 38253,
              "menu": []
            }
          ]
        }
      ]
    },
    {
      "articleId": 38247,
      "menu": []
    }
  ]
}
```