### PR TITLE
image-api: Add `cache-control` metadata when uploading images

### DIFF
--- a/image-api/src/main/scala/no/ndla/imageapi/ImageApiProperties.scala
+++ b/image-api/src/main/scala/no/ndla/imageapi/ImageApiProperties.scala
@@ -107,6 +107,8 @@ class ImageApiProperties extends BaseProps with StrictLogging {
   val StorageName: String    = propOrElse("IMAGE_FILE_S3_BUCKET", s"$Environment.images.ndla")
   val StorageRegion: Regions = propToAwsRegion("IMAGE_FILE_S3_BUCKET_REGION")
 
+  val S3NewFileCacheControlHeader: String = propOrElse("IMAGE_FILE_S3_BUCKET_CACHE_CONTROL", "max-age=2592000")
+
   val SearchIndex: String    = propOrElse("SEARCH_INDEX_NAME", "images")
   val SearchDocument         = "image"
   val TagSearchIndex: String = propOrElse("TAG_SEARCH_INDEX_NAME", "tags")

--- a/image-api/src/main/scala/no/ndla/imageapi/service/ImageStorageService.scala
+++ b/image-api/src/main/scala/no/ndla/imageapi/service/ImageStorageService.scala
@@ -76,7 +76,7 @@ trait ImageStorageService {
       val metadata = new ObjectMetadata()
       metadata.setContentType(contentType)
       metadata.setContentLength(size)
-      metadata.setCacheControl("max-age=2592000")
+      metadata.setCacheControl(props.S3NewFileCacheControlHeader)
 
       Try(amazonClient.putObject(new PutObjectRequest(StorageName, storageKey, stream, metadata))).map(_ => storageKey)
     }

--- a/image-api/src/main/scala/no/ndla/imageapi/service/ImageStorageService.scala
+++ b/image-api/src/main/scala/no/ndla/imageapi/service/ImageStorageService.scala
@@ -76,6 +76,7 @@ trait ImageStorageService {
       val metadata = new ObjectMetadata()
       metadata.setContentType(contentType)
       metadata.setContentLength(size)
+      metadata.setCacheControl("max-age=2592000")
 
       Try(amazonClient.putObject(new PutObjectRequest(StorageName, storageKey, stream, metadata))).map(_ => storageKey)
     }


### PR DESCRIPTION
Fikser NDLANO/Issues#3703 for nye bilder

Også må vi oppdatere metadataen på alle eksisterende bilder, feks med `s3cmd`:
`s3cmd --recursive modify --add-header="Cache-Control:max-age=2592000" s3://test.images.2.ndla/`
