### PR TITLE
draft-api: Make partial published fields trigger `started`

### DIFF
--- a/draft-api/src/main/scala/no/ndla/draftapi/service/ConverterService.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/service/ConverterService.scala
@@ -751,8 +751,7 @@ trait ConverterService {
             responsible = responsible,
             slug = article.slug.orElse(toMergeInto.slug),
             comments = updatedComments,
-            prioritized = article.prioritized.getOrElse(toMergeInto.prioritized),
-            started = true
+            prioritized = article.prioritized.getOrElse(toMergeInto.prioritized)
           )
 
           val articleWithNewContent = article.copy(content = newContent)

--- a/draft-api/src/test/scala/no/ndla/draftapi/service/WriteServiceTest.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/service/WriteServiceTest.scala
@@ -1560,7 +1560,7 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
     result.started should be(true)
   }
 
-  test("That partial published fields does set started") {
+  test("That partial published fields does not set started") {
     val existing = TestData.sampleDomainArticle.copy(
       started = false,
       status = TestData.statusWithPublished,

--- a/draft-api/src/test/scala/no/ndla/draftapi/service/WriteServiceTest.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/service/WriteServiceTest.scala
@@ -1559,4 +1559,33 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
     result.status.current should be(IN_PROGRESS.toString)
     result.started should be(true)
   }
+
+  test("That partial published fields does set started") {
+    val existing = TestData.sampleDomainArticle.copy(
+      started = false,
+      status = TestData.statusWithPublished,
+      responsible = Some(Responsible("responsible", NDLADate.now()))
+    )
+    val updatedArticle = TestData.blankUpdatedArticle.copy(
+      revision = 1,
+      metaDescription = Some("updated title"),
+      language = Some("nb")
+    )
+    when(draftRepository.withId(eqTo(existing.id.get))(any)).thenReturn(Some(existing))
+    val result = service
+      .updateArticle(
+        existing.id.get,
+        updatedArticle,
+        List.empty,
+        Seq.empty,
+        TestData.userWithWriteAccess,
+        None,
+        None,
+        None
+      )
+      .get
+
+    result.status.current should be(PUBLISHED.toString)
+    result.started should be(false)
+  }
 }


### PR DESCRIPTION
Fikser så delpubliserte felter ikke trigger `started` feltet.
Ref: https://trello.com/c/gp7zWSp2/327-p%C3%A5begynt-ressurs#comment-64de1526291e04033efa6eb7