### PR TITLE
#3658: ThreadContext in `NdlaMiddleware`

### DIFF
--- a/network/src/main/scala/no/ndla/network/tapir/NdlaMiddleware.scala
+++ b/network/src/main/scala/no/ndla/network/tapir/NdlaMiddleware.scala
@@ -64,7 +64,7 @@ trait NdlaMiddleware {
 
     def apply(req: Request[IO], responseIO: IO[Response[IO]]): IO[Response[IO]] = {
       val reqInfo = RequestInfo.fromRequest(req)
-      val set     = RequestInfo.set(reqInfo)
+      val set     = reqInfo.setRequestInfo()
       MDC.put("correlationID", reqInfo.correlationId.get): Unit
       val beforeTime = before(req)
 


### PR DESCRIPTION
Fixes NDLANO/Issues#3658

Dette løser problemet med `null` prefix i url'ene ved å sette gammeldags tråd-context for tapir applikasjonene også i tillegg til `IOLocal` saken.
Er ikke perfekt, men løser problemet frem til vi tar i bruk `IO` skikkelig :smile: