### PR TITLE
learningpath-api: Return cloned folder rather than parent

### DIFF
--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/UpdateService.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/UpdateService.scala
@@ -997,7 +997,7 @@ trait UpdateService {
               isCloning = true
             )
             clonedFolder <- cloneChildrenRecursively(sourceFolder, createdFolder, feideId)
-          } yield existingFolder.copy(subfolders = existingFolder.subfolders :+ clonedFolder)
+          } yield clonedFolder
       }
     }
 

--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/e2e/CloneFolderTest.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/e2e/CloneFolderTest.scala
@@ -428,21 +428,6 @@ class CloneFolderTest
       description = Some("samling 0")
     )
 
-    val expectedFolder = api.Folder(
-      id = customId,
-      name = destinationFolder.name,
-      status = destinationFolder.status.toString,
-      parentId = None,
-      breadcrumbs = List(api.Breadcrumb(id = customId, name = destinationFolder.name)),
-      subfolders = List(parent),
-      resources = List.empty,
-      rank = Some(1),
-      created = testClock.now(),
-      updated = testClock.now(),
-      shared = None,
-      description = Some("desc hue")
-    )
-
     val response = simpleHttpClient.send(
       quickRequest
         .post(
@@ -455,7 +440,7 @@ class CloneFolderTest
 
     val deserialized = read[api.Folder](response.body)
     val result       = replaceIdRecursively(deserialized, customId)
-    result should be(expectedFolder)
+    result should be(parent)
   }
 
   test("that cloning a folder with destination fails if destination-folder-id is not found") {


### PR DESCRIPTION
@katrinewi syns det var rart at vi returnerte "destination folder" når vi kloner en mappe, så vi returnerer mappen som ble klonet istedet.