### PR TITLE
Extend stats with grouped values

### DIFF
--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/model/api/Stats.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/model/api/Stats.scala
@@ -19,5 +19,11 @@ case class Stats(
     @(ApiModelProperty @field)(description = "The total number of favourited resources ") numberOfResources: Long,
     @(ApiModelProperty @field)(description = "The total number of created tags") numberOfTags: Long,
     @(ApiModelProperty @field)(description = "The total number of favourited subjects") numberOfSubjects: Long,
-    @(ApiModelProperty @field)(description = "The total number of shared folders") numberOfSharedFolders: Long
+    @(ApiModelProperty @field)(description = "The total number of shared folders") numberOfSharedFolders: Long,
+    @(ApiModelProperty @field)(description = "Stats for type resources") favouritedResources: List[ResourceStats]
+) {}
+
+case class ResourceStats(
+    @(ApiModelProperty @field)(description = "The type of favourited resouce") `type`: String,
+    @(ApiModelProperty @field)(description = "The number of favourited resource") number: Long
 ) {}

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/repository/FolderRepository.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/repository/FolderRepository.scala
@@ -589,5 +589,10 @@ trait FolderRepository {
         .single()
     }
 
+    def numberOfResourcesGrouped()(implicit session: DBSession = ReadOnlyAutoSession): List[(Long, String)] = {
+      sql"select count(*) as antall, resource_type from ${DBResource.table} group by resource_type"
+        .map(rs => (rs.long("antall"), rs.string("resource_type")))
+        .list()
+    }
   }
 }

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/ReadService.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/ReadService.scala
@@ -448,6 +448,7 @@ trait ReadService {
 
     def getStats: Option[Stats] = {
       implicit val session: DBSession = folderRepository.getSession(true)
+      val groupedResources            = folderRepository.numberOfResourcesGrouped()
       for {
         numberOfUsers         <- userRepository.numberOfUsers()
         numberOfFolders       <- folderRepository.numberOfFolders()
@@ -461,7 +462,8 @@ trait ReadService {
           numberOfResources,
           numberOfTags,
           numberOfSubjects,
-          numberOfSharedFolders
+          numberOfSharedFolders,
+          favouritedResources = groupedResources.map(gr => ResourceStats(gr._2, gr._1))
         )
       } yield stats
     }

--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/controller/StatsControllerTest.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/controller/StatsControllerTest.scala
@@ -25,7 +25,7 @@ class StatsControllerTest extends UnitSuite with TestEnvironment with ScalatraFu
   }
 
   test("That getting stats returns in fact stats") {
-    when(readService.getStats).thenReturn(Some(Stats(1, 2, 3, 4, 5, 6)))
+    when(readService.getStats).thenReturn(Some(Stats(1, 2, 3, 4, 5, 6, List.empty)))
     get("/") {
       status should be(200)
     }

--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/ReadServiceTest.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/ReadServiceTest.scala
@@ -705,7 +705,8 @@ class ReadServiceTest extends UnitSuite with UnitTestEnvironment {
     when(folderRepository.numberOfTags()(any)).thenReturn(Some(10))
     when(userRepository.numberOfSubjects()(any)).thenReturn(Some(5))
     when(folderRepository.numberOfSharedFolders()(any)).thenReturn(Some(5))
+    when(folderRepository.numberOfResourcesGrouped()(any)).thenReturn(List.empty)
 
-    service.getStats.get should be(Stats(5, 10, 20, 10, 5, 5))
+    service.getStats.get should be(Stats(5, 10, 20, 10, 5, 5, List.empty))
   }
 }


### PR DESCRIPTION
Legger på stats separert for ressurstype. Kan sikkert gjøres bedre men det funker.

Data fra test gir meg 
```
{
  "numberOfUsers": 4992,
  "numberOfFolders": 9639,
  "numberOfResources": 8727,
  "numberOfTags": 803,
  "numberOfSubjects": 110,
  "numberOfSharedFolders": 113,
  "favouritedResources": [
    {
      "type": "multidisciplinary",
      "number": 29
    },
    {
      "type": "learningpath",
      "number": 448
    },
    {
      "type": "video",
      "number": 14
    },
    {
      "type": "audio",
      "number": 3
    },
    {
      "type": "concept",
      "number": 5
    },
    {
      "type": "image",
      "number": 37
    },
    {
      "type": "article",
      "number": 8191
    }
  ]
}
```