### PR TITLE
#3719: Skip resizing svg-images even with weird fileextensions

### DIFF
--- a/image-api/src/main/scala/no/ndla/imageapi/controller/RawController.scala
+++ b/image-api/src/main/scala/no/ndla/imageapi/controller/RawController.scala
@@ -7,6 +7,7 @@
 
 package no.ndla.imageapi.controller
 
+import no.ndla.common.errors.ValidationException
 import no.ndla.common.model.NDLADate
 import no.ndla.imageapi.Props
 import no.ndla.imageapi.model.api.{Error, ErrorHelpers}
@@ -133,17 +134,23 @@ trait RawController {
     }: Unit
 
     private def getRawImage(imageName: String): Try[ImageStream] = {
-      val dynamicCropOrResize   = if (canDoDynamicCrop) dynamicCrop _ else resize _
+      val dynamicCropOrResize =
+        if (canDoDynamicCrop) dynamicCrop _
+        else {
+          resize _
+        }
       val nonResizableMimeTypes = List("image/gif", "image/svg", "image/svg+xml")
       imageStorage.get(imageName) match {
         case Success(img) if nonResizableMimeTypes.contains(img.contentType.toLowerCase) => Success(img)
         case Success(img) =>
           crop(img)
             .flatMap(dynamicCropOrResize)
-            .recover(ex => {
-              logger.error(s"Could not crop or resize image '$imageName', got exception: '${ex.getMessage}'", ex)
-              img
-            })
+            .recoverWith {
+              case ex: ValidationException => Failure(ex)
+              case ex =>
+                logger.error(s"Could not crop or resize image '$imageName', got exception: '${ex.getMessage}'", ex)
+                Success(img)
+            }
         case Failure(e) => Failure(e)
       }
     }


### PR DESCRIPTION
Fixes NDLANO/Issues#3719

Brukte lenger tid enn jeg tør å innrømme på å forstå at jeg hadde en feil i oppsettet mitt som gjorde at jeg testa feil ting :sweat_smile: 

Men etter jeg fiksa det så var ikke denne oppgaven så veldig vanskelig.
La inn funksjonalitet for å ikke feile dersom resizing eller cropping feiler, og heller bare logge feilen.
Blir litt mer robust, men kanskje litt vanskeligere å oppdage resizing feil uten å lese logger, hva tenker dere?