### PR TITLE
draft-api: Stop ignoring error in `ArticleApiClient`

### DIFF
--- a/article-api/src/main/scala/no/ndla/articleapi/controller/InternController.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/controller/InternController.scala
@@ -28,7 +28,7 @@ import no.ndla.network.tapir.{Service, TapirErrorHelpers}
 import sttp.model.StatusCode
 import sttp.tapir._
 import sttp.tapir.generic.auto._
-import sttp.tapir.model.CommaSeparated
+import sttp.tapir.model.{CommaSeparated, Delimited}
 import sttp.tapir.server.ServerEndpoint
 
 import java.util.concurrent.{Executors, TimeUnit}
@@ -174,7 +174,7 @@ trait InternController {
 
     def updateArticle: ServerEndpoint[Any, IO] = endpoint.post
       .in("article" / path[Long]("id"))
-      .in(query[CommaSeparated[String]]("external-id"))
+      .in(query[CommaSeparated[String]]("external-id").default(Delimited[",", String](List.empty)))
       .in(query[Boolean]("use-import-validation").default(false))
       .in(query[Boolean]("use-soft-validation").default(false))
       .in(jsonBody[Article])
@@ -186,7 +186,7 @@ trait InternController {
         writeService
           .updateArticle(
             article.copy(id = Some(id)),
-            externalIds.values,
+            externalIds.values.filterNot(_.isEmpty),
             useImportValidation,
             useSoftValidation
           )

--- a/article-api/src/main/scala/no/ndla/articleapi/integration/SearchApiClient.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/integration/SearchApiClient.scala
@@ -15,7 +15,7 @@ import no.ndla.common.model.NDLADate
 import no.ndla.common.model.domain.article.Article
 import no.ndla.common.model.domain.{ArticleType, Availability}
 import no.ndla.network.NdlaClient
-import org.json4s.Formats
+import org.json4s.{DefaultFormats, Formats}
 import org.json4s.ext.{EnumNameSerializer, JavaTimeSerializers}
 import org.json4s.native.Serialization.write
 import sttp.client3.quick._
@@ -36,11 +36,11 @@ trait SearchApiClient {
 
     def indexArticle(article: Article): Article = {
       implicit val formats: Formats =
-        org.json4s.DefaultFormats +
-          Json4s.serializer(ArticleType) +
-          new EnumNameSerializer(Availability) ++
+        org.json4s.DefaultFormats.withLong +
+          new EnumNameSerializer(Availability) +
+          NDLADate.Json4sSerializer ++
           JavaTimeSerializers.all +
-          NDLADate.Json4sSerializer
+          Json4s.serializer(ArticleType)
 
       implicit val executionContext: ExecutionContextExecutorService =
         ExecutionContext.fromExecutorService(Executors.newSingleThreadExecutor)
@@ -84,6 +84,7 @@ trait SearchApiClient {
     }
 
     def deleteArticle(id: Long): Long = {
+      implicit val formats = DefaultFormats
       ndlaClient.fetch(
         quickRequest
           .delete(uri"$InternalEndpoint/article/$id")

--- a/integration-tests/src/test/scala/no/ndla/integrationtests/draftapi/articleapi/ArticleApiClientTest.scala
+++ b/integration-tests/src/test/scala/no/ndla/integrationtests/draftapi/articleapi/ArticleApiClientTest.scala
@@ -190,4 +190,20 @@ class ArticleApiClientTest
       .flatMap(article => articleApiCient.validateArticle(article, importValidate = false, None))
     result.isSuccess should be(false)
   }
+
+  test("that updating an article returns 400 if missing required field") {
+    AuthUser.setHeader(s"Bearer $exampleToken")
+    val articleApiCient = new ArticleApiClient(articleApiBaseUrl)
+    val invalidArticle  = testArticle.copy(metaDescription = Seq.empty)
+    val result = articleApiCient.updateArticle(
+      id = 10,
+      draft = invalidArticle,
+      externalIds = List.empty,
+      useImportValidation = false,
+      useSoftValidation = false,
+      user = authUser
+    )
+
+    result.isSuccess should be(false)
+  }
 }

--- a/network/src/main/scala/no/ndla/network/NdlaClient.scala
+++ b/network/src/main/scala/no/ndla/network/NdlaClient.scala
@@ -26,7 +26,7 @@ trait NdlaClient {
     implicit val formats: Formats                = org.json4s.DefaultFormats
     private val ResponseErrorBodyCharacterCutoff = 1000
 
-    def fetch[A](request: NdlaRequest)(implicit mf: Manifest[A]): Try[A] = {
+    def fetch[A](request: NdlaRequest)(implicit formats: Formats, mf: Manifest[A]): Try[A] = {
       doFetch(addCorrelationId(request))
     }
 

--- a/network/src/test/scala/no/ndla/network/NdlaClientTest.scala
+++ b/network/src/test/scala/no/ndla/network/NdlaClientTest.scala
@@ -11,6 +11,7 @@ package no.ndla.network
 import no.ndla.common.CorrelationID
 import no.ndla.network.model.NdlaRequest
 import no.ndla.network.tapir.auth.TokenUser
+import org.json4s.DefaultFormats
 import org.mockito.Strictness
 
 import javax.servlet.http.HttpServletRequest
@@ -51,6 +52,7 @@ class NdlaClientTest extends UnitSuite with NdlaClient {
     when(httpResponseMock.statusText).thenReturn("status")
     when(httpResponseMock.body).thenReturn("body-with-error")
 
+    implicit val formats = DefaultFormats
     val result = ndlaClient.fetch[TestObject](httpRequestMock)
 
     result.isFailure should be(true)
@@ -68,6 +70,7 @@ class NdlaClientTest extends UnitSuite with NdlaClient {
     when(httpResponseMock.isSuccess).thenReturn(true)
     when(httpResponseMock.body).thenReturn(unparseableResponse)
 
+    implicit val formats = DefaultFormats
     val result = ndlaClient.fetch[TestObject](httpRequestMock)
     result.isFailure should be(true)
     result.failure.exception.getMessage should equal(s"Could not parse response with body: $unparseableResponse")
@@ -81,6 +84,7 @@ class NdlaClientTest extends UnitSuite with NdlaClient {
     when(httpResponseMock.isSuccess).thenReturn(true)
     when(httpResponseMock.body).thenReturn(ParseableContent)
 
+    implicit val formats = DefaultFormats
     val result = ndlaClient.fetch[TestObject](httpRequestMock)
     result.isSuccess should be(true)
     result.get.id should equal("1")
@@ -99,6 +103,7 @@ class NdlaClientTest extends UnitSuite with NdlaClient {
     when(httpRequestMock.header(eqTo("X-Correlation-ID"), eqTo("correlation-id"))).thenReturn(httpRequestMock)
     when(httpResponseMock.body).thenReturn(ParseableContent)
 
+    implicit val formats = DefaultFormats
     val result = ndlaClient.fetch[TestObject](httpRequestMock)
     result.isSuccess should be(true)
     result.get.id should equal("1")

--- a/oembed-proxy/src/test/scala/no/ndla/oembedproxy/service/OEmbedServiceTest.scala
+++ b/oembed-proxy/src/test/scala/no/ndla/oembedproxy/service/OEmbedServiceTest.scala
@@ -65,7 +65,7 @@ class OEmbedServiceTest extends UnitSuite with TestEnvironment {
   }
 
   test("That get returns a failure with HttpRequestException when receiving http error") {
-    when(ndlaClient.fetch[OEmbed](any[NdlaRequest])(any[Manifest[OEmbed]]))
+    when(ndlaClient.fetch[OEmbed](any[NdlaRequest])(any, any[Manifest[OEmbed]]))
       .thenReturn(Failure(new HttpRequestException("An error occured")))
     val oembedTry = oEmbedService.get("https://www.youtube.com/abc", None, None)
     oembedTry.isFailure should be(true)
@@ -73,7 +73,7 @@ class OEmbedServiceTest extends UnitSuite with TestEnvironment {
   }
 
   test("That get returns a Success with an oEmbed when http call is successful") {
-    when(ndlaClient.fetch[OEmbed](any[NdlaRequest])(any[Manifest[OEmbed]]))
+    when(ndlaClient.fetch[OEmbed](any[NdlaRequest])(any, any[Manifest[OEmbed]]))
       .thenReturn(Success(OEmbedResponse))
     val oembedTry = oEmbedService.get("https://ndla.no/abc", None, None)
     oembedTry.isSuccess should be(true)

--- a/oembed-proxy/src/test/scala/no/ndla/oembedproxy/service/ProviderServiceTest.scala
+++ b/oembed-proxy/src/test/scala/no/ndla/oembedproxy/service/ProviderServiceTest.scala
@@ -35,7 +35,7 @@ class ProviderServiceTest extends UnitSuite with TestEnvironment {
 
   test("That loadProvidersFromRequest fails on invalid url/bad response") {
     val invalidUrl = "invalidUrl123"
-    when(ndlaClient.fetch[OEmbed](any[NdlaRequest])(any[Manifest[OEmbed]]))
+    when(ndlaClient.fetch[OEmbed](any[NdlaRequest])(any, any[Manifest[OEmbed]]))
       .thenReturn(Failure(new HttpRequestException("An error occured")))
     intercept[DoNotUpdateMemoizeException] {
       providerService.loadProvidersFromRequest(quickRequest.get(uri"$invalidUrl"))
@@ -43,7 +43,7 @@ class ProviderServiceTest extends UnitSuite with TestEnvironment {
   }
 
   test("That loadProvidersFromRequest does not return an incomplete provider") {
-    when(ndlaClient.fetch[List[OEmbedProvider]](any[NdlaRequest])(any[Manifest[List[OEmbedProvider]]]))
+    when(ndlaClient.fetch[List[OEmbedProvider]](any[NdlaRequest])(any, any[Manifest[List[OEmbedProvider]]]))
       .thenReturn(Success(List(IncompleteProvider)))
 
     val providers = providerService.loadProvidersFromRequest(mock[NdlaRequest])
@@ -51,7 +51,7 @@ class ProviderServiceTest extends UnitSuite with TestEnvironment {
   }
 
   test("That loadProvidersFromRequest works for a single provider") {
-    when(ndlaClient.fetch[List[OEmbedProvider]](any[NdlaRequest])(any[Manifest[List[OEmbedProvider]]]))
+    when(ndlaClient.fetch[List[OEmbedProvider]](any[NdlaRequest])(any, any[Manifest[List[OEmbedProvider]]]))
       .thenReturn(Success(List(CompleteProvider)))
 
     val providers = providerService.loadProvidersFromRequest(mock[NdlaRequest])
@@ -59,7 +59,7 @@ class ProviderServiceTest extends UnitSuite with TestEnvironment {
   }
 
   test("That loadProvidersFromRequest only returns the complete provider") {
-    when(ndlaClient.fetch[List[OEmbedProvider]](any[NdlaRequest])(any[Manifest[List[OEmbedProvider]]]))
+    when(ndlaClient.fetch[List[OEmbedProvider]](any[NdlaRequest])(any, any[Manifest[List[OEmbedProvider]]]))
       .thenReturn(Success(List(IncompleteProvider, CompleteProvider)))
 
     val providers = providerService.loadProvidersFromRequest(mock[NdlaRequest])


### PR DESCRIPTION
Fixes NDLANO/Issues#3696

Var visst et par problemer her.
- ExternalIds ble sendt med som query-parameter selv om listen var tom. 
  - Det ble tolket av endepunktet som `List("")` så vi endte opp med å bruke soft-valideringen selvom vi ikke skulle det
- Vi ignorerte feilen fra article-api requesten med et uhell.

Kan testes ved å sjekke at publisering fungerer når det skal og feiler når det skal.
Testcasen fra issuet var at den skulle feile når metadescription var tom.