### PR TITLE
Rebuild embed validation

### DIFF
--- a/article-api/src/main/scala/no/ndla/articleapi/ArticleApiProperties.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/ArticleApiProperties.scala
@@ -8,7 +8,7 @@
 
 package no.ndla.articleapi
 
-import no.ndla.common.Environment.prop
+import no.ndla.common.Environment.{booleanPropOrFalse, prop}
 import no.ndla.common.configuration.{BaseProps, HasBaseProps}
 import no.ndla.common.secrets.PropertyKeys
 import no.ndla.network.{AuthUser, Domains}
@@ -103,6 +103,8 @@ class ArticleApiProperties extends BaseProps {
     ResourceType.H5P.toString   -> H5PAddress
   )
 
+  def AllowHtmlInTitle: Boolean = booleanPropOrFalse("ALLOW_HTML_IN_TITLE")
+
   def H5PAddress: String = propOrElse(
     "NDLA_H5P_ADDRESS",
     Map(
@@ -112,8 +114,8 @@ class ArticleApiProperties extends BaseProps {
     ).getOrElse(Environment, "https://h5p.ndla.no")
   )
 
-  def BrightcoveAccountId: String = prop("NDLA_BRIGHTCOVE_ACCOUNT_ID")
-  def BrightcovePlayerId: String  = prop("NDLA_BRIGHTCOVE_PLAYER_ID")
+  def BrightcoveAccountId: String        = prop("NDLA_BRIGHTCOVE_ACCOUNT_ID")
+  private def BrightcovePlayerId: String = prop("NDLA_BRIGHTCOVE_PLAYER_ID")
 
   def BrightcoveVideoScriptUrl =
     s"//players.brightcove.net/$BrightcoveAccountId/${BrightcovePlayerId}_default/index.min.js"

--- a/article-api/src/main/scala/no/ndla/articleapi/service/ReadService.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/service/ReadService.scala
@@ -26,7 +26,7 @@ import no.ndla.common.model.domain.article.Article
 import no.ndla.common.model.domain.{ArticleType, Availability}
 import no.ndla.network.clients.FeideApiClient
 import no.ndla.validation.HtmlTagRules.{jsoupDocumentToString, stringToJsoupDocument}
-import no.ndla.validation.{ResourceType, TagAttributes}
+import no.ndla.validation.{ResourceType, TagAttribute}
 import org.jsoup.nodes.Element
 
 import scala.jdk.CollectionConverters._
@@ -138,16 +138,16 @@ trait ReadService {
     }
 
     private def addUrlOnEmbedTag(embedTag: Element): Unit = {
-      val typeAndPathOption = embedTag.attr(TagAttributes.DataResource.toString) match {
+      val typeAndPathOption = embedTag.attr(TagAttribute.DataResource.toString) match {
         case resourceType
             if resourceType == ResourceType.File.toString
               || resourceType == ResourceType.H5P.toString
-              && embedTag.hasAttr(TagAttributes.DataPath.toString) =>
-          val path = embedTag.attr(TagAttributes.DataPath.toString)
+              && embedTag.hasAttr(TagAttribute.DataPath.toString) =>
+          val path = embedTag.attr(TagAttribute.DataPath.toString)
           Some((resourceType, path))
 
-        case resourceType if embedTag.hasAttr(TagAttributes.DataResource_Id.toString) =>
-          val id = embedTag.attr(TagAttributes.DataResource_Id.toString)
+        case resourceType if embedTag.hasAttr(TagAttribute.DataResource_Id.toString) =>
+          val id = embedTag.attr(TagAttribute.DataResource_Id.toString)
           Some((resourceType, id))
         case _ =>
           None
@@ -159,7 +159,7 @@ trait ReadService {
           val pathParts = Path.parse(path).parts
 
           embedTag.attr(
-            s"${TagAttributes.DataUrl}",
+            s"${TagAttribute.DataUrl}",
             baseUrl.addPathParts(pathParts).toString
           ): Unit
         case _ =>

--- a/article-api/src/main/scala/no/ndla/articleapi/validation/ContentValidator.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/validation/ContentValidator.scala
@@ -28,8 +28,7 @@ trait ContentValidator {
   val contentValidator: ContentValidator
 
   class ContentValidator() {
-    private val textValidator = new TextValidator
-    private val allowedTags   = if (props.AllowHtmlInTitle) Set("span") else Set.empty
+    private val allowedTags = if (props.AllowHtmlInTitle) Set("span") else Set.empty
 
     def softValidateArticle(article: Article, isImported: Boolean): Try[Article] = {
       val metaValidation =
@@ -83,7 +82,7 @@ trait ContentValidator {
     private def validateArticleContent(contents: Seq[ArticleContent]): Seq[ValidationMessage] = {
       contents.flatMap(content => {
         val field = s"content.${content.language}"
-        textValidator.validate(field, content.content, allLegalTags).toList ++
+        TextValidator.validate(field, content.content, allLegalTags).toList ++
           rootElementContainsOnlySectionBlocks(field, content.content) ++
           validateLanguage("content.language", content.language)
       }) ++ validateNonEmpty("content", contents)
@@ -108,7 +107,7 @@ trait ContentValidator {
 
     private def validateVisualElement(content: VisualElement): Seq[ValidationMessage] = {
       val field = s"visualElement.${content.language}"
-      textValidator
+      TextValidator
         .validateVisualElement(
           field,
           content.resource,
@@ -121,7 +120,7 @@ trait ContentValidator {
 
     private def validateIntroduction(content: Introduction): Seq[ValidationMessage] = {
       val field = s"introduction.${content.language}"
-      textValidator.validate(field, content.introduction, allowedTags).toList ++
+      TextValidator.validate(field, content.introduction, allowedTags).toList ++
         validateLanguage("introduction.language", content.language)
     }
 
@@ -132,7 +131,7 @@ trait ContentValidator {
       val nonEmptyValidation = if (allowEmpty) None else validateNonEmpty("metaDescription", contents)
       val validations = contents.flatMap(content => {
         val field = s"metaDescription.${content.language}"
-        textValidator.validate(field, content.content, Set.empty).toList ++
+        TextValidator.validate(field, content.content, Set.empty).toList ++
           validateLanguage("metaDescription.language", content.language)
       })
       validations ++ nonEmptyValidation
@@ -141,7 +140,7 @@ trait ContentValidator {
     private def validateTitle(titles: Seq[LanguageField[String]]): Seq[ValidationMessage] = {
       titles.flatMap(title => {
         val field = s"title.$language"
-        textValidator.validate(field, title.value, allowedTags).toList ++
+        TextValidator.validate(field, title.value, allowedTags).toList ++
           validateLanguage("title.language", title.language) ++
           validateLength("title", title.value, 256)
       }) ++ validateNonEmpty("title", titles)
@@ -157,7 +156,7 @@ trait ContentValidator {
           copyright.rightsholders.flatMap(a => validateAuthor(a, "copyright.rightsholders", props.rightsholderTypes))
       val originMessage =
         copyright.origin
-          .map(origin => textValidator.validate("copyright.origin", origin, Set.empty))
+          .map(origin => TextValidator.validate("copyright.origin", origin, Set.empty))
           .getOrElse(Seq.empty)
 
       licenseMessage ++ licenseCorrelationMessage ++ contributorsMessages ++ originMessage
@@ -177,8 +176,8 @@ trait ContentValidator {
     }
 
     private def validateAuthor(author: Author, fieldPath: String, allowedTypes: Seq[String]): Seq[ValidationMessage] = {
-      textValidator.validate(s"$fieldPath.type", author.`type`, Set.empty).toList ++
-        textValidator.validate(s"$fieldPath.name", author.name, Set.empty).toList ++
+      TextValidator.validate(s"$fieldPath.type", author.`type`, Set.empty).toList ++
+        TextValidator.validate(s"$fieldPath.name", author.name, Set.empty).toList ++
         validateAuthorType(s"$fieldPath.type", author.`type`, allowedTypes).toList
     }
 
@@ -212,7 +211,7 @@ trait ContentValidator {
         if (tags.isEmpty) Seq(ValidationMessage("tags", "The article must have at least one set of tags")) else Seq()
 
       tags.flatMap(tagList => {
-        tagList.tags.flatMap(textValidator.validate(s"tags.${tagList.language}", _, Set.empty)).toList :::
+        tagList.tags.flatMap(TextValidator.validate(s"tags.${tagList.language}", _, Set.empty)).toList :::
           validateLanguage("tags.language", tagList.language).toList
       }) ++ languageTagAmountErrors ++ noTagsError
     }
@@ -235,7 +234,7 @@ trait ContentValidator {
       (validateMetaImageId(metaImage.imageId) ++ validateMetaImageAltText(metaImage.altText)).toSeq
 
     private def validateMetaImageAltText(altText: String): Seq[ValidationMessage] =
-      textValidator.validate("metaImage.alt", altText, Set.empty)
+      TextValidator.validate("metaImage.alt", altText, Set.empty)
 
     private def validateMetaImageId(id: String): Option[ValidationMessage] = {
       def isAllDigits(x: String) = x forall Character.isDigit

--- a/article-api/src/main/scala/no/ndla/articleapi/validation/ContentValidator.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/validation/ContentValidator.scala
@@ -16,7 +16,7 @@ import no.ndla.common.model.domain.article.{Article, Copyright}
 import no.ndla.common.model.domain._
 import no.ndla.language.model.{Iso639, LanguageField}
 import no.ndla.mapping.License.getLicense
-import no.ndla.validation.HtmlTagRules.stringToJsoupDocument
+import no.ndla.validation.HtmlTagRules.{allLegalTags, stringToJsoupDocument}
 import no.ndla.validation.SlugValidator.validateSlug
 import no.ndla.validation.TextValidator
 
@@ -28,8 +28,8 @@ trait ContentValidator {
   val contentValidator: ContentValidator
 
   class ContentValidator() {
-    private val NoHtmlValidator = new TextValidator(allowHtml = false)
-    private val HtmlValidator   = new TextValidator(allowHtml = true)
+    private val textValidator = new TextValidator
+    private val allowedTags   = if (props.AllowHtmlInTitle) Set("span") else Set.empty
 
     def softValidateArticle(article: Article, isImported: Boolean): Try[Article] = {
       val metaValidation =
@@ -66,7 +66,7 @@ trait ContentValidator {
       }
     }
 
-    def validateRevisionDate(revisionDate: Option[NDLADate]): Seq[ValidationMessage] = {
+    private def validateRevisionDate(revisionDate: Option[NDLADate]): Seq[ValidationMessage] = {
       revisionDate match {
         case None => Seq(ValidationMessage("revisionDate", "Article must have at least one unfinished revision"))
         case _    => Seq.empty
@@ -83,13 +83,13 @@ trait ContentValidator {
     private def validateArticleContent(contents: Seq[ArticleContent]): Seq[ValidationMessage] = {
       contents.flatMap(content => {
         val field = s"content.${content.language}"
-        HtmlValidator.validate(field, content.content).toList ++
+        textValidator.validate(field, content.content, allLegalTags).toList ++
           rootElementContainsOnlySectionBlocks(field, content.content) ++
           validateLanguage("content.language", content.language)
       }) ++ validateNonEmpty("content", contents)
     }
 
-    def rootElementContainsOnlySectionBlocks(field: String, html: String): Option[ValidationMessage] = {
+    private def rootElementContainsOnlySectionBlocks(field: String, html: String): Option[ValidationMessage] = {
       val legalTopLevelTag = "section"
       val topLevelTags     = stringToJsoupDocument(html).children().asScala.map(_.tagName())
 
@@ -108,15 +108,20 @@ trait ContentValidator {
 
     private def validateVisualElement(content: VisualElement): Seq[ValidationMessage] = {
       val field = s"visualElement.${content.language}"
-      HtmlValidator
-        .validate(field, content.resource, requiredToOptional = Map("image" -> Seq("data-caption")))
+      textValidator
+        .validateVisualElement(
+          field,
+          content.resource,
+          allLegalTags,
+          requiredToOptional = Map("image" -> Seq("data-caption"))
+        )
         .toList ++
         validateLanguage("visualElement.language", content.language)
     }
 
     private def validateIntroduction(content: Introduction): Seq[ValidationMessage] = {
       val field = s"introduction.${content.language}"
-      NoHtmlValidator.validate(field, content.introduction).toList ++
+      textValidator.validate(field, content.introduction, allowedTags).toList ++
         validateLanguage("introduction.language", content.language)
     }
 
@@ -127,7 +132,7 @@ trait ContentValidator {
       val nonEmptyValidation = if (allowEmpty) None else validateNonEmpty("metaDescription", contents)
       val validations = contents.flatMap(content => {
         val field = s"metaDescription.${content.language}"
-        NoHtmlValidator.validate(field, content.content).toList ++
+        textValidator.validate(field, content.content, Set.empty).toList ++
           validateLanguage("metaDescription.language", content.language)
       })
       validations ++ nonEmptyValidation
@@ -136,7 +141,7 @@ trait ContentValidator {
     private def validateTitle(titles: Seq[LanguageField[String]]): Seq[ValidationMessage] = {
       titles.flatMap(title => {
         val field = s"title.$language"
-        NoHtmlValidator.validate(field, title.value).toList ++
+        textValidator.validate(field, title.value, allowedTags).toList ++
           validateLanguage("title.language", title.language) ++
           validateLength("title", title.value, 256)
       }) ++ validateNonEmpty("title", titles)
@@ -151,7 +156,9 @@ trait ContentValidator {
           copyright.processors.flatMap(a => validateAuthor(a, "copyright.processors", props.processorTypes)) ++
           copyright.rightsholders.flatMap(a => validateAuthor(a, "copyright.rightsholders", props.rightsholderTypes))
       val originMessage =
-        copyright.origin.map(origin => NoHtmlValidator.validate("copyright.origin", origin)).getOrElse(Seq.empty)
+        copyright.origin
+          .map(origin => textValidator.validate("copyright.origin", origin, Set.empty))
+          .getOrElse(Seq.empty)
 
       licenseMessage ++ licenseCorrelationMessage ++ contributorsMessages ++ originMessage
     }
@@ -170,12 +177,16 @@ trait ContentValidator {
     }
 
     private def validateAuthor(author: Author, fieldPath: String, allowedTypes: Seq[String]): Seq[ValidationMessage] = {
-      NoHtmlValidator.validate(s"$fieldPath.type", author.`type`).toList ++
-        NoHtmlValidator.validate(s"$fieldPath.name", author.name).toList ++
+      textValidator.validate(s"$fieldPath.type", author.`type`, Set.empty).toList ++
+        textValidator.validate(s"$fieldPath.name", author.name, Set.empty).toList ++
         validateAuthorType(s"$fieldPath.type", author.`type`, allowedTypes).toList
     }
 
-    def validateAuthorType(fieldPath: String, `type`: String, allowedTypes: Seq[String]): Option[ValidationMessage] = {
+    private def validateAuthorType(
+        fieldPath: String,
+        `type`: String,
+        allowedTypes: Seq[String]
+    ): Option[ValidationMessage] = {
       if (allowedTypes.contains(`type`.toLowerCase)) {
         None
       } else {
@@ -201,7 +212,7 @@ trait ContentValidator {
         if (tags.isEmpty) Seq(ValidationMessage("tags", "The article must have at least one set of tags")) else Seq()
 
       tags.flatMap(tagList => {
-        tagList.tags.flatMap(NoHtmlValidator.validate(s"tags.${tagList.language}", _)).toList :::
+        tagList.tags.flatMap(textValidator.validate(s"tags.${tagList.language}", _, Set.empty)).toList :::
           validateLanguage("tags.language", tagList.language).toList
       }) ++ languageTagAmountErrors ++ noTagsError
     }
@@ -224,11 +235,11 @@ trait ContentValidator {
       (validateMetaImageId(metaImage.imageId) ++ validateMetaImageAltText(metaImage.altText)).toSeq
 
     private def validateMetaImageAltText(altText: String): Seq[ValidationMessage] =
-      NoHtmlValidator.validate("metaImage.alt", altText)
+      textValidator.validate("metaImage.alt", altText, Set.empty)
 
     private def validateMetaImageId(id: String): Option[ValidationMessage] = {
       def isAllDigits(x: String) = x forall Character.isDigit
-      if (isAllDigits(id) && id.size > 0) {
+      if (isAllDigits(id) && id.nonEmpty) {
         None
       } else {
         Some(ValidationMessage("metaImageId", "Meta image ID must be a number"))

--- a/article-api/src/main/scala/no/ndla/articleapi/validation/ContentValidator.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/validation/ContentValidator.scala
@@ -28,7 +28,7 @@ trait ContentValidator {
   val contentValidator: ContentValidator
 
   class ContentValidator() {
-    private val allowedTags = if (props.AllowHtmlInTitle) Set("span") else Set.empty
+    private val allowedTags = if (props.AllowHtmlInTitle) Set("span") else Set.empty[String]
 
     def softValidateArticle(article: Article, isImported: Boolean): Try[Article] = {
       val metaValidation =

--- a/article-api/src/test/scala/no/ndla/articleapi/TestData.scala
+++ b/article-api/src/test/scala/no/ndla/articleapi/TestData.scala
@@ -133,7 +133,12 @@ trait TestData {
       publicDomainCopyright,
       Seq(Tag(Seq("a", "b", "c"), "en")),
       Seq(),
-      Seq(VisualElement("image", "en")),
+      Seq(
+        VisualElement(
+          "<ndlaembed data-resource=\"image\" data-resource_id=\"1\" data-size=\"large\" data-align=\"center\" data-alt=\"alt\" />",
+          "en"
+        )
+      ),
       Seq(Introduction("This is an introduction", "en")),
       Seq(Description("meta", "en")),
       Seq.empty,

--- a/article-api/src/test/scala/no/ndla/articleapi/TestEnvironment.scala
+++ b/article-api/src/test/scala/no/ndla/articleapi/TestEnvironment.scala
@@ -60,7 +60,9 @@ trait TestEnvironment
     with Props
     with TestData
     with DBMigrator {
-  val props: ArticleApiProperties = new ArticleApiProperties
+  val props: ArticleApiProperties = new ArticleApiProperties {
+    override def AllowHtmlInTitle: Boolean = true
+  }
   val TestData: TestData          = new TestData
   val migrator                    = mock[DBMigrator]
 

--- a/article-api/src/test/scala/no/ndla/articleapi/TestEnvironment.scala
+++ b/article-api/src/test/scala/no/ndla/articleapi/TestEnvironment.scala
@@ -63,8 +63,8 @@ trait TestEnvironment
   val props: ArticleApiProperties = new ArticleApiProperties {
     override def AllowHtmlInTitle: Boolean = true
   }
-  val TestData: TestData          = new TestData
-  val migrator                    = mock[DBMigrator]
+  val TestData: TestData = new TestData
+  val migrator           = mock[DBMigrator]
 
   val articleSearchService = mock[ArticleSearchService]
   val articleIndexService  = mock[ArticleIndexService]

--- a/article-api/src/test/scala/no/ndla/articleapi/service/ReadServiceTest.scala
+++ b/article-api/src/test/scala/no/ndla/articleapi/service/ReadServiceTest.scala
@@ -17,7 +17,7 @@ import no.ndla.common.configuration.Constants.EmbedTagName
 import no.ndla.common.errors.ValidationException
 import no.ndla.common.model.domain.{ArticleContent, ArticleType, Availability, VisualElement}
 import no.ndla.network.clients.FeideExtendedUserInfo
-import no.ndla.validation.{ResourceType, TagAttributes}
+import no.ndla.validation.{ResourceType, TagAttribute}
 import scalikejdbc.DBSession
 
 import scala.util.{Failure, Success, Try}
@@ -25,11 +25,11 @@ import scala.util.{Failure, Success, Try}
 class ReadServiceTest extends UnitSuite with TestEnvironment {
 
   val externalImageApiUrl: String = props.externalApiUrls("image")
-  val resourceIdAttr              = s"${TagAttributes.DataResource_Id}"
-  val resourceAttr                = s"${TagAttributes.DataResource}"
+  val resourceIdAttr              = s"${TagAttribute.DataResource_Id}"
+  val resourceAttr                = s"${TagAttribute.DataResource}"
   val imageType                   = s"${ResourceType.Image}"
   val h5pType                     = s"${ResourceType.H5P}"
-  val urlAttr                     = s"${TagAttributes.DataUrl}"
+  val urlAttr                     = s"${TagAttribute.DataUrl}"
 
   val content1 =
     s"""<$EmbedTagName $resourceIdAttr="123" $resourceAttr="$imageType" /><$EmbedTagName $resourceIdAttr=1234 $resourceAttr="$imageType" />"""
@@ -89,9 +89,9 @@ class ReadServiceTest extends UnitSuite with TestEnvironment {
   test("addUrlOnResource adds url attribute on file embeds") {
     val filePath = "files/lel/fileste.pdf"
     val content =
-      s"""<div data-type="file"><$EmbedTagName $resourceAttr="${ResourceType.File}" ${TagAttributes.DataPath}="$filePath" ${TagAttributes.Title}="This fancy pdf" /><$EmbedTagName $resourceAttr="${ResourceType.File}" ${TagAttributes.DataPath}="$filePath" ${TagAttributes.Title}="This fancy pdf" /></div>"""
+      s"""<div data-type="file"><$EmbedTagName $resourceAttr="${ResourceType.File}" ${TagAttribute.DataPath}="$filePath" ${TagAttribute.Title}="This fancy pdf" /><$EmbedTagName $resourceAttr="${ResourceType.File}" ${TagAttribute.DataPath}="$filePath" ${TagAttribute.Title}="This fancy pdf" /></div>"""
     val expectedResult =
-      s"""<div data-type="file"><$EmbedTagName $resourceAttr="${ResourceType.File}" ${TagAttributes.DataPath}="$filePath" ${TagAttributes.Title}="This fancy pdf" $urlAttr="http://api-gateway.ndla-local/$filePath" /><$EmbedTagName $resourceAttr="${ResourceType.File}" ${TagAttributes.DataPath}="$filePath" ${TagAttributes.Title}="This fancy pdf" $urlAttr="http://api-gateway.ndla-local/$filePath" /></div>"""
+      s"""<div data-type="file"><$EmbedTagName $resourceAttr="${ResourceType.File}" ${TagAttribute.DataPath}="$filePath" ${TagAttribute.Title}="This fancy pdf" $urlAttr="http://api-gateway.ndla-local/$filePath" /><$EmbedTagName $resourceAttr="${ResourceType.File}" ${TagAttribute.DataPath}="$filePath" ${TagAttribute.Title}="This fancy pdf" $urlAttr="http://api-gateway.ndla-local/$filePath" /></div>"""
     val result = readService.addUrlOnResource(content)
     result should equal(expectedResult)
   }
@@ -112,9 +112,9 @@ class ReadServiceTest extends UnitSuite with TestEnvironment {
   test("addUrlOnResource adds url attribute on h5p embeds") {
     val h5pPath = "/resource/89734643-4006-4c65-a5de-34989ba7b2c8"
     val content =
-      s"""<div><$EmbedTagName $resourceAttr="${ResourceType.H5P}" ${TagAttributes.DataPath}="$h5pPath" ${TagAttributes.Title}="This fancy h5p" /><$EmbedTagName $resourceAttr="${ResourceType.H5P}" ${TagAttributes.DataPath}="$h5pPath" ${TagAttributes.Title}="This fancy h5p" /></div>"""
+      s"""<div><$EmbedTagName $resourceAttr="${ResourceType.H5P}" ${TagAttribute.DataPath}="$h5pPath" ${TagAttribute.Title}="This fancy h5p" /><$EmbedTagName $resourceAttr="${ResourceType.H5P}" ${TagAttribute.DataPath}="$h5pPath" ${TagAttribute.Title}="This fancy h5p" /></div>"""
     val expectedResult =
-      s"""<div><$EmbedTagName $resourceAttr="${ResourceType.H5P}" ${TagAttributes.DataPath}="$h5pPath" ${TagAttributes.Title}="This fancy h5p" $urlAttr="https://h5p.ndla.no$h5pPath" /><$EmbedTagName $resourceAttr="${ResourceType.H5P}" ${TagAttributes.DataPath}="$h5pPath" ${TagAttributes.Title}="This fancy h5p" $urlAttr="https://h5p.ndla.no$h5pPath" /></div>"""
+      s"""<div><$EmbedTagName $resourceAttr="${ResourceType.H5P}" ${TagAttribute.DataPath}="$h5pPath" ${TagAttribute.Title}="This fancy h5p" $urlAttr="https://h5p.ndla.no$h5pPath" /><$EmbedTagName $resourceAttr="${ResourceType.H5P}" ${TagAttribute.DataPath}="$h5pPath" ${TagAttribute.Title}="This fancy h5p" $urlAttr="https://h5p.ndla.no$h5pPath" /></div>"""
     val result = readService.addUrlOnResource(content)
     result should equal(expectedResult)
   }

--- a/article-api/src/test/scala/no/ndla/articleapi/service/ReadServiceTest.scala
+++ b/article-api/src/test/scala/no/ndla/articleapi/service/ReadServiceTest.scala
@@ -97,7 +97,8 @@ class ReadServiceTest extends UnitSuite with TestEnvironment {
   }
 
   test("addIdAndUrlOnResource adds urls on all content translations in an article") {
-    val article = TestData.sampleArticleWithByNcSa.copy(content = Seq(articleContent1, articleContent2))
+    val article =
+      TestData.sampleArticleWithByNcSa.copy(content = Seq(articleContent1, articleContent2), visualElement = Seq.empty)
     val article1ExpectedResult = articleContent1.copy(content =
       s"""<$EmbedTagName $resourceIdAttr="123" $resourceAttr="$imageType" $urlAttr="$externalImageApiUrl/123" /><$EmbedTagName $resourceIdAttr="1234" $resourceAttr="$imageType" $urlAttr="$externalImageApiUrl/1234" />"""
     )

--- a/article-api/src/test/scala/no/ndla/articleapi/validation/ContentValidatorTest.scala
+++ b/article-api/src/test/scala/no/ndla/articleapi/validation/ContentValidatorTest.scala
@@ -28,6 +28,7 @@ import scala.util.Failure
 class ContentValidatorTest extends UnitSuite with TestEnvironment {
   override val contentValidator = new ContentValidator()
   val validDocument             = """<section><h1>heisann</h1><h2>heia</h2></section>"""
+  val validIntroduction         = """heisann <span lang="en">heia</span>"""
   val invalidDocument           = """<section><invalid></invalid></section>"""
 
   test("validateArticle does not throw an exception on a valid document") {
@@ -52,12 +53,20 @@ class ContentValidatorTest extends UnitSuite with TestEnvironment {
     contentValidator.validateArticle(article, false).isSuccess should be(true)
   }
 
-  test("validateArticle should throw an error if introduction contains HTML tags") {
+  test("validateArticle should throw an error if introduction contains illegal HTML tags") {
     val article = TestData.sampleArticleWithByNcSa.copy(
       content = Seq(ArticleContent(validDocument, "nb")),
       introduction = Seq(Introduction(validDocument, "nb"))
     )
     contentValidator.validateArticle(article, false).isFailure should be(true)
+  }
+
+  test("validateArticle should not throw an error if introduction contains legal HTML tags") {
+    val article = TestData.sampleArticleWithByNcSa.copy(
+      content = Seq(ArticleContent(validDocument, "nb")),
+      introduction = Seq(Introduction(validIntroduction, "nb"))
+    )
+    contentValidator.validateArticle(article, false).isFailure should be(false)
   }
 
   test("validateArticle should not throw an error if introduction contains plain text") {

--- a/article-api/src/test/scala/no/ndla/articleapi/validation/ContentValidatorTest.scala
+++ b/article-api/src/test/scala/no/ndla/articleapi/validation/ContentValidatorTest.scala
@@ -26,7 +26,7 @@ import no.ndla.mapping.License.{CC_BY_SA, NA}
 import scala.util.Failure
 
 class ContentValidatorTest extends UnitSuite with TestEnvironment {
-  override val contentValidator = new ContentValidator()
+  override val contentValidator = new ContentValidator
   val validDocument             = """<section><h1>heisann</h1><h2>heia</h2></section>"""
   val validIntroduction         = """heisann <span lang="en">heia</span>"""
   val invalidDocument           = """<section><invalid></invalid></section>"""

--- a/concept-api/src/main/scala/no/ndla/conceptapi/service/ConverterService.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/service/ConverterService.scala
@@ -24,7 +24,7 @@ import no.ndla.language.Language.{AllLanguages, UnknownLanguage, findByLanguageO
 import no.ndla.mapping.License.getLicense
 import no.ndla.network.tapir.auth.TokenUser
 import no.ndla.validation.HtmlTagRules.{jsoupDocumentToString, stringToJsoupDocument}
-import no.ndla.validation.{EmbedTagRules, HtmlTagRules, ResourceType, TagAttributes}
+import no.ndla.validation.{EmbedTagRules, HtmlTagRules, ResourceType, TagAttribute}
 import org.jsoup.nodes.Element
 
 import scala.jdk.CollectionConverters._
@@ -214,14 +214,14 @@ trait ConverterService {
       )
     }
 
-    private def removeUnknownEmbedTagAttributes(html: String): String = {
+    private def removeUnknownEmbedTagAttribute(html: String): String = {
       val document = HtmlTagRules.stringToJsoupDocument(html)
       document
         .select(EmbedTagName)
         .asScala
         .foreach(el => {
           ResourceType
-            .valueOf(el.attr(TagAttributes.DataResource.toString))
+            .valueOf(el.attr(TagAttribute.DataResource.toString))
             .map(EmbedTagRules.attributesForResourceType)
             .map(knownAttributes => HtmlTagRules.removeIllegalAttributes(el, knownAttributes.all.map(_.toString)))
         })
@@ -231,7 +231,7 @@ trait ConverterService {
 
     private def toDomainVisualElement(visualElement: String, language: String): domain.VisualElement = {
       domain.VisualElement(
-        visualElement = removeUnknownEmbedTagAttributes(visualElement),
+        visualElement = removeUnknownEmbedTagAttribute(visualElement),
         language = language
       )
     }
@@ -401,15 +401,15 @@ trait ConverterService {
     }
 
     private def addUrlOnEmbedTag(embedTag: Element): Unit = {
-      val typeAndPathOption = embedTag.attr(TagAttributes.DataResource.toString) match {
+      val typeAndPathOption = embedTag.attr(TagAttribute.DataResource.toString) match {
         case resourceType
             if resourceType == ResourceType.H5P.toString
-              && embedTag.hasAttr(TagAttributes.DataPath.toString) =>
-          val path = embedTag.attr(TagAttributes.DataPath.toString)
+              && embedTag.hasAttr(TagAttribute.DataPath.toString) =>
+          val path = embedTag.attr(TagAttribute.DataPath.toString)
           Some((resourceType, path))
 
-        case resourceType if embedTag.hasAttr(TagAttributes.DataResource_Id.toString) =>
-          val id = embedTag.attr(TagAttributes.DataResource_Id.toString)
+        case resourceType if embedTag.hasAttr(TagAttribute.DataResource_Id.toString) =>
+          val id = embedTag.attr(TagAttribute.DataResource_Id.toString)
           Some((resourceType, id))
         case _ =>
           None
@@ -422,7 +422,7 @@ trait ConverterService {
           val pathParts = Path.parse(path).parts
 
           embedTag.attr(
-            s"${TagAttributes.DataUrl}",
+            s"${TagAttribute.DataUrl}",
             baseUrl.addPathParts(pathParts).toString
           ): Unit
         case _ =>

--- a/concept-api/src/main/scala/no/ndla/conceptapi/service/ConverterService.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/service/ConverterService.scala
@@ -221,7 +221,7 @@ trait ConverterService {
         .asScala
         .foreach(el => {
           ResourceType
-            .valueOf(el.attr(TagAttribute.DataResource.toString))
+            .withNameOption(el.attr(TagAttribute.DataResource.toString))
             .map(EmbedTagRules.attributesForResourceType)
             .map(knownAttributes => HtmlTagRules.removeIllegalAttributes(el, knownAttributes.all.map(_.toString)))
         })

--- a/concept-api/src/main/scala/no/ndla/conceptapi/validation/ContentValidator.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/validation/ContentValidator.scala
@@ -26,7 +26,6 @@ trait ContentValidator {
   val contentValidator: ContentValidator
 
   class ContentValidator {
-    private val textValidator = new TextValidator
 
     def validateConcept(concept: Concept): Try[Concept] = {
       val validationErrors =
@@ -60,7 +59,7 @@ trait ContentValidator {
     }
 
     private def validateVisualElement(content: VisualElement): Seq[ValidationMessage] = {
-      textValidator
+      TextValidator
         .validateVisualElement(
           "visualElement",
           content.visualElement,
@@ -72,7 +71,7 @@ trait ContentValidator {
     }
 
     private def validateConceptContent(content: ConceptContent): Seq[ValidationMessage] = {
-      textValidator.validate("content", content.content, Set.empty).toList ++
+      TextValidator.validate("content", content.content, Set.empty).toList ++
         validateLanguage("language", content.language)
     }
 
@@ -82,7 +81,7 @@ trait ContentValidator {
     }
 
     private def validateTitle(title: String, language: String): Seq[ValidationMessage] = {
-      textValidator.validate(s"title.$language", title, Set.empty).toList ++
+      TextValidator.validate(s"title.$language", title, Set.empty).toList ++
         validateLanguage("language", language) ++
         validateLength(s"title.$language", title, 256) ++
         validateMinimumLength(s"title.$language", title, 1)
@@ -96,7 +95,7 @@ trait ContentValidator {
         .flatMap(validateAuthor) ++ copyright.rightsholders.flatMap(validateAuthor)
       val originMessage =
         copyright.origin
-          .map(origin => textValidator.validate("copyright.origin", origin, Set.empty))
+          .map(origin => TextValidator.validate("copyright.origin", origin, Set.empty))
           .toSeq
           .flatten
 
@@ -111,7 +110,10 @@ trait ContentValidator {
       }
     }
 
-    private def validateAuthorLicenseCorrelation(license: Option[String], authors: Seq[Author]) = {
+    private def validateAuthorLicenseCorrelation(
+        license: Option[String],
+        authors: Seq[Author]
+    ): Seq[ValidationMessage] = {
       val errorMessage = (lic: String) =>
         ValidationMessage("license.license", s"At least one copyright holder is required when license is $lic")
       license match {
@@ -121,8 +123,8 @@ trait ContentValidator {
     }
 
     private def validateAuthor(author: Author): Seq[ValidationMessage] = {
-      textValidator.validate("author.type", author.`type`, Set.empty).toList ++
-        textValidator.validate("author.name", author.name, Set.empty).toList
+      TextValidator.validate("author.type", author.`type`, Set.empty).toList ++
+        TextValidator.validate("author.name", author.name, Set.empty).toList
     }
 
     private def validateLanguage(fieldPath: String, languageCode: String): Option[ValidationMessage] = {
@@ -165,7 +167,7 @@ trait ContentValidator {
       else
         None
 
-    private def languageCodeSupported639(languageCode: String) = Iso639.get(languageCode).isSuccess
+    private def languageCodeSupported639(languageCode: String): Boolean = Iso639.get(languageCode).isSuccess
 
   }
 }

--- a/draft-api/src/main/scala/no/ndla/draftapi/DraftApiProperties.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/DraftApiProperties.scala
@@ -9,7 +9,7 @@ package no.ndla.draftapi
 
 import com.amazonaws.regions.Regions
 import com.typesafe.scalalogging.StrictLogging
-import no.ndla.common.Environment.{prop, propToAwsRegion}
+import no.ndla.common.Environment.{booleanPropOrFalse, prop, propToAwsRegion}
 import no.ndla.common.configuration.{BaseProps, HasBaseProps}
 import no.ndla.common.secrets.PropertyKeys
 import no.ndla.network.{AuthUser, Domains}
@@ -58,30 +58,31 @@ class DraftApiProperties extends BaseProps with StrictLogging {
     "image-api"   -> s"http://$ImageApiHost/intern"
   )
 
-  def BrightcoveAccountId: String = prop("NDLA_BRIGHTCOVE_ACCOUNT_ID")
-  def BrightcovePlayerId: String  = prop("NDLA_BRIGHTCOVE_PLAYER_ID")
+  def AllowHtmlInTitle: Boolean = booleanPropOrFalse("ALLOW_HTML_IN_TITLE")
+
+  def BrightcoveAccountId: String        = prop("NDLA_BRIGHTCOVE_ACCOUNT_ID")
+  private def BrightcovePlayerId: String = prop("NDLA_BRIGHTCOVE_PLAYER_ID")
 
   def BrightcoveVideoScriptUrl =
     s"//players.brightcove.net/$BrightcoveAccountId/${BrightcovePlayerId}_default/index.min.js"
   def H5PResizerScriptUrl = "//h5p.org/sites/all/modules/h5p/library/js/h5p-resizer.js"
   def NRKVideoScriptUrl = Seq("//www.nrk.no/serum/latest/js/video_embed.js", "//nrk.no/serum/latest/js/video_embed.js")
 
-  def SearchServer: String                 = propOrElse("SEARCH_SERVER", "http://search-draft-api.ndla-local")
-  def RunWithSignedSearchRequests: Boolean = propOrElse("RUN_WITH_SIGNED_SEARCH_REQUESTS", "true").toBoolean
-  def DraftSearchIndex: String             = propOrElse("SEARCH_INDEX_NAME", "draft-articles")
-  def DraftTagSearchIndex: String          = propOrElse("TAG_SEARCH_INDEX_NAME", "draft-tags")
-  def DraftGrepCodesSearchIndex: String    = propOrElse("GREP_CODES_SEARCH_INDEX_NAME", "draft-grepcodes")
-  def AgreementSearchIndex: String         = propOrElse("AGREEMENT_SEARCH_INDEX_NAME", "draft-agreements")
-  def DraftSearchDocument                  = "article-drafts"
-  def DraftTagSearchDocument               = "article-drafts-tag"
-  def DraftGrepCodesSearchDocument         = "article-drafts-grepcodes"
-  def AgreementSearchDocument              = "agreement-drafts"
-  def DefaultPageSize                      = 10
-  def MaxPageSize                          = 10000
-  def IndexBulkSize                        = 200
-  def ElasticSearchIndexMaxResultWindow    = 10000
-  def ElasticSearchScrollKeepAlive         = "1m"
-  def InitialScrollContextKeywords         = List("0", "initial", "start", "first")
+  def SearchServer: String              = propOrElse("SEARCH_SERVER", "http://search-draft-api.ndla-local")
+  def DraftSearchIndex: String          = propOrElse("SEARCH_INDEX_NAME", "draft-articles")
+  def DraftTagSearchIndex: String       = propOrElse("TAG_SEARCH_INDEX_NAME", "draft-tags")
+  def DraftGrepCodesSearchIndex: String = propOrElse("GREP_CODES_SEARCH_INDEX_NAME", "draft-grepcodes")
+  def AgreementSearchIndex: String      = propOrElse("AGREEMENT_SEARCH_INDEX_NAME", "draft-agreements")
+  def DraftSearchDocument               = "article-drafts"
+  def DraftTagSearchDocument            = "article-drafts-tag"
+  def DraftGrepCodesSearchDocument      = "article-drafts-grepcodes"
+  def AgreementSearchDocument           = "agreement-drafts"
+  def DefaultPageSize                   = 10
+  def MaxPageSize                       = 10000
+  def IndexBulkSize                     = 200
+  def ElasticSearchIndexMaxResultWindow = 10000
+  def ElasticSearchScrollKeepAlive      = "1m"
+  def InitialScrollContextKeywords      = List("0", "initial", "start", "first")
 
   def TaxonomyVersionHeader = "VersionHash"
 

--- a/draft-api/src/main/scala/no/ndla/draftapi/service/ConverterService.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/service/ConverterService.scala
@@ -320,7 +320,7 @@ trait ConverterService {
         .asScala
         .foreach(el => {
           ResourceType
-            .valueOf(el.attr(TagAttribute.DataResource.toString))
+            .withNameOption(el.attr(TagAttribute.DataResource.toString))
             .map(EmbedTagRules.attributesForResourceType)
             .map(knownAttributes => HtmlTagRules.removeIllegalAttributes(el, knownAttributes.all.map(_.toString)))
         })

--- a/draft-api/src/main/scala/no/ndla/draftapi/service/ReadService.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/service/ReadService.scala
@@ -129,16 +129,16 @@ trait ReadService {
     }
 
     private def addUrlOnEmbedTag(embedTag: Element): Unit = {
-      val typeAndPathOption = embedTag.attr(TagAttributes.DataResource.toString) match {
+      val typeAndPathOption = embedTag.attr(TagAttribute.DataResource.toString) match {
         case resourceType
             if resourceType == ResourceType.File.toString
               || resourceType == ResourceType.H5P.toString
-              && embedTag.hasAttr(TagAttributes.DataPath.toString) =>
-          val path = embedTag.attr(TagAttributes.DataPath.toString)
+              && embedTag.hasAttr(TagAttribute.DataPath.toString) =>
+          val path = embedTag.attr(TagAttribute.DataPath.toString)
           Some((resourceType, path))
 
-        case resourceType if embedTag.hasAttr(TagAttributes.DataResource_Id.toString) =>
-          val id = embedTag.attr(TagAttributes.DataResource_Id.toString)
+        case resourceType if embedTag.hasAttr(TagAttribute.DataResource_Id.toString) =>
+          val id = embedTag.attr(TagAttribute.DataResource_Id.toString)
           Some((resourceType, id))
         case _ =>
           None
@@ -150,7 +150,7 @@ trait ReadService {
           val pathParts = Path.parse(path).parts
 
           embedTag.attr(
-            s"${TagAttributes.DataUrl}",
+            s"${TagAttribute.DataUrl}",
             baseUrl.addPathParts(pathParts).toString
           ): Unit
         case _ =>

--- a/draft-api/src/main/scala/no/ndla/draftapi/service/WriteService.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/service/WriteService.scala
@@ -134,7 +134,7 @@ trait WriteService {
     def contentWithClonedFiles(contents: List[common.ArticleContent]): Try[List[common.ArticleContent]] = {
       contents.toList.traverse(content => {
         val doc    = HtmlTagRules.stringToJsoupDocument(content.content)
-        val embeds = doc.select(s"$EmbedTagName[${TagAttributes.DataResource}='${ResourceType.File}']").asScala
+        val embeds = doc.select(s"$EmbedTagName[${TagAttribute.DataResource}='${ResourceType.File}']").asScala
 
         embeds.toList.traverse(cloneEmbedAndUpdateElement) match {
           case Failure(ex) => Failure(ex)
@@ -145,14 +145,14 @@ trait WriteService {
 
     /** MUTATES fileEmbed by cloning file and updating data-path */
     def cloneEmbedAndUpdateElement(fileEmbed: Element): Try[Element] = {
-      Option(fileEmbed.attr(TagAttributes.DataPath.toString)) match {
+      Option(fileEmbed.attr(TagAttribute.DataPath.toString)) match {
         case Some(existingPath) =>
           cloneFileAndGetNewPath(existingPath).map(newPath => {
             // Jsoup is mutable and we use it here to update the embeds data-path with the cloned file
-            fileEmbed.attr(TagAttributes.DataPath.toString, newPath)
+            fileEmbed.attr(TagAttribute.DataPath.toString, newPath)
           })
         case None =>
-          Failure(api.CloneFileException(s"Could not get ${TagAttributes.DataPath} of file embed '$fileEmbed'."))
+          Failure(api.CloneFileException(s"Could not get ${TagAttribute.DataPath} of file embed '$fileEmbed'."))
       }
     }
 

--- a/draft-api/src/main/scala/no/ndla/draftapi/validation/ContentValidator.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/validation/ContentValidator.scala
@@ -194,7 +194,7 @@ trait ContentValidator {
     }
 
     private def validateTitle(title: String, language: String): Seq[ValidationMessage] = {
-      textValidator.validate(s"title.$language", title, Set.empty).toList ++
+      textValidator.validate(s"title.$language", title, allowedTags).toList ++
         validateLanguage("language", language) ++
         validateLength(s"title.$language", title, 256) ++
         validateMinimumLength(s"title.$language", title, 1)

--- a/draft-api/src/main/scala/no/ndla/draftapi/validation/ContentValidator.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/validation/ContentValidator.scala
@@ -34,7 +34,7 @@ trait ContentValidator {
 
   class ContentValidator() {
     import props.{BrightcoveVideoScriptUrl, H5PResizerScriptUrl, NRKVideoScriptUrl}
-    private val allowedTags = if (props.AllowHtmlInTitle) Set("span") else Set.empty
+    private val allowedTags = if (props.AllowHtmlInTitle) Set("span") else Set.empty[String]
 
     def validateDate(fieldName: String, dateString: String): Seq[ValidationMessage] = {
       NDLADate.fromString(dateString) match {

--- a/draft-api/src/main/scala/no/ndla/draftapi/validation/ContentValidator.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/validation/ContentValidator.scala
@@ -34,8 +34,7 @@ trait ContentValidator {
 
   class ContentValidator() {
     import props.{BrightcoveVideoScriptUrl, H5PResizerScriptUrl, NRKVideoScriptUrl}
-    private val textValidator = new TextValidator
-    private val allowedTags   = if (props.AllowHtmlInTitle) Set("span") else Set.empty
+    private val allowedTags = if (props.AllowHtmlInTitle) Set("span") else Set.empty
 
     def validateDate(fieldName: String, dateString: String): Seq[ValidationMessage] = {
       NDLADate.fromString(dateString) match {
@@ -123,7 +122,7 @@ trait ContentValidator {
     }
 
     private def validateArticleContent(content: ArticleContent): Seq[ValidationMessage] = {
-      textValidator.validate("content", content.content, allLegalTags).toList ++
+      TextValidator.validate("content", content.content, allLegalTags).toList ++
         rootElementContainsOnlySectionBlocks("content.content", content.content) ++
         validateLanguage("content.language", content.language)
     }
@@ -146,7 +145,7 @@ trait ContentValidator {
     }
 
     private def validateVisualElement(content: VisualElement): List[ValidationMessage] = {
-      textValidator
+      TextValidator
         .validateVisualElement(
           "visualElement",
           content.resource,
@@ -172,12 +171,12 @@ trait ContentValidator {
     }
 
     private def validateIntroduction(content: Introduction): List[ValidationMessage] = {
-      textValidator.validate("introduction", content.introduction, allowedTags).toList ++
+      TextValidator.validate("introduction", content.introduction, allowedTags).toList ++
         validateLanguage("language", content.language)
     }
 
     private def validateMetaDescription(content: Description): List[ValidationMessage] = {
-      textValidator.validate("metaDescription", content.content, Set.empty).toList ++
+      TextValidator.validate("metaDescription", content.content, Set.empty).toList ++
         validateLanguage("language", content.language)
     }
 
@@ -194,7 +193,7 @@ trait ContentValidator {
     }
 
     private def validateTitle(title: String, language: String): Seq[ValidationMessage] = {
-      textValidator.validate(s"title.$language", title, allowedTags).toList ++
+      TextValidator.validate(s"title.$language", title, allowedTags).toList ++
         validateLanguage("language", language) ++
         validateLength(s"title.$language", title, 256) ++
         validateMinimumLength(s"title.$language", title, 1)
@@ -206,7 +205,7 @@ trait ContentValidator {
         validateAuthor
       ) ++ copyright.rightsholders.flatMap(validateAuthor)
       val originMessage =
-        copyright.origin.map(origin => textValidator.validate("copyright.origin", origin, Set.empty)).toSeq.flatten
+        copyright.origin.map(origin => TextValidator.validate("copyright.origin", origin, Set.empty)).toSeq.flatten
 
       licenseMessage ++ contributorsMessages ++ originMessage
     }
@@ -219,13 +218,13 @@ trait ContentValidator {
     }
 
     private def validateAuthor(author: Author): Seq[ValidationMessage] = {
-      textValidator.validate("author.type", author.`type`, Set.empty).toList ++
-        textValidator.validate("author.name", author.name, Set.empty).toList
+      TextValidator.validate("author.type", author.`type`, Set.empty).toList ++
+        TextValidator.validate("author.name", author.name, Set.empty).toList
     }
 
-    private def validateTags(tags: Seq[Tag]) = {
+    private def validateTags(tags: Seq[Tag]): Seq[ValidationMessage] = {
       tags.flatMap(tagList => {
-        tagList.tags.flatMap(textValidator.validate("tags", _, Set.empty)).toList :::
+        tagList.tags.flatMap(TextValidator.validate("tags", _, Set.empty)).toList :::
           validateLanguage("language", tagList.language).toList
       })
     }
@@ -248,7 +247,7 @@ trait ContentValidator {
       (validateMetaImageId(metaImage.imageId) ++ validateMetaImageAltText(metaImage.altText)).toSeq
 
     private def validateMetaImageAltText(altText: String): Seq[ValidationMessage] =
-      textValidator.validate("metaImage.alt", altText, Set.empty)
+      TextValidator.validate("metaImage.alt", altText, Set.empty)
 
     private def validateMetaImageId(id: String): Option[ValidationMessage] = {
       def isAllDigits(x: String) = x forall Character.isDigit
@@ -259,7 +258,7 @@ trait ContentValidator {
       }
     }
 
-    private def validateLanguage(fieldPath: String, languageCode: String) = {
+    private def validateLanguage(fieldPath: String, languageCode: String): Option[ValidationMessage] = {
       if (languageCode.nonEmpty && languageCodeSupported639(languageCode)) {
         None
       } else {

--- a/draft-api/src/test/scala/no/ndla/draftapi/service/ConverterServiceTest.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/service/ConverterServiceTest.scala
@@ -9,19 +9,18 @@ package no.ndla.draftapi.service
 
 import cats.effect.unsafe.implicits.global
 import no.ndla.common
-import no.ndla.common.model.{api => commonApi}
 import no.ndla.common.configuration.Constants.EmbedTagName
 import no.ndla.common.errors.ValidationException
-import no.ndla.common.model.NDLADate
 import no.ndla.common.model.domain._
 import no.ndla.common.model.domain.draft.DraftStatus._
-import no.ndla.common.model.domain.draft.{Comment, DraftCopyright, Draft, DraftStatus}
+import no.ndla.common.model.domain.draft.{Comment, Draft, DraftCopyright, DraftStatus}
+import no.ndla.common.model.{NDLADate, api => commonApi}
 import no.ndla.draftapi.model.api
 import no.ndla.draftapi.model.api.{NewComment, UpdatedComment}
 import no.ndla.draftapi.{TestData, TestEnvironment, UnitSuite}
 import no.ndla.mapping.License.CC_BY
 import no.ndla.network.tapir.auth.TokenUser
-import no.ndla.validation.{ResourceType, TagAttributes}
+import no.ndla.validation.{ResourceType, TagAttribute}
 import org.jsoup.nodes.Element
 import org.mockito.invocation.InvocationOnMock
 
@@ -78,11 +77,11 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
 
   test("toDomainArticleShould should remove unneeded attributes on embed-tags") {
     val content =
-      s"""<h1>hello</h1><$EmbedTagName ${TagAttributes.DataResource}="${ResourceType.Image}" ${TagAttributes.DataUrl}="http://some-url" data-random="hehe" />"""
-    val expectedContent = s"""<h1>hello</h1><$EmbedTagName ${TagAttributes.DataResource}="${ResourceType.Image}" />"""
+      s"""<h1>hello</h1><$EmbedTagName ${TagAttribute.DataResource}="${ResourceType.Image}" ${TagAttribute.DataUrl}="http://some-url" data-random="hehe" />"""
+    val expectedContent = s"""<h1>hello</h1><$EmbedTagName ${TagAttribute.DataResource}="${ResourceType.Image}" />"""
     val visualElement =
-      s"""<$EmbedTagName ${TagAttributes.DataResource}="${ResourceType.Image}" ${TagAttributes.DataUrl}="http://some-url" data-random="hehe" />"""
-    val expectedVisualElement = s"""<$EmbedTagName ${TagAttributes.DataResource}="${ResourceType.Image}" />"""
+      s"""<$EmbedTagName ${TagAttribute.DataResource}="${ResourceType.Image}" ${TagAttribute.DataUrl}="http://some-url" data-random="hehe" />"""
+    val expectedVisualElement = s"""<$EmbedTagName ${TagAttribute.DataResource}="${ResourceType.Image}" />"""
     val apiArticle            = TestData.newArticle.copy(content = Some(content), visualElement = Some(visualElement))
     val expectedTime          = TestData.today
 

--- a/draft-api/src/test/scala/no/ndla/draftapi/service/ReadServiceTest.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/service/ReadServiceTest.scala
@@ -11,7 +11,7 @@ import no.ndla.common.configuration.Constants.EmbedTagName
 import no.ndla.common.errors.ValidationException
 import no.ndla.common.model.domain.{ArticleContent, VisualElement}
 import no.ndla.draftapi.{TestData, TestEnvironment, UnitSuite}
-import no.ndla.validation.{ResourceType, TagAttributes}
+import no.ndla.validation.{ResourceType, TagAttribute}
 import scalikejdbc.DBSession
 
 import scala.util.{Failure, Success}
@@ -19,25 +19,25 @@ import scala.util.{Failure, Success}
 class ReadServiceTest extends UnitSuite with TestEnvironment {
   import props.externalApiUrls
 
-  val externalImageApiUrl = externalApiUrls("image")
-  val resourceIdAttr      = s"${TagAttributes.DataResource_Id}"
-  val resourceAttr        = s"${TagAttributes.DataResource}"
-  val imageType           = s"${ResourceType.Image}"
-  val h5pType             = s"${ResourceType.H5P}"
-  val urlAttr             = s"${TagAttributes.DataUrl}"
+  val externalImageApiUrl: String = externalApiUrls("image")
+  val resourceIdAttr              = s"${TagAttribute.DataResource_Id}"
+  val resourceAttr                = s"${TagAttribute.DataResource}"
+  val imageType                   = s"${ResourceType.Image}"
+  val h5pType                     = s"${ResourceType.H5P}"
+  val urlAttr                     = s"${TagAttribute.DataUrl}"
 
   val content1 =
     s"""<$EmbedTagName $resourceIdAttr="123" $resourceAttr="$imageType" /><$EmbedTagName $resourceIdAttr=1234 $resourceAttr="$imageType" />"""
 
   val content2 =
     s"""<$EmbedTagName $resourceIdAttr="321" $resourceAttr="$imageType" /><$EmbedTagName $resourceIdAttr=4321 $resourceAttr="$imageType" />"""
-  val articleContent1 = ArticleContent(content1, "und")
+  val articleContent1: ArticleContent = ArticleContent(content1, "und")
 
-  val expectedArticleContent1 = articleContent1.copy(content =
+  val expectedArticleContent1: ArticleContent = articleContent1.copy(content =
     s"""<$EmbedTagName $resourceIdAttr="123" $resourceAttr="$imageType" $urlAttr="$externalImageApiUrl/123" /><$EmbedTagName $resourceIdAttr="1234" $resourceAttr="$imageType" $urlAttr="$externalImageApiUrl/1234" />"""
   )
 
-  val articleContent2 = ArticleContent(content2, "und")
+  val articleContent2: ArticleContent = ArticleContent(content2, "und")
 
   override val readService      = new ReadService
   override val converterService = new ConverterService
@@ -92,9 +92,9 @@ class ReadServiceTest extends UnitSuite with TestEnvironment {
   test("addUrlOnResource adds url attribute on file embeds") {
     val filePath = "files/lel/fileste.pdf"
     val content =
-      s"""<div data-type="file"><$EmbedTagName $resourceAttr="${ResourceType.File}" ${TagAttributes.DataPath}="$filePath" ${TagAttributes.Title}="This fancy pdf" /><$EmbedTagName $resourceAttr="${ResourceType.File}" ${TagAttributes.DataPath}="$filePath" ${TagAttributes.Title}="This fancy pdf" /></div>"""
+      s"""<div data-type="file"><$EmbedTagName $resourceAttr="${ResourceType.File}" ${TagAttribute.DataPath}="$filePath" ${TagAttribute.Title}="This fancy pdf" /><$EmbedTagName $resourceAttr="${ResourceType.File}" ${TagAttribute.DataPath}="$filePath" ${TagAttribute.Title}="This fancy pdf" /></div>"""
     val expectedResult =
-      s"""<div data-type="file"><$EmbedTagName $resourceAttr="${ResourceType.File}" ${TagAttributes.DataPath}="$filePath" ${TagAttributes.Title}="This fancy pdf" $urlAttr="http://api-gateway.ndla-local/$filePath" /><$EmbedTagName $resourceAttr="${ResourceType.File}" ${TagAttributes.DataPath}="$filePath" ${TagAttributes.Title}="This fancy pdf" $urlAttr="http://api-gateway.ndla-local/$filePath" /></div>"""
+      s"""<div data-type="file"><$EmbedTagName $resourceAttr="${ResourceType.File}" ${TagAttribute.DataPath}="$filePath" ${TagAttribute.Title}="This fancy pdf" $urlAttr="http://api-gateway.ndla-local/$filePath" /><$EmbedTagName $resourceAttr="${ResourceType.File}" ${TagAttribute.DataPath}="$filePath" ${TagAttribute.Title}="This fancy pdf" $urlAttr="http://api-gateway.ndla-local/$filePath" /></div>"""
     val result = readService.addUrlOnResource(content)
     result should equal(expectedResult)
   }
@@ -102,9 +102,9 @@ class ReadServiceTest extends UnitSuite with TestEnvironment {
   test("addUrlOnResource adds url attribute on h5p embeds") {
     val h5pPath = "/resource/89734643-4006-4c65-a5de-34989ba7b2c8"
     val content =
-      s"""<div><$EmbedTagName $resourceAttr="${ResourceType.H5P}" ${TagAttributes.DataPath}="$h5pPath" ${TagAttributes.Title}="This fancy h5p" /><$EmbedTagName $resourceAttr="${ResourceType.H5P}" ${TagAttributes.DataPath}="$h5pPath" ${TagAttributes.Title}="This fancy h5p" /></div>"""
+      s"""<div><$EmbedTagName $resourceAttr="${ResourceType.H5P}" ${TagAttribute.DataPath}="$h5pPath" ${TagAttribute.Title}="This fancy h5p" /><$EmbedTagName $resourceAttr="${ResourceType.H5P}" ${TagAttribute.DataPath}="$h5pPath" ${TagAttribute.Title}="This fancy h5p" /></div>"""
     val expectedResult =
-      s"""<div><$EmbedTagName $resourceAttr="${ResourceType.H5P}" ${TagAttributes.DataPath}="$h5pPath" ${TagAttributes.Title}="This fancy h5p" $urlAttr="https://h5p.ndla.no$h5pPath" /><$EmbedTagName $resourceAttr="${ResourceType.H5P}" ${TagAttributes.DataPath}="$h5pPath" ${TagAttributes.Title}="This fancy h5p" $urlAttr="https://h5p.ndla.no$h5pPath" /></div>"""
+      s"""<div><$EmbedTagName $resourceAttr="${ResourceType.H5P}" ${TagAttribute.DataPath}="$h5pPath" ${TagAttribute.Title}="This fancy h5p" $urlAttr="https://h5p.ndla.no$h5pPath" /><$EmbedTagName $resourceAttr="${ResourceType.H5P}" ${TagAttribute.DataPath}="$h5pPath" ${TagAttribute.Title}="This fancy h5p" $urlAttr="https://h5p.ndla.no$h5pPath" /></div>"""
     val result = readService.addUrlOnResource(content)
     result should equal(expectedResult)
   }

--- a/validation/src/main/resources/embed-tag-rules.json
+++ b/validation/src/main/resources/embed-tag-rules.json
@@ -100,7 +100,7 @@
           "name": "data-resource_id",
           "validation": {
             "required": true,
-            "nullable": false
+            "allowEmpty": false
           }
         },
         {
@@ -244,7 +244,7 @@
           "name": "data-resource_id",
           "validation": {
             "required": true,
-            "nullable": false
+            "allowEmpty": false
           }
         },
         {
@@ -359,7 +359,7 @@
           "name": "data-content-id",
           "validation": {
             "required": true,
-            "nullable": false
+            "allowEmpty": false
           }
         },
         {

--- a/validation/src/main/resources/embed-tag-rules.json
+++ b/validation/src/main/resources/embed-tag-rules.json
@@ -779,7 +779,7 @@
         {
           "name": "data-language",
           "validation": {
-            "required": true
+            "required": false
           }
         },
         {

--- a/validation/src/main/resources/embed-tag-rules.json
+++ b/validation/src/main/resources/embed-tag-rules.json
@@ -875,12 +875,24 @@
           }
         },
         {
+          "name": "data-title-language",
+          "validation": {
+            "required": false
+          }
+        },
+        {
           "name": "data-description",
           "validation": {
             "required": true,
             "allowedHtml": [
               "span"
             ]
+          }
+        },
+        {
+          "name": "data-description-language",
+          "validation": {
+            "required": false
           }
         },
         {
@@ -940,6 +952,12 @@
         },
         {
           "name": "data-date",
+          "validation": {
+            "required": false
+          }
+        },
+        {
+          "name": "data-language",
           "validation": {
             "required": false
           }

--- a/validation/src/main/resources/embed-tag-rules.json
+++ b/validation/src/main/resources/embed-tag-rules.json
@@ -1,82 +1,176 @@
 {
   "attributes": {
     "h5p": {
-      "required": [
-        "data-resource",
-        "data-path"
-      ],
-      "optional": [
-        [
-          "data-title"
-        ],
-        [
-          "data-url"
-        ]
+      "fields": [
+        {
+          "name": "data-resource",
+          "validation": {
+            "required": true
+          }
+        },
+        {
+          "name": "data-path",
+          "validation": {
+            "required": true
+          }
+        },
+        {
+          "name": "data-title",
+          "validation": {
+            "required": false
+          }
+        },
+        {
+          "name": "data-url",
+          "validation": {
+            "required": false
+          }
+        }
       ]
     },
     "external": {
-      "required": [
-        "data-resource",
-        "data-url",
-        "data-type"
-      ],
-      "optional": [
-        [
-          "data-caption"
-        ],
-        [
-          "data-title"
-        ],
-        [
-          "data-imageid",
-          "data-caption",
-          "data-title"
-        ]
+      "fields": [
+        {
+          "name": "data-resource",
+          "validation": {
+            "required": true
+          }
+        },
+        {
+          "name": "data-url",
+          "validation": {
+            "required": true
+          }
+        },
+        {
+          "name": "data-type",
+          "validation": {
+            "required": true
+          }
+        },
+        {
+          "name": "data-caption",
+          "validation": {
+            "required": false
+          }
+        },
+        {
+          "name": "data-title",
+          "validation": {
+            "required": false
+          }
+        },
+        {
+          "name": "data-imageid",
+          "validation": {
+            "required": false,
+            "mustCoexistWith": [
+              "data-caption",
+              "data-title"
+            ]
+          }
+        }
       ]
     },
     "error": {
-      "required": [
-        "data-resource",
-        "data-message"
+      "fields": [
+        {
+          "name": "data-resource",
+          "validation": {
+            "required": true
+          }
+        },
+        {
+          "name": "data-message",
+          "validation": {
+            "required": true
+          }
+        }
       ]
     },
     "audio": {
-      "requiredNonEmpty": [
-        "data-resource_id"
-      ],
-      "required": [
-        "data-resource",
-        "data-resource_id",
-        "data-type"
-      ],
-      "optional": [
-        [
-          "data-caption"
-        ],
-        [
-          "data-alt"
-        ]
+      "fields": [
+        {
+          "name": "data-resource",
+          "validation": {
+            "required": true
+          }
+        },
+        {
+          "name": "data-resource_id",
+          "validation": {
+            "required": true,
+            "nullable": false
+          }
+        },
+        {
+          "name": "data-type",
+          "validation": {
+            "required": true
+          }
+        },
+        {
+          "name": "data-caption",
+          "validation": {
+            "required": false
+          }
+        },
+        {
+          "name": "data-alt",
+          "validation": {
+            "required": false
+          }
+        }
       ]
     },
     "nrk": {
-      "required": [
-        "data-resource",
-        "data-nrk-video-id",
-        "data-url"
+      "fields": [
+        {
+          "name": "data-resource",
+          "validation": {
+            "required": true
+          }
+        },
+        {
+          "name": "data-nrk-video-id",
+          "validation": {
+            "required": true
+          }
+        },
+        {
+          "name": "data-url",
+          "validation": {
+            "required": true
+          }
+        }
       ]
     },
     "content-link": {
-      "required": [
-        "data-resource",
-        "data-content-id"
-      ],
-      "optional": [
-        [
-          "data-open-in"
-        ],
-        [
-          "data-content-type"
-        ]
+      "fields": [
+        {
+          "name": "data-resource",
+          "validation": {
+            "required": true
+          }
+        },
+        {
+          "name": "data-content-id",
+          "validation": {
+            "required": true
+          }
+        },
+        {
+          "name": "data-content-type",
+          "validation": {
+            "required": false
+          }
+        },
+        {
+          "name": "data-open-in",
+          "validation": {
+            "required": false
+          }
+        }
       ],
       "children": {
         "required": true,
@@ -93,109 +187,317 @@
       }
     },
     "brightcove": {
-      "required": [
-        "data-resource",
-        "data-caption",
-        "data-videoid",
-        "data-account",
-        "data-player"
-      ],
-      "optional": [
-        [
-          "data-title"
-        ],
-        [
-          "data-alt"
-        ]
+      "fields": [
+        {
+          "name": "data-resource",
+          "validation": {
+            "required": true
+          }
+        },
+        {
+          "name": "data-caption",
+          "validation": {
+            "required": true
+          }
+        },
+        {
+          "name": "data-videoid",
+          "validation": {
+            "required": true
+          }
+        },
+        {
+          "name": "data-account",
+          "validation": {
+            "required": true
+          }
+        },
+        {
+          "name": "data-player",
+          "validation": {
+            "required": true
+          }
+        },
+        {
+          "name": "data-title",
+          "validation": {
+            "required": false
+          }
+        },
+        {
+          "name": "data-alt",
+          "validation": {
+            "required": false
+          }
+        }
       ]
     },
     "image": {
-      "requiredNonEmpty": [
-        "data-resource_id"
-      ],
-      "required": [
-        "data-resource",
-        "data-resource_id",
-        "data-size",
-        "data-alt",
-        "data-caption",
-        "data-align"
-      ],
-      "optional": [
-        [
-          "data-upper-left-x",
-          "data-upper-left-y",
-          "data-lower-right-x",
-          "data-lower-right-y"
-        ],
-        [
-          "data-focal-x",
-          "data-focal-y"
-        ],
-        [
-          "data-is-decorative"
-        ],
-        [
-          "data-border"
-        ]
+      "fields": [
+        {
+          "name": "data-resource",
+          "validation": {
+            "required": true
+          }
+        },
+        {
+          "name": "data-resource_id",
+          "validation": {
+            "required": true,
+            "nullable": false
+          }
+        },
+        {
+          "name": "data-align",
+          "validation": {
+            "required": true
+          }
+        },
+        {
+          "name": "data-alt",
+          "validation": {
+            "required": true
+          }
+        },
+        {
+          "name": "data-caption",
+          "validation": {
+            "required": true
+          }
+        },
+        {
+          "name": "data-size",
+          "validation": {
+            "required": true
+          }
+        },
+        {
+          "name": "data-border",
+          "validation": {
+            "required": false
+          }
+        },
+        {
+          "name": "data-is-decorative",
+          "validation": {
+            "required": false
+          }
+        },
+        {
+          "name": "data-focal-x",
+          "validation": {
+            "required": false,
+            "mustCoexistWith": [
+              "data-focal-y"
+            ]
+          }
+        },
+        {
+          "name": "data-focal-y",
+          "validation": {
+            "required": false,
+            "mustCoexistWith": [
+              "data-focal-x"
+            ]
+          }
+        },
+        {
+          "name": "data-upper-left-x",
+          "validation": {
+            "required": false,
+            "mustCoexistWith": [
+              "data-upper-left-y",
+              "data-lower-right-x",
+              "data-lower-right-y"
+            ]
+          }
+        },
+        {
+          "name": "data-upper-left-y",
+          "validation": {
+            "required": false,
+            "mustCoexistWith": [
+              "data-upper-left-x",
+              "data-lower-right-x",
+              "data-lower-right-y"
+            ]
+          }
+        },
+        {
+          "name": "data-lower-right-x",
+          "validation": {
+            "required": false,
+            "mustCoexistWith": [
+              "data-upper-left-x",
+              "data-upper-left-y",
+              "data-lower-right-y"
+            ]
+          }
+        },
+        {
+          "name": "data-lower-right-y",
+          "validation": {
+            "required": false,
+            "mustCoexistWith": [
+              "data-upper-left-x",
+              "data-upper-left-y",
+              "data-lower-right-x"
+            ]
+          }
+        }
       ]
     },
     "concept": {
-      "requiredNonEmpty": [
-        "data-content-id"
-      ],
-      "required": [
-        "data-resource",
-        "data-content-id",
-        "data-type"
-      ],
-      "optional": [
-        [
-          "data-link-text"
-        ]
+      "fields": [
+        {
+          "name": "data-resource",
+          "validation": {
+            "required": true
+          }
+        },
+        {
+          "name": "data-content-id",
+          "validation": {
+            "required": true,
+            "nullable": false
+          }
+        },
+        {
+          "name": "data-type",
+          "validation": {
+            "required": true
+          }
+        },
+        {
+          "name": "data-link-text",
+          "validation": {
+            "required": false
+          }
+        }
       ]
     },
     "concept-list": {
-      "required": [
-        "data-resource"
-      ],
-      "optional": [
-        [
-          "data-tag",
-          "data-title"
-        ],
-        [
-          "data-tag",
-          "data-title",
-          "data-subject-id"
-        ],
-        [
-          "data-resource_id",
-          "data-recursive"
-        ]
+      "fields": [
+        {
+          "name": "data-resource",
+          "validation": {
+            "required": true
+          }
+        },
+        {
+          "name": "data-tag",
+          "validation": {
+            "required": false,
+            "mustCoexistWith": [
+              "data-title"
+            ]
+          }
+        },
+        {
+          "name": "data-title",
+          "validation": {
+            "required": false,
+            "mustCoexistWith": [
+              "data-tag"
+            ]
+          }
+        },
+        {
+          "name": "data-subject-id",
+          "validation": {
+            "required": false,
+            "mustCoexistWith": [
+              "data-tag",
+              "data-title"
+            ]
+          }
+        },
+        {
+          "name": "data-resource_id",
+          "validation": {
+            "required": false,
+            "mustCoexistWith": [
+              "data-recursive"
+            ]
+          }
+        },
+        {
+          "name": "data-recursive",
+          "validation": {
+            "required": false,
+            "mustCoexistWith": [
+              "data-resource_id"
+            ]
+          }
+        }
       ]
     },
     "iframe": {
-      "required": [
-        "data-resource",
-        "data-url",
-        "data-type"
+      "fields": [
+        {
+          "name": "data-resource",
+          "validation": {
+            "required": true
+          }
+        },
+        {
+          "name": "data-url",
+          "validation": {
+            "required": true
+          }
+        },
+        {
+          "name": "data-type",
+          "validation": {
+            "required": true
+          }
+        },
+        {
+          "name": "data-title",
+          "validation": {
+            "required": false
+          }
+        },
+        {
+          "name": "data-caption",
+          "validation": {
+            "required": false,
+            "mustCoexistWith": [
+              "data-title",
+              "data-imageid"
+            ]
+          }
+        },
+        {
+          "name": "data-imageid",
+          "validation": {
+            "required": false,
+            "mustCoexistWith": [
+              "data-title",
+              "data-caption"
+            ]
+          }
+        },
+        {
+          "name": "data-height",
+          "validation": {
+            "required": false,
+            "mustCoexistWith": [
+              "data-width"
+            ]
+          }
+        },
+        {
+          "name": "data-width",
+          "validation": {
+            "required": false,
+            "mustCoexistWith": [
+              "data-height"
+            ]
+          }
+        }
       ],
-      "optional": [
-        [
-          "data-width",
-          "data-height"
-        ],
-        [
-          "data-title"
-        ],
-        [
-          "data-title",
-          "data-caption",
-          "data-imageid"
-        ]
-      ],
-      "validSrcDomains": [
+      "validUrlDomains": [
         ".*.ndla.no",
         "vimeo.com",
         "ndla.filmiundervisning.no",
@@ -244,42 +546,113 @@
       ]
     },
     "footnote": {
-      "required": [
-        "data-resource",
-        "data-title",
-        "data-type",
-        "data-year",
-        "data-edition",
-        "data-publisher",
-        "data-authors"
+      "fields": [
+        {
+          "name": "data-resource",
+          "validation": {
+            "required": true
+          }
+        },
+        {
+          "name": "data-title",
+          "validation": {
+            "required": true
+          }
+        },
+        {
+          "name": "data-type",
+          "validation": {
+            "required": true
+          }
+        },
+        {
+          "name": "data-year",
+          "validation": {
+            "required": true
+          }
+        },
+        {
+          "name": "data-edition",
+          "validation": {
+            "required": true
+          }
+        },
+        {
+          "name": "data-publisher",
+          "validation": {
+            "required": true
+          }
+        },
+        {
+          "name": "data-authors",
+          "validation": {
+            "required": true
+          }
+        }
       ]
     },
     "code-block": {
-      "required": [
-        "data-resource",
-        "data-code-format",
-        "data-code-content"
-      ],
-      "optional": [
-        [
-          "data-title"
-        ]
+      "fields": [
+        {
+          "name": "data-resource",
+          "validation": {
+            "required": true
+          }
+        },
+        {
+          "name": "data-code-format",
+          "validation": {
+            "required": true
+          }
+        },
+        {
+          "name": "data-code-content",
+          "validation": {
+            "required": true
+          }
+        },
+        {
+          "name": "data-title",
+          "validation": {
+            "required": false
+          }
+        }
       ]
     },
     "related-content": {
+      "fields": [
+        {
+          "name": "data-resource",
+          "validation": {
+            "required": true
+          }
+        },
+        {
+          "name": "data-article-id",
+          "validation": {
+            "required": false
+          }
+        },
+        {
+          "name": "data-url",
+          "validation": {
+            "required": false,
+            "mustCoexistWith": [
+              "data-title"
+            ]
+          }
+        },
+        {
+          "name": "data-title",
+          "validation": {
+            "required": false,
+            "mustCoexistWith": [
+              "data-url"
+            ]
+          }
+        }
+      ],
       "mustContainAtLeastOneOptionalAttribute": true,
-      "required": [
-        "data-resource"
-      ],
-      "optional": [
-        [
-          "data-article-id"
-        ],
-        [
-          "data-url",
-          "data-title"
-        ]
-      ],
       "mustBeDirectChildOf": {
         "name": "div",
         "requiredAttr": [
@@ -290,21 +663,43 @@
       }
     },
     "file": {
-      "required": [
-        "data-resource",
-        "data-title",
-        "data-path"
-      ],
-      "optional": [
-        [
-          "data-type"
-        ],
-        [
-          "data-alt"
-        ],
-        [
-          "data-display"
-        ]
+      "fields": [
+        {
+          "name": "data-resource",
+          "validation": {
+            "required": true
+          }
+        },
+        {
+          "name": "data-title",
+          "validation": {
+            "required": true
+          }
+        },
+        {
+          "name": "data-path",
+          "validation": {
+            "required": true
+          }
+        },
+        {
+          "name": "data-type",
+          "validation": {
+            "required": false
+          }
+        },
+        {
+          "name": "data-alt",
+          "validation": {
+            "required": false
+          }
+        },
+        {
+          "name": "data-display",
+          "validation": {
+            "required": false
+          }
+        }
       ],
       "mustBeDirectChildOf": {
         "name": "div",
@@ -316,81 +711,239 @@
       }
     },
     "contact-block": {
-      "required": [
-        "data-resource",
-        "data-job-title",
-        "data-name",
-        "data-email",
-        "data-description",
-        "data-image-id"
-      ],
-      "optional": [
-        [
-          "data-blob-color"
-        ],
-        [
-          "data-blob"
-        ]
+      "fields": [
+        {
+          "name": "data-resource",
+          "validation": {
+            "required": true
+          }
+        },
+        {
+          "name": "data-job-title",
+          "validation": {
+            "required": true
+          }
+        },
+        {
+          "name": "data-name",
+          "validation": {
+            "required": true
+          }
+        },
+        {
+          "name": "data-email",
+          "validation": {
+            "required": true
+          }
+        },
+        {
+          "name": "data-description",
+          "validation": {
+            "required": true
+          }
+        },
+        {
+          "name": "data-image-id",
+          "validation": {
+            "required": true
+          }
+        },
+        {
+          "name": "data-blob",
+          "validation": {
+            "required": false
+          }
+        },
+        {
+          "name": "data-blob-color",
+          "validation": {
+            "required": false
+          }
+        }
       ]
     },
     "blog-post": {
-      "required": [
-        "data-resource",
-        "data-image-id",
-        "data-language",
-        "data-title",
-        "data-url"
-      ],
-      "optional": [
-        [
-          "data-size"
-        ],
-        [
-          "data-author"
-        ]
+      "fields": [
+        {
+          "name": "data-resource",
+          "validation": {
+            "required": true
+          }
+        },
+        {
+          "name": "data-image-id",
+          "validation": {
+            "required": true
+          }
+        },
+        {
+          "name": "data-language",
+          "validation": {
+            "required": true
+          }
+        },
+        {
+          "name": "data-title",
+          "validation": {
+            "required": true,
+            "allowedHtml": [
+              "span"
+            ]
+          }
+        },
+        {
+          "name": "data-url",
+          "validation": {
+            "required": true
+          }
+        },
+        {
+          "name": "data-size",
+          "validation": {
+            "required": false
+          }
+        },
+        {
+          "name": "data-author",
+          "validation": {
+            "required": false
+          }
+        }
       ]
     },
     "key-figure": {
-      "required": [
-        "data-resource",
-        "data-image-id",
-        "data-title",
-        "data-subtitle"
+      "fields": [
+        {
+          "name": "data-resource",
+          "validation": {
+            "required": true
+          }
+        },
+        {
+          "name": "data-image-id",
+          "validation": {
+            "required": true
+          }
+        },
+        {
+          "name": "data-title",
+          "validation": {
+            "required": true,
+            "allowedHtml": [
+              "span"
+            ]
+          }
+        },
+        {
+          "name": "data-subtitle",
+          "validation": {
+            "required": true,
+            "allowedHtml": [
+              "span"
+            ]
+          }
+        },
+        {
+          "name": "data-size",
+          "validation": {
+            "required": false
+          }
+        },
+        {
+          "name": "data-author",
+          "validation": {
+            "required": false
+          }
+        }
       ]
     },
     "campaign-block": {
-      "required": [
-        "data-resource",
-        "data-title",
-        "data-title-language",
-        "data-description",
-        "data-description-language",
-        "data-heading-level",
-        "data-url",
-        "data-url-text"
-      ],
-      "optional": [
-        [
-          "data-image-id"
-        ],
-        [
-          "data-image-side"
-        ]
+      "fields": [
+        {
+          "name": "data-resource",
+          "validation": {
+            "required": true
+          }
+        },
+        {
+          "name": "data-title",
+          "validation": {
+            "required": true,
+            "allowedHtml": [
+              "span"
+            ]
+          }
+        },
+        {
+          "name": "data-description",
+          "validation": {
+            "required": true,
+            "allowedHtml": [
+              "span"
+            ]
+          }
+        },
+        {
+          "name": "data-heading-level",
+          "validation": {
+            "required": true
+          }
+        },
+        {
+          "name": "data-url",
+          "validation": {
+            "required": true
+          }
+        },
+        {
+          "name": "data-url-text",
+          "validation": {
+            "required": true
+          }
+        },
+        {
+          "name": "data-image-id",
+          "validation": {
+            "required": false
+          }
+        },
+        {
+          "name": "data-image-side",
+          "validation": {
+            "required": true
+          }
+        }
       ]
     },
     "link-block": {
-      "required": [
-        "data-resource",
-        "data-title",
-        "data-url"
-      ],
-      "optional": [
-        [
-          "data-date"
-        ],
-        [
-          "data-language"
-        ]
+      "fields": [
+        {
+          "name": "data-resource",
+          "validation": {
+            "required": true
+          }
+        },
+        {
+          "name": "data-title",
+          "validation": {
+            "required": true,
+            "allowedHtml": [
+              "span"
+            ]
+          }
+        },
+        {
+          "name": "data-url",
+          "validation": {
+            "required": true
+          }
+        },
+        {
+          "name": "data-date",
+          "validation": {
+            "required": false
+          }
+        }
       ]
     }
   }

--- a/validation/src/main/resources/html-rules.json
+++ b/validation/src/main/resources/html-rules.json
@@ -1,173 +1,176 @@
 {
   "attributes": {
     "nav": {
-      "optional": [
-        [
-          "data-type"
-        ]
+      "fields": [
+        {
+          "name": "data-type"
+        }
       ]
     },
     "span": {
       "mustContainAtLeastOneOptionalAttribute": true,
-      "optional": [
-        [
-          "lang"
-        ],
-        [
-          "data-size"
-        ]
+      "fields": [
+        {
+          "name": "lang"
+        },
+        {
+          "name": "dir"
+        },
+        {
+          "name": "data-size"
+        }
       ]
     },
     "colgroup": {
-      "optional": [
-        [
-          "span"
-        ],
-        [
-          "style"
-        ]
+      "fields": [
+        {
+          "name": "span"
+        },
+        {
+          "name": "style"
+        }
       ]
     },
     "col": {
-      "optional": [
-        [
-          "span"
-        ],
-        [
-          "style"
-        ]
+      "fields": [
+        {
+          "name": "span"
+        },
+        {
+          "name": "style"
+        }
       ]
     },
     "div": {
-      "optional": [
-        [
-          "class"
-        ],
-        [
-          "data-type"
-        ],
-        [
-          "data-columns"
-        ],
-        [
-          "data-border"
-        ],
-        [
-          "data-background"
-        ],
-        [
-          "data-size"
-        ],
-        [
-          "data-parallax-cell"
-        ]
+      "fields": [
+        {
+          "name": "class"
+        },
+        {
+          "name": "data-type"
+        },
+        {
+          "name": "data-columns"
+        },
+        {
+          "name": "data-border"
+        },
+        {
+          "name": "data-background"
+        },
+        {
+          "name": "data-size"
+        },
+        {
+          "name": "data-parallax-cell"
+        }
       ]
     },
     "td": {
-      "optional": [
-        [
-          "valign"
-        ],
-        [
-          "align"
-        ],
-        [
-          "colspan"
-        ],
-        [
-          "rowspan"
-        ],
-        [
-          "id"
-        ],
-        [
-          "class"
-        ],
-        [
-          "headers"
-        ]
+      "fields": [
+        {
+          "name": "valign"
+        },
+        {
+          "name": "align"
+        },
+        {
+          "name": "colspan"
+        },
+        {
+          "name": "rowspan"
+        },
+        {
+          "name": "id"
+        },
+        {
+          "name": "headers"
+        },
+        {
+          "name": "class"
+        }
       ]
     },
     "th": {
-      "optional": [
-        [
-          "valign"
-        ],
-        [
-          "align"
-        ],
-        [
-          "colspan"
-        ],
-        [
-          "rowspan"
-        ],
-        [
-          "id"
-        ],
-        [
-          "scope"
-        ],
-        [
-          "class"
-        ]
+      "fields": [
+        {
+          "name": "valign"
+        },
+        {
+          "name": "align"
+        },
+        {
+          "name": "colspan"
+        },
+        {
+          "name": "rowspan"
+        },
+        {
+          "name": "id"
+        },
+        {
+          "name": "scope"
+        },
+        {
+          "name": "class"
+        }
       ]
     },
     "a": {
-      "optional": [
-        [
-          "href"
-        ],
-        [
-          "title"
-        ],
-        [
-          "name"
-        ],
-        [
-          "target"
-        ],
-        [
-          "rel"
-        ]
+      "fields": [
+        {
+          "name": "href"
+        },
+        {
+          "name": "title"
+        },
+        {
+          "name": "name"
+        },
+        {
+          "name": "target"
+        },
+        {
+          "name": "rel"
+        }
       ]
     },
     "ol": {
-      "optional": [
-        [
-          "data-type"
-        ],
-        [
-          "start"
-        ]
+      "fields": [
+        {
+          "name": "data-type"
+        },
+        {
+          "name": "start"
+        }
       ]
     },
     "aside": {
-      "optional": [
-        [
-          "data-type"
-        ]
+      "fields": [
+        {
+          "name": "data-type"
+        }
       ]
     },
     "p": {
-      "optional": [
-        [
-          "data-align"
-        ]
+      "fields": [
+        {
+          "name": "data-align"
+        }
       ]
     },
     "ul": {
-      "optional": [
-        [
-          "data-type"
-        ]
+      "fields": [
+        {
+          "name": "data-type"
+        }
       ]
     },
     "details": {
-      "optional": [
-        [
-          "class"
-        ]
+      "fields": [
+        {
+          "name": "class"
+        }
       ]
     }
   },

--- a/validation/src/main/scala/no/ndla/validation/EmbedTagRules.scala
+++ b/validation/src/main/scala/no/ndla/validation/EmbedTagRules.scala
@@ -13,7 +13,7 @@ import scala.language.postfixOps
 object EmbedTagRules {
   private[validation] lazy val attributeRules: Map[ResourceType.Value, TagRules.TagAttributeRules] = embedRulesToJson
 
-  lazy val allEmbedTagAttributes: Set[TagAttributes.Value] = attributeRules.flatMap { case (_, attrRules) =>
+  lazy val allEmbedTagAttributes: Set[TagAttribute] = attributeRules.flatMap { case (_, attrRules) =>
     attrRules.all
   } toSet
 

--- a/validation/src/main/scala/no/ndla/validation/EmbedTagRules.scala
+++ b/validation/src/main/scala/no/ndla/validation/EmbedTagRules.scala
@@ -7,25 +7,27 @@
 
 package no.ndla.validation
 
+import enumeratum._
+
 import scala.io.Source
 import scala.language.postfixOps
 
 object EmbedTagRules {
-  private[validation] lazy val attributeRules: Map[ResourceType.Value, TagRules.TagAttributeRules] = embedRulesToJson
+  private[validation] lazy val attributeRules: Map[ResourceType, TagRules.TagAttributeRules] = embedRulesToJson
 
   lazy val allEmbedTagAttributes: Set[TagAttribute] = attributeRules.flatMap { case (_, attrRules) =>
     attrRules.all
   } toSet
 
-  def attributesForResourceType(resourceType: ResourceType.Value): TagRules.TagAttributeRules =
+  def attributesForResourceType(resourceType: ResourceType): TagRules.TagAttributeRules =
     attributeRules(resourceType)
 
-  private def embedRulesToJson: Map[ResourceType.Value, TagRules.TagAttributeRules] = {
+  private def embedRulesToJson: Map[ResourceType, TagRules.TagAttributeRules] = {
     val attrs = TagRules.convertJsonStrToAttributeRules(Source.fromResource("embed-tag-rules.json").mkString)
 
-    def strToResourceType(str: String): ResourceType.Value =
+    def strToResourceType(str: String): ResourceType =
       ResourceType
-        .valueOf(str)
+        .withNameOption(str)
         .getOrElse(
           throw new ConfigurationException(s"Missing declaration of resource type '$str' in ResourceType enum")
         )
@@ -36,31 +38,32 @@ object EmbedTagRules {
   }
 }
 
-object ResourceType extends Enumeration {
-  val Error: ResourceType.Value           = Value("error")
-  val Image: ResourceType.Value           = Value("image")
-  val Audio: ResourceType.Value           = Value("audio")
-  val H5P: ResourceType.Value             = Value("h5p")
-  val Brightcove: ResourceType.Value      = Value("brightcove")
-  val ContentLink: ResourceType.Value     = Value("content-link")
-  val ExternalContent: ResourceType.Value = Value("external")
-  val IframeContent: ResourceType.Value   = Value("iframe")
-  val NRKContent: ResourceType.Value      = Value("nrk")
-  val Concept: ResourceType.Value         = Value("concept")
-  val ConceptList: ResourceType.Value     = Value("concept-list")
-  val FootNote: ResourceType.Value        = Value("footnote")
-  val CodeBlock: ResourceType.Value       = Value("code-block")
-  val RelatedContent: ResourceType.Value  = Value("related-content")
-  val File: ResourceType.Value            = Value("file")
-  val ContactBlock: ResourceType.Value    = Value("contact-block")
-  val BlogPost: ResourceType.Value        = Value("blog-post")
-  val KeyFigure: ResourceType.Value       = Value("key-figure")
-  val CampaignBlock: ResourceType.Value   = Value("campaign-block")
-  val LinkBlock: ResourceType.Value       = Value("link-block")
+sealed abstract class ResourceType(override val entryName: String) extends EnumEntry {
+  override def toString: String = entryName
+}
 
-  def all: Set[String] = ResourceType.values.map(_.toString)
+object ResourceType extends Enum[ResourceType] {
+  val values: IndexedSeq[ResourceType] = findValues
 
-  def valueOf(s: String): Option[ResourceType.Value] = {
-    ResourceType.values.find(_.toString == s)
-  }
+  case object Error           extends ResourceType("error")
+  case object Image           extends ResourceType("image")
+  case object Audio           extends ResourceType("audio")
+  case object H5P             extends ResourceType("h5p")
+  case object Brightcove      extends ResourceType("brightcove")
+  case object ContentLink     extends ResourceType("content-link")
+  case object ExternalContent extends ResourceType("external")
+  case object IframeContent   extends ResourceType("iframe")
+  case object NRKContent      extends ResourceType("nrk")
+  case object Concept         extends ResourceType("concept")
+  case object ConceptList     extends ResourceType("concept-list")
+  case object FootNote        extends ResourceType("footnote")
+  case object CodeBlock       extends ResourceType("code-block")
+  case object RelatedContent  extends ResourceType("related-content")
+  case object File            extends ResourceType("file")
+  case object ContactBlock    extends ResourceType("contact-block")
+  case object BlogPost        extends ResourceType("blog-post")
+  case object KeyFigure       extends ResourceType("key-figure")
+  case object CampaignBlock   extends ResourceType("campaign-block")
+  case object LinkBlock       extends ResourceType("link-block")
+
 }

--- a/validation/src/main/scala/no/ndla/validation/TagRules.scala
+++ b/validation/src/main/scala/no/ndla/validation/TagRules.scala
@@ -1,8 +1,6 @@
 package no.ndla.validation
 
-import enumeratum._
-import enumeratum.Json4s
-
+import enumeratum.{Json4s, _}
 import org.json4s.Formats
 import org.json4s.JsonAST.JObject
 import org.json4s.native.JsonMethods._
@@ -17,7 +15,6 @@ object TagRules {
   ) {
     lazy val all: Set[TagAttribute] = fields.map(f => f.name)
 
-    lazy val allFields: Set[Field]        = fields
     lazy val optional: Set[Field]         = fields.filter(f => !f.validation.required)
     lazy val required: Set[Field]         = fields.filter(f => f.validation.required)
     lazy val requiredNonEmpty: Set[Field] = required.filter(f => !f.validation.nullable)

--- a/validation/src/main/scala/no/ndla/validation/TagRules.scala
+++ b/validation/src/main/scala/no/ndla/validation/TagRules.scala
@@ -17,7 +17,7 @@ object TagRules {
 
     lazy val optional: Set[Field]         = fields.filter(f => !f.validation.required)
     lazy val required: Set[Field]         = fields.filter(f => f.validation.required)
-    lazy val requiredNonEmpty: Set[Field] = required.filter(f => !f.validation.nullable)
+    lazy val requiredNonEmpty: Set[Field] = required.filter(f => !f.validation.allowEmpty)
 
     def field(tag: TagAttribute): Option[Field] = fields.find(f => f.name == tag)
 
@@ -36,7 +36,7 @@ object TagRules {
 
   case class Validation(
       required: Boolean = false,
-      nullable: Boolean = true,
+      allowEmpty: Boolean = true,
       allowedHtml: Set[String] = Set.empty,
       mustCoexistWith: List[TagAttribute] = List.empty
   )

--- a/validation/src/main/scala/no/ndla/validation/TagRules.scala
+++ b/validation/src/main/scala/no/ndla/validation/TagRules.scala
@@ -1,35 +1,44 @@
 package no.ndla.validation
 
+import enumeratum._
+import enumeratum.Json4s
+
 import org.json4s.Formats
 import org.json4s.JsonAST.JObject
-import org.json4s.ext._
 import org.json4s.native.JsonMethods._
 
 object TagRules {
   case class TagAttributeRules(
-      required: Set[TagAttributes.Value],
-      requiredNonEmpty: Set[TagAttributes.Value],
-      optional: Seq[Set[TagAttributes.Value]],
-      validSrcDomains: Option[Seq[String]],
+      fields: Set[Field],
+      validUrlDomains: Option[Seq[String]],
       mustBeDirectChildOf: Option[ParentTag],
       children: Option[ChildrenRule],
       mustContainAtLeastOneOptionalAttribute: Option[Boolean]
   ) {
-    lazy val all: Set[TagAttributes.Value] = required ++ requiredNonEmpty ++ optional.flatten
+    lazy val all: Set[TagAttribute] = fields.map(f => f.name)
+
+    lazy val optional: Set[Field]         = fields.filter(f => !f.validation.required)
+    lazy val required: Set[Field]         = fields.filter(f => f.validation.required)
+    lazy val requiredNonEmpty: Set[Field] = required.filter(f => !f.validation.nullable)
 
     def mustContainOptionalAttribute: Boolean = this.mustContainAtLeastOneOptionalAttribute.getOrElse(false)
 
     def withOptionalRequired(toBeOptional: Seq[String]): TagAttributeRules = {
-      val toBeOptionalEnums = toBeOptional.flatMap(TagAttributes.valueOf)
-      val newReq            = required.filterNot(toBeOptionalEnums.contains)
-      val newOpt            = optional ++ toBeOptionalEnums.map(o => Set(o))
+      val toBeOptionalEnums = toBeOptional.map(TagAttribute.withName)
+      val otherFields       = fields.filterNot(f => toBeOptionalEnums.contains(f.name))
+      val flipped = fields.diff(otherFields).map(f => f.copy(validation = f.validation.copy(required = false)))
 
       this.copy(
-        required = newReq,
-        optional = newOpt
+        fields = flipped ++ otherFields
       )
     }
   }
+
+  case class TagValidation(required: Boolean = false, nullable: Boolean = true, mustCoexistWith: List[TagAttribute] = List.empty)
+  object TagValidation {
+    def default: TagValidation = TagValidation(mustCoexistWith = List.empty)
+  }
+  case class Field(name: TagAttribute, validation: TagValidation = TagValidation.default)
 
   case class ParentTag(name: String, requiredAttr: List[(String, String)], conditions: Option[Condition])
   case class ChildrenRule(required: Boolean, allowedChildren: List[String])
@@ -39,11 +48,11 @@ object TagRules {
   case class Condition(childCount: String)
 
   object TagAttributeRules {
-    def empty: TagAttributeRules = TagAttributeRules(Set.empty, Set.empty, Seq.empty, None, None, None, None)
+    def empty: TagAttributeRules = TagAttributeRules(Set.empty, None, None, None, None)
   }
 
   def convertJsonStrToAttributeRules(jsonStr: String): Map[String, TagAttributeRules] = {
-    implicit val formats: Formats = org.json4s.DefaultFormats + new EnumNameSerializer(TagAttributes)
+    implicit val formats: Formats = org.json4s.DefaultFormats + Json4s.serializer(TagAttribute)
 
     (parse(jsonStr) \ "attributes")
       .extract[JObject]
@@ -55,94 +64,90 @@ object TagRules {
   }
 }
 
-object TagAttributes extends Enumeration {
-  val DataUrl: TagAttributes.Value                 = Value("data-url")
-  val DataAlt: TagAttributes.Value                 = Value("data-alt")
-  val DataSize: TagAttributes.Value                = Value("data-size")
-  val DataAlign: TagAttributes.Value               = Value("data-align")
-  val DataWidth: TagAttributes.Value               = Value("data-width")
-  val DataHeight: TagAttributes.Value              = Value("data-height")
-  val DataPlayer: TagAttributes.Value              = Value("data-player")
-  val DataMessage: TagAttributes.Value             = Value("data-message")
-  val DataCaption: TagAttributes.Value             = Value("data-caption")
-  val DataAccount: TagAttributes.Value             = Value("data-account")
-  val DataVideoId: TagAttributes.Value             = Value("data-videoid")
-  val DataImageId: TagAttributes.Value             = Value("data-imageid")
-  val DataImage_Id: TagAttributes.Value            = Value("data-image-id")
-  val DataResource: TagAttributes.Value            = Value("data-resource")
-  val DataLanguage: TagAttributes.Value            = Value("data-language")
-  val DataAuthor: TagAttributes.Value              = Value("data-author")
-  val DataLinkText: TagAttributes.Value            = Value("data-link-text")
-  val DataOpenIn: TagAttributes.Value              = Value("data-open-in")
-  val DataContentId: TagAttributes.Value           = Value("data-content-id")
-  val DataContentType: TagAttributes.Value         = Value("data-content-type")
-  val DataNRKVideoId: TagAttributes.Value          = Value("data-nrk-video-id")
-  val DataResource_Id: TagAttributes.Value         = Value("data-resource_id")
-  val DataTitle: TagAttributes.Value               = Value("data-title")
-  val DataType: TagAttributes.Value                = Value("data-type")
-  val DataYear: TagAttributes.Value                = Value("data-year")
-  val DataEdition: TagAttributes.Value             = Value("data-edition")
-  val DataPublisher: TagAttributes.Value           = Value("data-publisher")
-  val DataAuthors: TagAttributes.Value             = Value("data-authors")
-  val DataArticleId: TagAttributes.Value           = Value("data-article-id")
-  val DataPath: TagAttributes.Value                = Value("data-path")
-  val DataFormat: TagAttributes.Value              = Value("data-code-format")
-  val DataContent: TagAttributes.Value             = Value("data-code-content")
-  val DataDisplay: TagAttributes.Value             = Value("data-display")
-  val DataRecursive: TagAttributes.Value           = Value("data-recursive")
-  val DataSubjectId: TagAttributes.Value           = Value("data-subject-id")
-  val DataTag: TagAttributes.Value                 = Value("data-tag")
-  val DataEmail: TagAttributes.Value               = Value("data-email")
-  val DataBlob: TagAttributes.Value                = Value("data-blob")
-  val DataBlobColor: TagAttributes.Value           = Value("data-blob-color")
-  val DataName: TagAttributes.Value                = Value("data-name")
-  val DataDescription: TagAttributes.Value         = Value("data-description")
-  val DataJobTitle: TagAttributes.Value            = Value("data-job-title")
-  val DataUpperLeftY: TagAttributes.Value          = Value("data-upper-left-y")
-  val DataUpperLeftX: TagAttributes.Value          = Value("data-upper-left-x")
-  val DataLowerRightY: TagAttributes.Value         = Value("data-lower-right-y")
-  val DataLowerRightX: TagAttributes.Value         = Value("data-lower-right-x")
-  val DataFocalX: TagAttributes.Value              = Value("data-focal-x")
-  val DataFocalY: TagAttributes.Value              = Value("data-focal-y")
-  val DataIsDecorative: TagAttributes.Value        = Value("data-is-decorative")
-  val DataSubtitle: TagAttributes.Value            = Value("data-subtitle")
-  val DataColumns: TagAttributes.Value             = Value("data-columns")
-  val DataBorder: TagAttributes.Value              = Value("data-border")
-  val DataBackground: TagAttributes.Value          = Value("data-background")
-  val DataTitleLanguage: TagAttributes.Value       = Value("data-title-language")
-  val DataDescriptionLanguage: TagAttributes.Value = Value("data-description-language")
-  val DataHeadingLevel: TagAttributes.Value        = Value("data-heading-level")
-  val DataUrlText: TagAttributes.Value             = Value("data-url-text")
-  val DataImageSide: TagAttributes.Value           = Value("data-image-side")
-  val DataParallaxCell: TagAttributes.Value        = Value("data-parallax-cell")
-  val XMLNsAttribute: TagAttributes.Value          = Value("xmlns")
-  val DataDate: TagAttributes.Value                = Value("data-date")
+sealed abstract class TagAttribute(override val entryName: String) extends EnumEntry {
+  override def toString: String = entryName
+}
+object TagAttribute extends Enum[TagAttribute] {
+  val values: IndexedSeq[TagAttribute] = findValues
 
-  val Href: TagAttributes.Value    = Value("href")
-  val Title: TagAttributes.Value   = Value("title")
-  val Align: TagAttributes.Value   = Value("align")
-  val Valign: TagAttributes.Value  = Value("valign")
-  val Target: TagAttributes.Value  = Value("target")
-  val Rel: TagAttributes.Value     = Value("rel")
-  val Class: TagAttributes.Value   = Value("class")
-  val Lang: TagAttributes.Value    = Value("lang")
-  val Rowspan: TagAttributes.Value = Value("rowspan")
-  val Colspan: TagAttributes.Value = Value("colspan")
-  val Name: TagAttributes.Value    = Value("name")
-  val Start: TagAttributes.Value   = Value("start")
-  val Style: TagAttributes.Value   = Value("style")
-  val Span: TagAttributes.Value    = Value("span")
-  val Id: TagAttributes.Value      = Value("id")
-  val Scope: TagAttributes.Value   = Value("scope")
-  val Headers: TagAttributes.Value = Value("headers")
+  case object Align          extends TagAttribute("align")
+  case object Class          extends TagAttribute("class")
+  case object Colspan        extends TagAttribute("colspan")
+  case object Dir            extends TagAttribute("dir")
+  case object Headers        extends TagAttribute("headers")
+  case object Href           extends TagAttribute("href")
+  case object Id             extends TagAttribute("id")
+  case object Lang           extends TagAttribute("lang")
+  case object Name           extends TagAttribute("name")
+  case object Rel            extends TagAttribute("rel")
+  case object Rowspan        extends TagAttribute("rowspan")
+  case object Scope          extends TagAttribute("scope")
+  case object Span           extends TagAttribute("span")
+  case object Start          extends TagAttribute("start")
+  case object Style          extends TagAttribute("style")
+  case object Target         extends TagAttribute("target")
+  case object Title          extends TagAttribute("title")
+  case object Valign         extends TagAttribute("valign")
+  case object XMLNsAttribute extends TagAttribute("xmlns")
 
-  private[validation] def getOrCreate(s: String): TagAttributes.Value = {
-    valueOf(s).getOrElse(Value(s))
-  }
-
-  def all: Set[String] = TagAttributes.values.map(_.toString)
-
-  def valueOf(s: String): Option[TagAttributes.Value] = {
-    TagAttributes.values.find(_.toString == s)
-  }
+  case object DataAccount             extends TagAttribute("data-account")
+  case object DataAlign               extends TagAttribute("data-align")
+  case object DataAlt                 extends TagAttribute("data-alt")
+  case object DataArticleId           extends TagAttribute("data-article-id")
+  case object DataAuthor              extends TagAttribute("data-author")
+  case object DataAuthors             extends TagAttribute("data-authors")
+  case object DataBackground          extends TagAttribute("data-background")
+  case object DataBlob                extends TagAttribute("data-blob")
+  case object DataBlobColor           extends TagAttribute("data-blob-color")
+  case object DataBorder              extends TagAttribute("data-border")
+  case object DataCaption             extends TagAttribute("data-caption")
+  case object DataColumns             extends TagAttribute("data-columns")
+  case object DataContent             extends TagAttribute("data-code-content")
+  case object DataContentId           extends TagAttribute("data-content-id")
+  case object DataContentType         extends TagAttribute("data-content-type")
+  case object DataDate                extends TagAttribute("data-date")
+  case object DataDescription         extends TagAttribute("data-description")
+  case object DataDescriptionLanguage extends TagAttribute("data-description-language")
+  case object DataDisplay             extends TagAttribute("data-display")
+  case object DataEdition             extends TagAttribute("data-edition")
+  case object DataEmail               extends TagAttribute("data-email")
+  case object DataFocalX              extends TagAttribute("data-focal-x")
+  case object DataFocalY              extends TagAttribute("data-focal-y")
+  case object DataFormat              extends TagAttribute("data-code-format")
+  case object DataHeadingLevel        extends TagAttribute("data-heading-level")
+  case object DataHeight              extends TagAttribute("data-height")
+  case object DataImageId             extends TagAttribute("data-imageid")
+  case object DataImageSide           extends TagAttribute("data-image-side")
+  case object DataImage_Id            extends TagAttribute("data-image-id")
+  case object DataIsDecorative        extends TagAttribute("data-is-decorative")
+  case object DataJobTitle            extends TagAttribute("data-job-title")
+  case object DataLanguage            extends TagAttribute("data-language")
+  case object DataLinkText            extends TagAttribute("data-link-text")
+  case object DataLowerRightX         extends TagAttribute("data-lower-right-x")
+  case object DataLowerRightY         extends TagAttribute("data-lower-right-y")
+  case object DataMessage             extends TagAttribute("data-message")
+  case object DataNRKVideoId          extends TagAttribute("data-nrk-video-id")
+  case object DataName                extends TagAttribute("data-name")
+  case object DataOpenIn              extends TagAttribute("data-open-in")
+  case object DataParallaxCell        extends TagAttribute("data-parallax-cell")
+  case object DataPath                extends TagAttribute("data-path")
+  case object DataPlayer              extends TagAttribute("data-player")
+  case object DataPublisher           extends TagAttribute("data-publisher")
+  case object DataRecursive           extends TagAttribute("data-recursive")
+  case object DataResource            extends TagAttribute("data-resource")
+  case object DataResource_Id         extends TagAttribute("data-resource_id")
+  case object DataSize                extends TagAttribute("data-size")
+  case object DataSubjectId           extends TagAttribute("data-subject-id")
+  case object DataSubtitle            extends TagAttribute("data-subtitle")
+  case object DataTag                 extends TagAttribute("data-tag")
+  case object DataTitle               extends TagAttribute("data-title")
+  case object DataTitleLanguage       extends TagAttribute("data-title-language")
+  case object DataType                extends TagAttribute("data-type")
+  case object DataUpperLeftX          extends TagAttribute("data-upper-left-x")
+  case object DataUpperLeftY          extends TagAttribute("data-upper-left-y")
+  case object DataUrl                 extends TagAttribute("data-url")
+  case object DataUrlText             extends TagAttribute("data-url-text")
+  case object DataVideoId             extends TagAttribute("data-videoid")
+  case object DataWidth               extends TagAttribute("data-width")
+  case object DataYear                extends TagAttribute("data-year")
 }

--- a/validation/src/main/scala/no/ndla/validation/TagRules.scala
+++ b/validation/src/main/scala/no/ndla/validation/TagRules.scala
@@ -40,6 +40,7 @@ object TagRules {
   case class Validation(
       required: Boolean = false,
       nullable: Boolean = true,
+      allowedHtml: Set[String] = Set.empty,
       mustCoexistWith: List[TagAttribute] = List.empty
   )
   case class Field(name: TagAttribute, validation: Validation = Validation()) {

--- a/validation/src/main/scala/no/ndla/validation/TagRules.scala
+++ b/validation/src/main/scala/no/ndla/validation/TagRules.scala
@@ -17,9 +17,12 @@ object TagRules {
   ) {
     lazy val all: Set[TagAttribute] = fields.map(f => f.name)
 
+    lazy val allFields: Set[Field]        = fields
     lazy val optional: Set[Field]         = fields.filter(f => !f.validation.required)
     lazy val required: Set[Field]         = fields.filter(f => f.validation.required)
     lazy val requiredNonEmpty: Set[Field] = required.filter(f => !f.validation.nullable)
+
+    def field(tag: TagAttribute): Option[Field] = fields.find(f => f.name == tag)
 
     def mustContainOptionalAttribute: Boolean = this.mustContainAtLeastOneOptionalAttribute.getOrElse(false)
 
@@ -34,11 +37,14 @@ object TagRules {
     }
   }
 
-  case class TagValidation(required: Boolean = false, nullable: Boolean = true, mustCoexistWith: List[TagAttribute] = List.empty)
-  object TagValidation {
-    def default: TagValidation = TagValidation(mustCoexistWith = List.empty)
+  case class Validation(
+      required: Boolean = false,
+      nullable: Boolean = true,
+      mustCoexistWith: List[TagAttribute] = List.empty
+  )
+  case class Field(name: TagAttribute, validation: Validation = Validation()) {
+    override def toString: String = name.entryName
   }
-  case class Field(name: TagAttribute, validation: TagValidation = TagValidation.default)
 
   case class ParentTag(name: String, requiredAttr: List[(String, String)], conditions: Option[Condition])
   case class ChildrenRule(required: Boolean, allowedChildren: List[String])

--- a/validation/src/main/scala/no/ndla/validation/TagValidator.scala
+++ b/validation/src/main/scala/no/ndla/validation/TagValidator.scala
@@ -37,7 +37,7 @@ class TagValidator {
 
   }
 
-  def validateHtmlTag(fieldName: String, html: Element): Seq[ValidationMessage] = {
+  private def validateHtmlTag(fieldName: String, html: Element): Seq[ValidationMessage] = {
     val tagName = html.tagName
     if (!HtmlTagRules.isTagValid(tagName)) {
       return Seq.empty
@@ -54,8 +54,8 @@ class TagValidator {
       .map(missingAttributes =>
         ValidationMessage(
           fieldName,
-          s"$tagName must contain the following attributes: ${legalAttributesForTag.required.mkString(", ")}. " +
-            s"Optional attributes are: ${legalAttributesForTag.optional.mkString(", ")}. " +
+          s"$tagName must contain the following attributes: ${legalAttributesForTag.required.map(_.name).mkString(", ")}. " +
+            s"Optional attributes are: ${legalAttributesForTag.optional.map(_.name).mkString(", ")}. " +
             s"Missing: ${missingAttributes.mkString(", ")}"
         )
       )
@@ -96,30 +96,30 @@ class TagValidator {
 
   private def getRules(
       fieldName: String,
-      attributes: Map[TagAttributes.Value, String],
+      attributes: Map[TagAttribute, String],
       requiredToOptional: Map[String, Seq[String]]
   ): Either[ValidationMessage, (ResourceType.Value, TagAttributeRules)] = {
     val attributeKeys = attributes.keySet
-    if (!attributeKeys.contains(TagAttributes.DataResource)) {
+    if (!attributeKeys.contains(TagAttribute.DataResource)) {
       return Left(
         ValidationMessage(
           fieldName,
-          s"$EmbedTagName tags must contain a ${TagAttributes.DataResource} attribute"
+          s"$EmbedTagName tags must contain a ${TagAttribute.DataResource} attribute"
         )
       )
     }
 
-    if (!ResourceType.all.contains(attributes(TagAttributes.DataResource))) {
+    if (!ResourceType.all.contains(attributes(TagAttribute.DataResource))) {
       return Left(
         ValidationMessage(
           fieldName,
-          s"The ${TagAttributes.DataResource} attribute can only contain one of the following values: ${ResourceType.all
+          s"The ${TagAttribute.DataResource} attribute can only contain one of the following values: ${ResourceType.all
               .mkString(", ")}"
         )
       )
     }
 
-    val resourceType = ResourceType.valueOf(attributes(TagAttributes.DataResource)).get
+    val resourceType = ResourceType.valueOf(attributes(TagAttribute.DataResource)).get
     val attributeRulesForTag = EmbedTagRules
       .attributesForResourceType(resourceType)
       .withOptionalRequired(requiredToOptional.getOrElse(resourceType.toString, Seq.empty))
@@ -160,7 +160,7 @@ class TagValidator {
 
   private def isSameEmbedType(embed: Element, n: Node): Boolean = {
     n.nodeName() == embed.tagName &&
-    n.attr(TagAttributes.DataResource.toString) == embed.attr(TagAttributes.DataResource.toString)
+    n.attr(TagAttribute.DataResource.toString) == embed.attr(TagAttribute.DataResource.toString)
   }
 
   /** Counts number of siblings that are next to the embed, with the same type.
@@ -232,11 +232,11 @@ class TagValidator {
 
   private def verifyRequiredOptional(
       fieldName: String,
-      attributes: Map[TagAttributes.Value, String],
+      attributes: Map[TagAttribute, String],
       resourceType: ResourceType.Value,
       attributeRulesForTag: TagAttributeRules
   ): Seq[ValidationMessage] = {
-    val legalOptionals              = attributeRulesForTag.optional.flatten.toSet
+    val legalOptionals              = attributeRulesForTag.optional.map(f => f.name)
     val legalOptionalAttributesUsed = attributes.keySet.intersect(legalOptionals)
 
     if (attributeRulesForTag.mustContainOptionalAttribute && legalOptionalAttributesUsed.isEmpty) {
@@ -251,7 +251,7 @@ class TagValidator {
     }
   }
 
-  def validateChildren(
+  private def validateChildren(
       fieldName: String,
       resourceType: ResourceType.Value,
       tagRules: TagAttributeRules,
@@ -295,7 +295,7 @@ class TagValidator {
 
     val illegalAttributesUsed: Set[String] = attributes.keySet.diff(legalAttributeKeys)
     val legalOptionalAttributesUsed =
-      attributes.keySet.intersect(legalAttributesForTag.optional.flatten.map(_.toString).toSet)
+      attributes.keySet.intersect(legalAttributesForTag.optional.map(_.name.entryName))
 
     val illegalTagsError = if (illegalAttributesUsed.nonEmpty) {
       List(
@@ -321,7 +321,7 @@ class TagValidator {
 
   private def attributesContainsNoHtml(
       fieldName: String,
-      attributes: Map[TagAttributes.Value, String]
+      attributes: Map[TagAttribute, String]
   ): Option[ValidationMessage] = {
     val attributesWithHtml = attributes.toList
       .filter { case (_, value) =>
@@ -346,9 +346,9 @@ class TagValidator {
       fieldName: String,
       attributeRulesForTag: TagAttributeRules,
       resourceType: ResourceType.Value,
-      attributes: Map[TagAttributes.Value, String]
+      attributes: Map[TagAttribute, String]
   ): Seq[ValidationMessage] = {
-    val partialErrorMessage = s"An $EmbedTagName HTML tag with ${TagAttributes.DataResource}=$resourceType"
+    val partialErrorMessage = s"An $EmbedTagName HTML tag with ${TagAttribute.DataResource}=$resourceType"
 
     verifyEmbedTagBasedOnResourceType(fieldName, attributeRulesForTag, attributes, resourceType) ++
       verifyOptionals(fieldName, attributeRulesForTag, attributes.keySet, partialErrorMessage) ++
@@ -358,21 +358,21 @@ class TagValidator {
   private def verifyEmbedTagBasedOnResourceType(
       fieldName: String,
       attrRules: TagAttributeRules,
-      actualAttributes: Map[TagAttributes.Value, String],
+      actualAttributes: Map[TagAttribute, String],
       resourceType: ResourceType.Value
   ): Seq[ValidationMessage] = {
-    val requiredAttrs     = attrRules.required ++ attrRules.requiredNonEmpty
+    val requiredAttrs     = attrRules.required
     val missingAttributes = getMissingAttributes(requiredAttrs, actualAttributes.keySet)
-    val illegalAttributes = getMissingAttributes(actualAttributes.keySet, attrRules.all)
+    val illegalAttributes = getIllegalAttributes(actualAttributes.keySet, attrRules.fields)
 
-    val partialErrorMessage = s"An $EmbedTagName HTML tag with ${TagAttributes.DataResource}=$resourceType"
+    val partialErrorMessage = s"An $EmbedTagName HTML tag with ${TagAttribute.DataResource}=$resourceType"
 
     val missingErrors = missingAttributes
       .map(missingAttributes =>
         ValidationMessage(
           fieldName,
-          s"$partialErrorMessage must contain the following attributes: ${requiredAttrs.mkString(", ")}. " +
-            s"Optional attributes are: ${attrRules.optional.mkString(", ")}. " +
+          s"$partialErrorMessage must contain the following attributes: ${requiredAttrs.map(_.name).mkString(", ")}. " +
+            s"Optional attributes are: ${attrRules.optional.map(_.name).mkString(", ")}. " +
             s"Missing: ${missingAttributes.mkString(", ")}"
         )
       )
@@ -387,11 +387,11 @@ class TagValidator {
       )
 
     val requiredNonEmptyErrors = actualAttributes.flatMap { case (a, b) =>
-      if (attrRules.requiredNonEmpty.contains(a) && b.isEmpty) {
+      if (requiredAttrs.filter(f => !f.validation.nullable).map(_.name).contains(a) && b.isEmpty) {
         Some(
           ValidationMessage(
             fieldName,
-            s"$partialErrorMessage must contain non-empty attributes: ${attrRules.requiredNonEmpty.mkString(", ")}."
+            s"$partialErrorMessage must contain non-empty attributes: ${attrRules.requiredNonEmpty.map(_.name).mkString(", ")}."
           )
         )
       } else { None }
@@ -403,48 +403,43 @@ class TagValidator {
   private def verifyOptionals(
       fieldName: String,
       attrsRules: TagAttributeRules,
-      actualAttributes: Set[TagAttributes.Value],
+      actualAttributes: Set[TagAttribute],
       partialErrorMessage: String
   ): Seq[ValidationMessage] = {
-    val usedOptionalAttr = actualAttributes.intersect(attrsRules.optional.flatten.toSet)
-    val fullMatchGroups = attrsRules.optional.filter(optSet => {
-      val usedFromOptSet = optSet.intersect(usedOptionalAttr)
-      val isFullMatch    = usedFromOptSet.size == optSet.size
-      isFullMatch
-    })
+    val usedOptionalFields = attrsRules.optional.filter(f => actualAttributes.contains(f.name))
+    val neededOptionals    = usedOptionalFields.flatMap(f => f.validation.mustCoexistWith)
+    val missingOptionals   = neededOptionals.diff(actualAttributes)
 
-    val allMatchedTags = fullMatchGroups.flatten.toSet
-    val unmatchedTags  = usedOptionalAttr.diff(allMatchedTags)
-
-    buildUnmatchedErrors(fieldName, unmatchedTags, attrsRules, partialErrorMessage)
+    buildUnmatchedErrors(fieldName, missingOptionals, usedOptionalFields.map(f => f.name), attrsRules, partialErrorMessage)
   }
 
   private def buildUnmatchedErrors(
-      fieldName: String,
-      unmatchedTags: Set[TagAttributes.Value],
-      attrsRules: TagAttributeRules,
-      partialErrorMessage: String
+                                    fieldName: String,
+                                    missingTags: Set[TagAttribute],
+                                    usedOptionals: Set[TagAttribute],
+                                    attrsRules: TagAttributeRules,
+                                    partialErrorMessage: String
   ): Seq[ValidationMessage] =
-    if (unmatchedTags.isEmpty) { Seq.empty }
+    if (missingTags.isEmpty) { Seq.empty }
     else {
-      unmatchedTags.toSeq.map(tag => {
-        val groupsWithTag = attrsRules.optional.filter(_.contains(tag))
-        val groupErrors   = groupsWithTag.map(x => s"[${x.mkString(",")}] (Missing: $unmatchedTags)")
+      missingTags.toSeq.map(tag => {
+        val optionalField = attrsRules.optional.filter(_.name.eq(tag))
+        val optionGroup   = optionalField.flatMap(f => f.validation.mustCoexistWith :+ f.name)
+        val groupErrors   = s"${optionGroup.mkString(",")} (Missing: ${optionGroup.diff(usedOptionals).mkString(",")})"
         ValidationMessage(
           fieldName,
-          s"$partialErrorMessage must contain all or none of the attributes in the optional attribute groups: (${groupErrors
-              .mkString(", ")})"
+          s"$partialErrorMessage must contain all or none of the attributes in the optional attribute group: (${groupErrors})"
         )
-      })
+      }).distinct
     }
 
   private def verifySourceUrl(
       fieldName: String,
       attrs: TagAttributeRules,
-      usedAttributes: Map[TagAttributes.Value, String],
+      usedAttributes: Map[TagAttribute, String],
       resourceType: ResourceType.Value
   ): Seq[ValidationMessage] = {
-    (usedAttributes.get(TagAttributes.DataUrl), attrs.validSrcDomains) match {
+    (usedAttributes.get(TagAttribute.DataUrl), attrs.validUrlDomains) match {
       case (Some(url), Some(sourceDomains)) =>
         val urlHost               = url.hostOption.map(_.toString).getOrElse("")
         val urlMatchesValidDomain = sourceDomains.exists(domain => urlHost.matches(domain))
@@ -454,7 +449,7 @@ class TagValidator {
           Seq(
             ValidationMessage(
               fieldName,
-              s"An $EmbedTagName HTML tag with ${TagAttributes.DataResource}=$resourceType can only contain ${TagAttributes.DataUrl} urls from the following domains: ${attrs.validSrcDomains
+              s"An $EmbedTagName HTML tag with ${TagAttribute.DataResource}=$resourceType can only contain ${TagAttribute.DataUrl} urls from the following domains: ${attrs.validUrlDomains
                   .mkString(", ")}"
             )
           )
@@ -463,23 +458,31 @@ class TagValidator {
   }
 
   private def getMissingAttributes(
-      requiredAttributes: Set[TagAttributes.Value],
-      attributeKeys: Set[TagAttributes.Value]
-  ) = {
-    val missing = requiredAttributes diff attributeKeys
+      requiredAttributes: Set[TagRules.Field],
+      attributeKeys: Set[TagAttribute]
+  ): Option[Set[TagAttribute]] = {
+    val missing = requiredAttributes.map(_.name) diff attributeKeys
     missing.headOption.map(_ => missing)
+  }
+
+  private def getIllegalAttributes(
+      usedAttributes: Set[TagAttribute],
+      legalFields: Set[TagRules.Field]
+  ): Option[Set[TagAttribute]] = {
+    val illegal = usedAttributes.filterNot(legalFields.map(f => f.name))
+    if (illegal.isEmpty) None else Some(illegal)
   }
 
   private def getLegalAttributesUsed(
       allAttributes: Map[String, String],
       tagName: String
-  ): Map[TagAttributes.Value, String] = {
+  ): Map[TagAttribute, String] = {
     val legalAttributeKeys = HtmlTagRules.legalAttributesForTag(tagName)
 
     allAttributes
       .filter { case (key, _) => legalAttributeKeys.contains(key) }
       .map { case (key, value) =>
-        TagAttributes.valueOf(key).getOrElse(TagAttributes.getOrCreate(key)) -> value
+        TagAttribute.withName(key) -> value
       }
   }
 

--- a/validation/src/main/scala/no/ndla/validation/TagValidator.scala
+++ b/validation/src/main/scala/no/ndla/validation/TagValidator.scala
@@ -389,7 +389,7 @@ object TagValidator {
       )
 
     val requiredNonEmptyErrors = actualAttributes.flatMap { case (a, b) =>
-      if (requiredAttrs.filter(f => !f.validation.nullable).map(_.name).contains(a) && b.isEmpty) {
+      if (requiredAttrs.filter(f => !f.validation.allowEmpty).map(_.name).contains(a) && b.isEmpty) {
         Some(
           ValidationMessage(
             fieldName,

--- a/validation/src/main/scala/no/ndla/validation/TagValidator.scala
+++ b/validation/src/main/scala/no/ndla/validation/TagValidator.scala
@@ -17,7 +17,7 @@ import org.jsoup.nodes.{Element, Node}
 import scala.jdk.CollectionConverters._
 import scala.util.{Success, Try}
 
-class TagValidator {
+object TagValidator {
 
   def validate(
       fieldName: String,
@@ -34,7 +34,6 @@ class TagValidator {
         else validateHtmlTag(fieldName, tag)
       })
       .toList
-
   }
 
   private def validateHtmlTag(fieldName: String, html: Element): Seq[ValidationMessage] = {
@@ -328,9 +327,7 @@ class TagValidator {
       .filter { case (attribute, value) =>
         attributeRulesForTag
           .field(attribute)
-          .exists(field =>
-            new TextValidator().validate(attribute.toString, value, field.validation.allowedHtml).nonEmpty
-          )
+          .exists(field => TextValidator.validate(attribute.toString, value, field.validation.allowedHtml).nonEmpty)
       }
       .toMap
       .keySet
@@ -440,7 +437,7 @@ class TagValidator {
           val groupErrors = s"${optionGroup.mkString(",")} (Missing: ${optionGroup.diff(usedOptionals).mkString(",")})"
           ValidationMessage(
             fieldName,
-            s"$partialErrorMessage must contain all or none of the attributes in the optional attribute group: (${groupErrors})"
+            s"$partialErrorMessage must contain all or none of the attributes in the optional attribute group: ($groupErrors)"
           )
         })
         .distinct

--- a/validation/src/main/scala/no/ndla/validation/TextValidator.scala
+++ b/validation/src/main/scala/no/ndla/validation/TextValidator.scala
@@ -35,7 +35,7 @@ object TextValidator {
   def validate(
       fieldPath: String,
       text: String,
-      allowedTags: Set[_ <: String],
+      allowedTags: Set[String],
       requiredToOptional: Map[String, Seq[String]] = Map.empty
   ): Seq[ValidationMessage] = {
     if (allowedTags.isEmpty) {
@@ -48,7 +48,7 @@ object TextValidator {
   def validateVisualElement(
       fieldPath: String,
       text: String,
-      allowedTags: Set[_ <: String] = HtmlTagRules.allLegalTags,
+      allowedTags: Set[String] = HtmlTagRules.allLegalTags,
       requiredToOptional: Map[String, Seq[String]] = Map.empty
   ): Seq[ValidationMessage] = {
 
@@ -73,7 +73,7 @@ object TextValidator {
       fieldPath: String,
       text: String,
       requiredToOptional: Map[String, Seq[String]],
-      allowedTags: Set[_ <: String]
+      allowedTags: Set[String]
   ): Seq[ValidationMessage] = {
 
     val whiteList = new Safelist().addTags(allowedTags.toSeq: _*)

--- a/validation/src/main/scala/no/ndla/validation/TextValidator.scala
+++ b/validation/src/main/scala/no/ndla/validation/TextValidator.scala
@@ -14,11 +14,10 @@ import org.jsoup.safety.Safelist
 
 import scala.jdk.CollectionConverters.IteratorHasAsScala
 
-class TextValidator {
-  private def IllegalContentInBasicText = "The content contains illegal tags and/or attributes. Allowed HTML tags are:"
+object TextValidator {
+  private val IllegalContentInBasicText = "The content contains illegal tags and/or attributes. Allowed HTML tags are:"
   private val IllegalContentInPlainText = "The content contains illegal html-characters. No HTML is allowed"
   private val FieldEmpty                = "Required field is empty"
-  private val TagValidator              = new TagValidator
 
   /** Validates text Will validate legal html tags if html is allowed.
     *

--- a/validation/src/main/scala/no/ndla/validation/ValidationRules.scala
+++ b/validation/src/main/scala/no/ndla/validation/ValidationRules.scala
@@ -1,4 +1,5 @@
 package no.ndla.validation
+import org.json4s.DefaultFormats
 import org.json4s.native.JsonMethods.parse
 
 import scala.io.Source
@@ -10,7 +11,7 @@ object ValidationRules {
   def mathMLRulesJson: Map[String, Any]   = convertJsonStr(Source.fromResource("mathml-rules.json").mkString)
 
   private def convertJsonStr(jsonStr: String): Map[String, Any] = {
-    implicit val formats = org.json4s.DefaultFormats
+    implicit val formats: DefaultFormats.type = org.json4s.DefaultFormats
     parse(jsonStr).extract[Map[String, Any]]
   }
 

--- a/validation/src/test/scala/no/ndla/validation/EmbedTagRulesTest.scala
+++ b/validation/src/test/scala/no/ndla/validation/EmbedTagRulesTest.scala
@@ -57,7 +57,7 @@ class EmbedTagRulesTest extends UnitSuite {
     )
   }
 
-  test("Not nullable fields should not be allowed to be empty-strings") {
+  test("Fields with allowEmpty=false should not be allowed to be empty") {
     val embedString =
       s"""<$EmbedTagName
         | data-resource="image"

--- a/validation/src/test/scala/no/ndla/validation/EmbedTagRulesTest.scala
+++ b/validation/src/test/scala/no/ndla/validation/EmbedTagRulesTest.scala
@@ -18,14 +18,19 @@ class EmbedTagRulesTest extends UnitSuite {
     val resourceTypesFromConfigFile      = EmbedTagRules.attributeRules.keys
     val resourceTypesFromEnumDeclaration = ResourceType.values
 
-    resourceTypesFromEnumDeclaration should equal(resourceTypesFromConfigFile)
+    resourceTypesFromEnumDeclaration.foreach(rt => {
+        resourceTypesFromConfigFile.should(contain(rt))
+      }
+    )
   }
 
   test("data-resource should be required for all resource types") {
     val resourceTypesFromConfigFile = EmbedTagRules.attributeRules.keys
 
     resourceTypesFromConfigFile.foreach(resType =>
-      EmbedTagRules.attributesForResourceType(resType).required.map(f => f.name) should contain(TagAttribute.DataResource)
+      EmbedTagRules.attributesForResourceType(resType).required.map(f => f.name) should contain(
+        TagAttribute.DataResource
+      )
     )
   }
 

--- a/validation/src/test/scala/no/ndla/validation/EmbedTagRulesTest.scala
+++ b/validation/src/test/scala/no/ndla/validation/EmbedTagRulesTest.scala
@@ -9,7 +9,6 @@ package no.ndla.validation
 
 import no.ndla.common.configuration.Constants.EmbedTagName
 import no.ndla.common.errors.ValidationMessage
-import no.ndla.mapping.UnitSuite
 import no.ndla.validation.TagRules.Condition
 
 class EmbedTagRulesTest extends UnitSuite {
@@ -34,18 +33,17 @@ class EmbedTagRulesTest extends UnitSuite {
   }
 
   test("Every mustBeDirectChildOf -> condition block must be valid") {
-    val embedTagValidator = new TagValidator()
 
     EmbedTagRules.attributeRules.flatMap { case (tag, rule) =>
       rule.mustBeDirectChildOf.flatMap(parentRule => {
         parentRule.conditions.map(c => {
-          val res = embedTagValidator.checkParentConditions(tag.toString, c, 1)
+          val res = TagValidator.checkParentConditions(tag.toString, c, 1)
           res.isRight should be(true)
         })
       })
     }
 
-    val result1 = embedTagValidator.checkParentConditions("test", Condition("apekatt=2"), 3)
+    val result1 = TagValidator.checkParentConditions("test", Condition("apekatt=2"), 3)
     result1 should be(
       Left(
         Seq(
@@ -69,9 +67,8 @@ class EmbedTagRulesTest extends UnitSuite {
         | data-alt=""
         | data-caption=""
         |/>""".stripMargin
-    val embedTagValidator = new TagValidator()
 
-    val result = embedTagValidator.validate("test", embedString)
+    val result = TagValidator.validate("test", embedString)
     result should be(
       Seq(
         ValidationMessage(
@@ -90,9 +87,8 @@ class EmbedTagRulesTest extends UnitSuite {
          | data-type="external"
          | data-title="Youtube-video"
          |/>""".stripMargin
-    val embedTagValidator = new TagValidator()
 
-    val result = embedTagValidator.validate("test", embedString)
+    val result = TagValidator.validate("test", embedString)
     result should be(
       Seq.empty
     )
@@ -107,9 +103,8 @@ class EmbedTagRulesTest extends UnitSuite {
          | data-title="Youtube-video"
          | data-imageid="123"
          |/>""".stripMargin
-    val embedTagValidator = new TagValidator()
 
-    val result = embedTagValidator.validate("test", embedString)
+    val result = TagValidator.validate("test", embedString)
     result should be(
       Seq(
         ValidationMessage(
@@ -130,9 +125,8 @@ class EmbedTagRulesTest extends UnitSuite {
          | data-alt=""
          | data-caption="Bilde på <span lang='en'>engelsk</span>"
          |/>""".stripMargin
-    val embedTagValidator = new TagValidator()
 
-    val result = embedTagValidator.validate("test", embedString)
+    val result = TagValidator.validate("test", embedString)
     result should be(
       Seq(
         ValidationMessage(
@@ -151,9 +145,8 @@ class EmbedTagRulesTest extends UnitSuite {
          | data-title="Hva skjer hos <span lang='en'>NDLA</span>"
          | data-url="https://ndla.no"
          |/>""".stripMargin
-    val embedTagValidator = new TagValidator()
 
-    val result = embedTagValidator.validate("test", embedString)
+    val result = TagValidator.validate("test", embedString)
     result should be(
       Seq.empty
     )

--- a/validation/src/test/scala/no/ndla/validation/EmbedTagRulesTest.scala
+++ b/validation/src/test/scala/no/ndla/validation/EmbedTagRulesTest.scala
@@ -12,9 +12,6 @@ import no.ndla.common.errors.ValidationMessage
 import no.ndla.mapping.UnitSuite
 import no.ndla.validation.TagRules.Condition
 
-import scala.{Seq, collection}
-import scala.collection.immutable
-
 class EmbedTagRulesTest extends UnitSuite {
 
   test("Rules for all resource types should be defined") {

--- a/validation/src/test/scala/no/ndla/validation/EmbedTagRulesTest.scala
+++ b/validation/src/test/scala/no/ndla/validation/EmbedTagRulesTest.scala
@@ -57,7 +57,7 @@ class EmbedTagRulesTest extends UnitSuite {
     )
   }
 
-  test("RequiredNonEmpty fields should not be allowed to be empty-strings") {
+  test("Not nullable fields should not be allowed to be empty-strings") {
     val embedString =
       s"""<$EmbedTagName
         | data-resource="image"

--- a/validation/src/test/scala/no/ndla/validation/EmbedTagValidatorTest.scala
+++ b/validation/src/test/scala/no/ndla/validation/EmbedTagValidatorTest.scala
@@ -55,7 +55,7 @@ class EmbedTagValidatorTest extends UnitSuite {
       Map(
         TagAttribute.DataResource.toString -> ResourceType.ExternalContent.toString,
         TagAttribute.DataUrl.toString      -> "google.com",
-        "illegalattr"                       -> "test"
+        "illegalattr"                      -> "test"
       )
     )
 

--- a/validation/src/test/scala/no/ndla/validation/EmbedTagValidatorTest.scala
+++ b/validation/src/test/scala/no/ndla/validation/EmbedTagValidatorTest.scala
@@ -9,13 +9,11 @@ package no.ndla.validation
 
 import no.ndla.common.configuration.Constants.EmbedTagName
 import no.ndla.common.errors.ValidationMessage
-import no.ndla.mapping.UnitSuite
 import no.ndla.validation.TagRules.Condition
 
 class EmbedTagValidatorTest extends UnitSuite {
-  val embedTagValidator = new TagValidator()
 
-  private def childCountValidationMessage(fieldName: String) =
+  private def childCountValidationMessage(fieldName: String): Seq[ValidationMessage] =
     Seq(
       ValidationMessage(
         fieldName,
@@ -38,15 +36,18 @@ class EmbedTagValidatorTest extends UnitSuite {
     s"""<$EmbedTagName ${generateAttributes(strAttrs)}>$children</$EmbedTagName>"""
   }
 
-  private def findErrorByMessage(validationMessages: Seq[ValidationMessage], partialMessage: String) =
+  private def findErrorByMessage(
+      validationMessages: Seq[ValidationMessage],
+      partialMessage: String
+  ): Option[ValidationMessage] =
     validationMessages.find(_.message.contains(partialMessage))
 
   test("validate should return an empty sequence if input is not an embed tag or an html tag with attributes") {
-    embedTagValidator.validate("content", "<h1>hello</h1>") should equal(Seq())
+    TagValidator.validate("content", "<h1>hello</h1>") should equal(Seq())
   }
 
   test("validate should return a validation error if input is a html tag with that should not have attributes") {
-    val res = embedTagValidator.validate("content", "<h1 test='test'>hello</h1>")
+    val res = TagValidator.validate("content", "<h1 test='test'>hello</h1>")
     findErrorByMessage(res, "An HTML tag 'h1' contains an illegal attribute(s) 'test'.").size should be(1)
   }
 
@@ -59,7 +60,7 @@ class EmbedTagValidatorTest extends UnitSuite {
       )
     )
 
-    val res = embedTagValidator.validate("content", s"""<$EmbedTagName $attrs />""")
+    val res = TagValidator.validate("content", s"""<$EmbedTagName $attrs />""")
     findErrorByMessage(res, "illegal attribute(s) 'illegalattr'").size should be(1)
   }
 
@@ -70,7 +71,7 @@ class EmbedTagValidatorTest extends UnitSuite {
         TagAttribute.DataUrl      -> "<i>google.com</i>"
       )
     )
-    val res = embedTagValidator.validate("content", tag)
+    val res = TagValidator.validate("content", tag)
     findErrorByMessage(res, "contains attributes with HTML: data-url").size should be(1)
   }
 
@@ -78,7 +79,7 @@ class EmbedTagValidatorTest extends UnitSuite {
     "validate should return validation error if embed tag does not contain required attributes for data-resource=image"
   ) {
     val tag = generateTagWithAttrs(Map(TagAttribute.DataResource -> ResourceType.Image.toString))
-    val res = embedTagValidator.validate("content", tag)
+    val res = TagValidator.validate("content", tag)
     findErrorByMessage(
       res,
       s"data-resource=${ResourceType.Image} must contain the following attributes:"
@@ -95,7 +96,7 @@ class EmbedTagValidatorTest extends UnitSuite {
         TagAttribute.DataAlt         -> "alttext"
       )
     )
-    val res = embedTagValidator.validate(
+    val res = TagValidator.validate(
       "content",
       tag,
       requiredToOptional = Map("image" -> Seq(TagAttribute.DataCaption.toString))
@@ -114,14 +115,14 @@ class EmbedTagValidatorTest extends UnitSuite {
         TagAttribute.DataAlign       -> "left"
       )
     )
-    embedTagValidator.validate("content", tag).size should be(0)
+    TagValidator.validate("content", tag).size should be(0)
   }
 
   test(
     "validate should return validation error if embed tag does not contain required attributes for data-resource=audio"
   ) {
     val tag = generateTagWithAttrs(Map(TagAttribute.DataResource -> ResourceType.Audio.toString))
-    val res = embedTagValidator.validate("content", tag)
+    val res = TagValidator.validate("content", tag)
     findErrorByMessage(
       res,
       s"data-resource=${ResourceType.Audio} must contain the following attributes:"
@@ -137,14 +138,14 @@ class EmbedTagValidatorTest extends UnitSuite {
         TagAttribute.DataType        -> "standard"
       )
     )
-    embedTagValidator.validate("content", tag).size should be(0)
+    TagValidator.validate("content", tag).size should be(0)
   }
 
   test(
     "validate should return validation error if embed tag does not contain required attributes for data-resource=h5p"
   ) {
     val tag = generateTagWithAttrs(Map(TagAttribute.DataResource -> ResourceType.H5P.toString))
-    val res = embedTagValidator.validate("content", tag)
+    val res = TagValidator.validate("content", tag)
     findErrorByMessage(res, s"data-resource=${ResourceType.H5P} must contain the following attributes:").size should be(
       1
     )
@@ -157,7 +158,7 @@ class EmbedTagValidatorTest extends UnitSuite {
         TagAttribute.DataPath     -> "/h5p/embed/1234"
       )
     )
-    val t = embedTagValidator.validate("content", tag)
+    val t = TagValidator.validate("content", tag)
     t.size should be(0)
   }
 
@@ -165,7 +166,7 @@ class EmbedTagValidatorTest extends UnitSuite {
     "validate should return validation error if embed tag does not contain required attributes for data-resource=brightcove"
   ) {
     val tag = generateTagWithAttrs(Map(TagAttribute.DataResource -> ResourceType.Brightcove.toString))
-    val res = embedTagValidator.validate("content", tag)
+    val res = TagValidator.validate("content", tag)
     findErrorByMessage(
       res,
       s"data-resource=${ResourceType.Brightcove} must contain the following attributes:"
@@ -182,14 +183,14 @@ class EmbedTagValidatorTest extends UnitSuite {
         TagAttribute.DataPlayer   -> "B28fas"
       )
     )
-    embedTagValidator.validate("content", tag).size should be(0)
+    TagValidator.validate("content", tag).size should be(0)
   }
 
   test(
     "validate should return validation error if embed tag does not contain required attributes for data-resource=content-link"
   ) {
     val tag = generateTagWithAttrs(Map(TagAttribute.DataResource -> ResourceType.ContentLink.toString))
-    val res = embedTagValidator.validate("content", tag)
+    val res = TagValidator.validate("content", tag)
     findErrorByMessage(
       res,
       s"data-resource=${ResourceType.ContentLink} must contain the following attributes:"
@@ -205,7 +206,7 @@ class EmbedTagValidatorTest extends UnitSuite {
       ),
       "interesting article"
     )
-    embedTagValidator.validate("content", tag).size should be(0)
+    TagValidator.validate("content", tag).size should be(0)
   }
 
   test("validate should return validation errors if content-link embed-tag is used incorrectly") {
@@ -216,7 +217,7 @@ class EmbedTagValidatorTest extends UnitSuite {
         TagAttribute.DataOpenIn    -> "new-context"
       )
     )
-    embedTagValidator.validate("content", tag).size should be(1)
+    TagValidator.validate("content", tag).size should be(1)
   }
 
   test("validate should return allow valid children for content-link") {
@@ -228,7 +229,7 @@ class EmbedTagValidatorTest extends UnitSuite {
       ),
       "<strong>Apekatt</strong> er kult"
     )
-    embedTagValidator.validate("content", tag).size should be(0)
+    TagValidator.validate("content", tag).size should be(0)
   }
 
   test("validate should return validation errors if content-link has invalid children") {
@@ -240,14 +241,14 @@ class EmbedTagValidatorTest extends UnitSuite {
       ),
       "<div><strong>Apekatt</strong> er kult</div>"
     )
-    embedTagValidator.validate("content", tag).size should be(1)
+    TagValidator.validate("content", tag).size should be(1)
   }
 
   test(
     "validate should return validation error if embed tag does not contain required attributes for data-resource=error"
   ) {
     val tag = generateTagWithAttrs(Map(TagAttribute.DataResource -> ResourceType.Error.toString))
-    val res = embedTagValidator.validate("content", tag)
+    val res = TagValidator.validate("content", tag)
     findErrorByMessage(
       res,
       s"data-resource=${ResourceType.Error} must contain the following attributes:"
@@ -258,14 +259,14 @@ class EmbedTagValidatorTest extends UnitSuite {
     val tag = generateTagWithAttrs(
       Map(TagAttribute.DataResource -> ResourceType.Error.toString, TagAttribute.DataMessage -> "interesting article")
     )
-    embedTagValidator.validate("content", tag).size should be(0)
+    TagValidator.validate("content", tag).size should be(0)
   }
 
   test(
     "validate should return validation error if embed tag does not contain required attributes for data-resource=external"
   ) {
     val tag = generateTagWithAttrs(Map(TagAttribute.DataResource -> ResourceType.ExternalContent.toString))
-    val res = embedTagValidator.validate("content", tag)
+    val res = TagValidator.validate("content", tag)
     findErrorByMessage(
       res,
       s"data-resource=${ResourceType.ExternalContent} must contain the following attributes:"
@@ -280,14 +281,14 @@ class EmbedTagValidatorTest extends UnitSuite {
         TagAttribute.DataType     -> "iframe"
       )
     )
-    embedTagValidator.validate("content", tag).size should be(0)
+    TagValidator.validate("content", tag).size should be(0)
   }
 
   test(
     "validate should return validation error if embed tag does not contain required attributes for data-resource=nrk"
   ) {
     val tag = generateTagWithAttrs(Map(TagAttribute.DataResource -> ResourceType.NRKContent.toString))
-    val res = embedTagValidator.validate("content", tag)
+    val res = TagValidator.validate("content", tag)
     findErrorByMessage(
       res,
       s"data-resource=${ResourceType.NRKContent} must contain the following attributes:"
@@ -302,7 +303,7 @@ class EmbedTagValidatorTest extends UnitSuite {
         TagAttribute.DataUrl        -> "http://nrk.no/video/123"
       )
     )
-    embedTagValidator.validate("content", tag).size should be(0)
+    TagValidator.validate("content", tag).size should be(0)
   }
 
   test(
@@ -314,7 +315,7 @@ class EmbedTagValidatorTest extends UnitSuite {
         TagAttribute.DataTag      -> "Liste::"
       )
     )
-    val res = embedTagValidator.validate("content", tag)
+    val res = TagValidator.validate("content", tag)
     findErrorByMessage(
       res,
       s"data-resource=${ResourceType.ConceptList} must contain all or none of the attributes in the optional attribute group"
@@ -326,7 +327,7 @@ class EmbedTagValidatorTest extends UnitSuite {
         TagAttribute.DataResource_Id -> "1"
       )
     )
-    val res2 = embedTagValidator.validate("content", tag2)
+    val res2 = TagValidator.validate("content", tag2)
     findErrorByMessage(
       res2,
       s"data-resource=${ResourceType.ConceptList} must contain all or none of the attributes in the optional attribute group"
@@ -343,7 +344,7 @@ class EmbedTagValidatorTest extends UnitSuite {
         TagAttribute.DataSubjectId -> "urn:subject:123"
       )
     )
-    embedTagValidator.validate("content", tag).size should be(0)
+    TagValidator.validate("content", tag).size should be(0)
 
     val tag2 = generateTagWithAttrs(
       Map(
@@ -352,7 +353,7 @@ class EmbedTagValidatorTest extends UnitSuite {
         TagAttribute.DataTag      -> "Liste:kategori:kategori2"
       )
     )
-    embedTagValidator.validate("content", tag2).size should be(0)
+    TagValidator.validate("content", tag2).size should be(0)
 
     val tag3 = generateTagWithAttrs(
       Map(
@@ -361,7 +362,7 @@ class EmbedTagValidatorTest extends UnitSuite {
         TagAttribute.DataRecursive   -> "false"
       )
     )
-    embedTagValidator.validate("content", tag3).size should be(0)
+    TagValidator.validate("content", tag3).size should be(0)
   }
 
   test("validate should fail if only one optional attribute is specified") {
@@ -377,7 +378,7 @@ class EmbedTagValidatorTest extends UnitSuite {
         TagAttribute.DataFocalX      -> "0"
       )
     )
-    val messages = embedTagValidator.validate("content", tag)
+    val messages = TagValidator.validate("content", tag)
     messages.size should be(2)
   }
 
@@ -400,7 +401,7 @@ class EmbedTagValidatorTest extends UnitSuite {
       )
     )
 
-    embedTagValidator.validate("content", tag).size should be(0)
+    TagValidator.validate("content", tag).size should be(0)
   }
 
   test("validate should succeed if all attributes in an attribute group are specified") {
@@ -417,7 +418,7 @@ class EmbedTagValidatorTest extends UnitSuite {
       )
     )
 
-    embedTagValidator.validate("content", tagWithFocal).size should be(0)
+    TagValidator.validate("content", tagWithFocal).size should be(0)
 
     val tagWithCrop = generateTagWithAttrs(
       Map(
@@ -435,7 +436,7 @@ class EmbedTagValidatorTest extends UnitSuite {
       )
     )
 
-    embedTagValidator.validate("content", tagWithCrop).size should be(0)
+    TagValidator.validate("content", tagWithCrop).size should be(0)
 
     val tagWithDecor = generateTagWithAttrs(
       Map(
@@ -449,7 +450,7 @@ class EmbedTagValidatorTest extends UnitSuite {
       )
     )
 
-    embedTagValidator.validate("content", tagWithDecor).size should be(0)
+    TagValidator.validate("content", tagWithDecor).size should be(0)
   }
 
   test("validate should succeed if source url is from a legal domain") {
@@ -462,7 +463,7 @@ class EmbedTagValidatorTest extends UnitSuite {
         TagAttribute.DataHeight   -> "1"
       )
     )
-    embedTagValidator.validate("content", tag).size should be(0)
+    TagValidator.validate("content", tag).size should be(0)
 
     val tag2 = generateTagWithAttrs(
       Map(
@@ -473,7 +474,7 @@ class EmbedTagValidatorTest extends UnitSuite {
         TagAttribute.DataHeight   -> "1"
       )
     )
-    embedTagValidator.validate("content", tag2).size should be(0)
+    TagValidator.validate("content", tag2).size should be(0)
   }
 
   test("validate should fail if source url is from an illlegal domain") {
@@ -487,7 +488,7 @@ class EmbedTagValidatorTest extends UnitSuite {
       )
     )
 
-    val result = embedTagValidator.validate("content", tag)
+    val result = TagValidator.validate("content", tag)
     result.size should be(1)
     result.head.message
       .contains(s"can only contain ${TagAttribute.DataUrl} urls from the following domains:") should be(true)
@@ -504,16 +505,16 @@ class EmbedTagValidatorTest extends UnitSuite {
       )
     )
 
-    embedTagValidator.validate("content", tag).size should be(0)
+    TagValidator.validate("content", tag).size should be(0)
   }
 
   test("validate should not return validation errors if lang attribute is present") {
-    val res = embedTagValidator.validate("content", "<span lang='nb'>test</span>")
+    val res = TagValidator.validate("content", "<span lang='nb'>test</span>")
     res.size should be(0)
   }
 
   test("validate should not return validation errors if lang attribute is present dd") {
-    val res = embedTagValidator.validate("content", "<span test='nb'>test</span>")
+    val res = TagValidator.validate("content", "<span test='nb'>test</span>")
     res.size should equal(2)
     findErrorByMessage(
       res,
@@ -522,7 +523,7 @@ class EmbedTagValidatorTest extends UnitSuite {
   }
 
   test("validate should return not return validation errors if colspan is present on th or td") {
-    val res = embedTagValidator.validate(
+    val res = TagValidator.validate(
       "content",
       "<table><thead><tr><th colspan=\"2\">Hei</th></tr></thead><tbody><tr><td>Hei</td><td>Hå</td></tr></tbody></table>"
     )
@@ -530,7 +531,7 @@ class EmbedTagValidatorTest extends UnitSuite {
   }
 
   test("validate should return error if span does not have any attributes") {
-    val res = embedTagValidator.validate("content", "<span>lorem ipsum</span>")
+    val res = TagValidator.validate("content", "<span>lorem ipsum</span>")
     res.size should equal(1)
   }
 
@@ -541,16 +542,16 @@ class EmbedTagValidatorTest extends UnitSuite {
     val invalidRelatedArticle = s"""<$EmbedTagName data-resource="related-content" data-url="http://example.com" />"""
     val emptyAndInvalidEmbed  = s"""<$EmbedTagName data-resource="related-content" />"""
 
-    val res = embedTagValidator.validate(
+    val res = TagValidator.validate(
       "content",
       s"""<div data-type="related-content">$validRelatedExternalEmbed$validRelatedArticle</div>"""
     )
     res.size should be(0)
     val res2 =
-      embedTagValidator.validate("content", s"""<div data-type="related-content">$invalidRelatedArticle</div>""")
+      TagValidator.validate("content", s"""<div data-type="related-content">$invalidRelatedArticle</div>""")
     res2.size should be(1)
     val res3 =
-      embedTagValidator.validate("content", s"""<div data-type="related-content">$emptyAndInvalidEmbed</div>""")
+      TagValidator.validate("content", s"""<div data-type="related-content">$emptyAndInvalidEmbed</div>""")
     res3.size should be(1)
   }
 
@@ -558,18 +559,18 @@ class EmbedTagValidatorTest extends UnitSuite {
     val validRelatedExternalEmbed =
       s"""<$EmbedTagName data-resource="related-content" data-url="http://example.com" data-title="Eksempel tittel right here, yo" />"""
 
-    val res = embedTagValidator.validate("content", s"""<div>$validRelatedExternalEmbed</div>""")
+    val res = TagValidator.validate("content", s"""<div>$validRelatedExternalEmbed</div>""")
     res.size should be(1)
     res.head.message should be(
       """Embed tag with 'related-content' requires a parent 'div', with attributes: 'data-type="related-content"'"""
     )
-    val res2 = embedTagValidator.validate("content", s"""$validRelatedExternalEmbed""")
+    val res2 = TagValidator.validate("content", s"""$validRelatedExternalEmbed""")
     res2.size should be(1)
     res2.head.message should be(
       """Embed tag with 'related-content' requires a parent 'div', with attributes: 'data-type="related-content"'"""
     )
     val res3 =
-      embedTagValidator.validate("content", s"""<p data-type='related-content'>$validRelatedExternalEmbed</p>""")
+      TagValidator.validate("content", s"""<p data-type='related-content'>$validRelatedExternalEmbed</p>""")
     res3.size should be(2)
     res3.last.message should be(
       """Embed tag with 'related-content' requires a parent 'div', with attributes: 'data-type="related-content"'"""
@@ -577,47 +578,47 @@ class EmbedTagValidatorTest extends UnitSuite {
   }
 
   test("checkParentConditions should work for < operator") {
-    val result1 = embedTagValidator.checkParentConditions("test", Condition("apekatt<2"), 3)
+    val result1 = TagValidator.checkParentConditions("test", Condition("apekatt<2"), 3)
     result1 should be(Left(childCountValidationMessage("test")))
 
-    val result2 = embedTagValidator.checkParentConditions("test", Condition("<2"), 3)
+    val result2 = TagValidator.checkParentConditions("test", Condition("<2"), 3)
     result2 should be(Right(false))
 
-    val result3 = embedTagValidator.checkParentConditions("test", Condition("<2"), 1)
+    val result3 = TagValidator.checkParentConditions("test", Condition("<2"), 1)
     result3 should be(Right(true))
 
-    val result4 = embedTagValidator.checkParentConditions("test", Condition("< 2"), 1)
+    val result4 = TagValidator.checkParentConditions("test", Condition("< 2"), 1)
     result4 should be(Right(true))
   }
 
   test("checkParentConditions should work for > operator") {
-    val result1 = embedTagValidator.checkParentConditions("test", Condition("apekatt>2"), 3)
+    val result1 = TagValidator.checkParentConditions("test", Condition("apekatt>2"), 3)
     result1 should be(Left(childCountValidationMessage("test")))
 
-    val result2 = embedTagValidator.checkParentConditions("test", Condition(">2"), 3)
+    val result2 = TagValidator.checkParentConditions("test", Condition(">2"), 3)
     result2 should be(Right(true))
 
-    val result3 = embedTagValidator.checkParentConditions("test", Condition(">2"), 1)
+    val result3 = TagValidator.checkParentConditions("test", Condition(">2"), 1)
     result3 should be(Right(false))
 
-    val result4 = embedTagValidator.checkParentConditions("test", Condition(">    2"), 1)
+    val result4 = TagValidator.checkParentConditions("test", Condition(">    2"), 1)
     result4 should be(Right(false))
   }
 
   test("checkParentConditions should work for = operator") {
-    val result1 = embedTagValidator.checkParentConditions("test", Condition("apekatt=2"), 3)
+    val result1 = TagValidator.checkParentConditions("test", Condition("apekatt=2"), 3)
     result1 should be(Left(childCountValidationMessage("test")))
 
-    val result2 = embedTagValidator.checkParentConditions("test", Condition("=2"), 2)
+    val result2 = TagValidator.checkParentConditions("test", Condition("=2"), 2)
     result2 should be(Right(true))
 
-    val result3 = embedTagValidator.checkParentConditions("test", Condition("=2"), 1)
+    val result3 = TagValidator.checkParentConditions("test", Condition("=2"), 1)
     result3 should be(Right(false))
 
-    val result4 = embedTagValidator.checkParentConditions("test", Condition(" =  2 "), 2)
+    val result4 = TagValidator.checkParentConditions("test", Condition(" =  2 "), 2)
     result4 should be(Right(true))
 
-    val result5 = embedTagValidator.checkParentConditions("test", Condition("2"), 1)
+    val result5 = TagValidator.checkParentConditions("test", Condition("2"), 1)
     result5 should be(Left(Seq(ValidationMessage("test", "Could not find supported operator (<, > or =)"))))
   }
 
@@ -625,7 +626,7 @@ class EmbedTagValidatorTest extends UnitSuite {
     val content =
       s"""<section><$EmbedTagName data-alt="Øvingsark for teiknskriving for leksjon 1" data-path="files/147739/ovelsesark_for_tegnskriving_for_leksjon_1.pdf" data-resource="file" data-title="Øvelsesark for tegnskriving for leksjon 1" data-type="pdf" /><p><span data-size="large">你</span></p><$EmbedTagName data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:163943" /><p><span data-size="large">您</span></p><$EmbedTagName data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:163944" /><p><span data-size="large">好</span></p><$EmbedTagName data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:163946" /><p><span data-size="large">李</span></p><$EmbedTagName data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:163948" /><p><span data-size="large">美</span></p><$EmbedTagName data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:163950" /><p><span data-size="large">玉</span></p><$EmbedTagName data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:163952" /><p><span data-size="large">马</span></p><$EmbedTagName data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:163953" /><p><span data-size="large">红</span></p><$EmbedTagName data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:163956" /><p><span data-size="large">老</span></p><$EmbedTagName data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:163959" /><p><span data-size="large">师</span></p><$EmbedTagName data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:163960" /><p><span data-size="large">贵</span></p><$EmbedTagName data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:164025" /><p><span data-size="large">姓</span></p><$EmbedTagName data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:164029" /><p><span data-size="large">王</span></p><$EmbedTagName data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:164031" /><p><span data-size="large">们</span></p><$EmbedTagName data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:164032" /><p><span data-size="large">我</span></p><$EmbedTagName data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:164034" /><p><span data-size="large">叫</span></p><$EmbedTagName data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:164035" /><p><span data-size="large">什</span></p><$EmbedTagName data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:164036" /><p><span data-size="large">么</span></p><$EmbedTagName data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:164037" /><p><span data-size="large">名</span></p><$EmbedTagName data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:164038" /><p><span data-size="large">字</span></p><$EmbedTagName data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:164039" /><p><span data-size="large">呢</span></p><$EmbedTagName data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:164067" /><p><span data-size="large">认</span></p><$EmbedTagName data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:164069" /><p><span data-size="large">识</span></p><$EmbedTagName data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:164072" /><p><span data-size="large">很</span></p><$EmbedTagName data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:164077" /><p><span data-size="large">高</span></p><$EmbedTagName data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:164078" /><p><span data-size="large">兴</span></p><$EmbedTagName data-account="4806596774001" data-caption="" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:164079" /></section>"""
 
-    val res = embedTagValidator.validate("content", content)
+    val res = TagValidator.validate("content", content)
     res should be(
       Seq(
         ValidationMessage(
@@ -640,25 +641,25 @@ class EmbedTagValidatorTest extends UnitSuite {
     {
       val content = s"""<section><p><$EmbedTagName type="a" data-resource="file" /></p></section>"""
       val embed   = HtmlTagRules.stringToJsoupDocument(content).select(EmbedTagName).first()
-      embedTagValidator.numDirectEqualSiblings(embed) should be(1)
+      TagValidator.numDirectEqualSiblings(embed) should be(1)
     }
     {
       val content =
         s"""<section><p><$EmbedTagName type="a" data-resource="file" /><$EmbedTagName type="b" data-resource="file" /><$EmbedTagName type="c" data-resource="file" /><$EmbedTagName type="d" data-resource="file" /></p></section>"""
       val embed = HtmlTagRules.stringToJsoupDocument(content).select(s"$EmbedTagName[type=b]").first()
-      embedTagValidator.numDirectEqualSiblings(embed) should be(4)
+      TagValidator.numDirectEqualSiblings(embed) should be(4)
     }
     {
       val content =
         s"""<section><p><$EmbedTagName type="a" data-resource="file" />, <$EmbedTagName type="b" data-resource="file" />, <$EmbedTagName type="c" data-resource="file" />, <$EmbedTagName type="d" data-resource="file" /></p></section>"""
       val embed = HtmlTagRules.stringToJsoupDocument(content).select(s"$EmbedTagName[type=d]").first()
-      embedTagValidator.numDirectEqualSiblings(embed) should be(1)
+      TagValidator.numDirectEqualSiblings(embed) should be(1)
     }
     {
       val content =
         s"""<section><p><$EmbedTagName type="a" data-resource="file" />, <$EmbedTagName type="b" data-resource="file" />, <$EmbedTagName type="c" data-resource="file" /><$EmbedTagName type="d" data-resource="file" /></p></section>"""
       val embed = HtmlTagRules.stringToJsoupDocument(content).select(s"$EmbedTagName[type=c]").first()
-      embedTagValidator.numDirectEqualSiblings(embed) should be(2)
+      TagValidator.numDirectEqualSiblings(embed) should be(2)
     }
   }
 
@@ -679,7 +680,7 @@ class EmbedTagValidatorTest extends UnitSuite {
           |</p>
           |</section>""".stripMargin
     val embed = HtmlTagRules.stringToJsoupDocument(content).select(s"$EmbedTagName[type=c]").first()
-    embedTagValidator.numDirectEqualSiblings(embed) should be(3)
+    TagValidator.numDirectEqualSiblings(embed) should be(3)
   }
 
   test("validate should return no errors when data-title is used as a standalone tag in iframe") {
@@ -697,7 +698,7 @@ class EmbedTagValidatorTest extends UnitSuite {
       )
     )
 
-    val res = embedTagValidator.validate("content", s"""<$EmbedTagName $attrs />""")
+    val res = TagValidator.validate("content", s"""<$EmbedTagName $attrs />""")
     res.headOption should be(None)
   }
 
@@ -715,7 +716,7 @@ class EmbedTagValidatorTest extends UnitSuite {
       )
     )
 
-    val res = embedTagValidator.validate("content", s"""<$EmbedTagName $attrs />""")
+    val res = TagValidator.validate("content", s"""<$EmbedTagName $attrs />""")
     res.headOption should be(None)
   }
 }

--- a/validation/src/test/scala/no/ndla/validation/EmbedTagValidatorTest.scala
+++ b/validation/src/test/scala/no/ndla/validation/EmbedTagValidatorTest.scala
@@ -25,15 +25,15 @@ class EmbedTagValidatorTest extends UnitSuite {
     )
 
   private def generateAttributes(attrs: Map[String, String]): String = {
-    attrs.toList.sortBy(_._1.toString).map { case (key, value) => s"""$key="$value"""" }.mkString(" ")
+    attrs.toList.sortBy(_._1).map { case (key, value) => s"""$key="$value"""" }.mkString(" ")
   }
 
-  private def generateTagWithAttrs(attrs: Map[TagAttributes.Value, String]): String = {
+  private def generateTagWithAttrs(attrs: Map[TagAttribute, String]): String = {
     val strAttrs = attrs map { case (k, v) => k.toString -> v }
     s"""<$EmbedTagName ${generateAttributes(strAttrs)}></$EmbedTagName>"""
   }
 
-  private def generateTagWithAttrsAndChildren(attrs: Map[TagAttributes.Value, String], children: String): String = {
+  private def generateTagWithAttrsAndChildren(attrs: Map[TagAttribute, String], children: String): String = {
     val strAttrs = attrs map { case (k, v) => k.toString -> v }
     s"""<$EmbedTagName ${generateAttributes(strAttrs)}>$children</$EmbedTagName>"""
   }
@@ -53,8 +53,8 @@ class EmbedTagValidatorTest extends UnitSuite {
   test("validate should return validation error if embed tag uses illegal attributes") {
     val attrs = generateAttributes(
       Map(
-        TagAttributes.DataResource.toString -> ResourceType.ExternalContent.toString,
-        TagAttributes.DataUrl.toString      -> "google.com",
+        TagAttribute.DataResource.toString -> ResourceType.ExternalContent.toString,
+        TagAttribute.DataUrl.toString      -> "google.com",
         "illegalattr"                       -> "test"
       )
     )
@@ -66,8 +66,8 @@ class EmbedTagValidatorTest extends UnitSuite {
   test("validate should return validation error if an attribute contains HTML") {
     val tag = generateTagWithAttrs(
       Map(
-        TagAttributes.DataResource -> ResourceType.ExternalContent.toString,
-        TagAttributes.DataUrl      -> "<i>google.com</i>"
+        TagAttribute.DataResource -> ResourceType.ExternalContent.toString,
+        TagAttribute.DataUrl      -> "<i>google.com</i>"
       )
     )
     val res = embedTagValidator.validate("content", tag)
@@ -77,7 +77,7 @@ class EmbedTagValidatorTest extends UnitSuite {
   test(
     "validate should return validation error if embed tag does not contain required attributes for data-resource=image"
   ) {
-    val tag = generateTagWithAttrs(Map(TagAttributes.DataResource -> ResourceType.Image.toString))
+    val tag = generateTagWithAttrs(Map(TagAttribute.DataResource -> ResourceType.Image.toString))
     val res = embedTagValidator.validate("content", tag)
     findErrorByMessage(
       res,
@@ -88,17 +88,17 @@ class EmbedTagValidatorTest extends UnitSuite {
   test("validate should return not validation error if embed tag misses moved required to optional") {
     val tag = generateTagWithAttrs(
       Map(
-        TagAttributes.DataResource    -> ResourceType.Image.toString,
-        TagAttributes.DataResource_Id -> "1234",
-        TagAttributes.DataSize        -> "fullbredde",
-        TagAttributes.DataAlign       -> "",
-        TagAttributes.DataAlt         -> "alttext"
+        TagAttribute.DataResource    -> ResourceType.Image.toString,
+        TagAttribute.DataResource_Id -> "1234",
+        TagAttribute.DataSize        -> "fullbredde",
+        TagAttribute.DataAlign       -> "",
+        TagAttribute.DataAlt         -> "alttext"
       )
     )
     val res = embedTagValidator.validate(
       "content",
       tag,
-      requiredToOptional = Map("image" -> Seq(TagAttributes.DataCaption.toString))
+      requiredToOptional = Map("image" -> Seq(TagAttribute.DataCaption.toString))
     )
     res should be(Seq.empty)
   }
@@ -106,12 +106,12 @@ class EmbedTagValidatorTest extends UnitSuite {
   test("validate should return no validation errors if image embed-tag is used correctly") {
     val tag = generateTagWithAttrs(
       Map(
-        TagAttributes.DataResource    -> ResourceType.Image.toString,
-        TagAttributes.DataResource_Id -> "1234",
-        TagAttributes.DataSize        -> "fullbredde",
-        TagAttributes.DataAlt         -> "alternative text",
-        TagAttributes.DataCaption     -> "here is a rabbit",
-        TagAttributes.DataAlign       -> "left"
+        TagAttribute.DataResource    -> ResourceType.Image.toString,
+        TagAttribute.DataResource_Id -> "1234",
+        TagAttribute.DataSize        -> "fullbredde",
+        TagAttribute.DataAlt         -> "alternative text",
+        TagAttribute.DataCaption     -> "here is a rabbit",
+        TagAttribute.DataAlign       -> "left"
       )
     )
     embedTagValidator.validate("content", tag).size should be(0)
@@ -120,7 +120,7 @@ class EmbedTagValidatorTest extends UnitSuite {
   test(
     "validate should return validation error if embed tag does not contain required attributes for data-resource=audio"
   ) {
-    val tag = generateTagWithAttrs(Map(TagAttributes.DataResource -> ResourceType.Audio.toString))
+    val tag = generateTagWithAttrs(Map(TagAttribute.DataResource -> ResourceType.Audio.toString))
     val res = embedTagValidator.validate("content", tag)
     findErrorByMessage(
       res,
@@ -131,10 +131,10 @@ class EmbedTagValidatorTest extends UnitSuite {
   test("validate should return no validation errors if audio embed-tag is used correctly") {
     val tag = generateTagWithAttrs(
       Map(
-        TagAttributes.DataResource    -> ResourceType.Audio.toString,
-        TagAttributes.DataResource_Id -> "1234",
-        TagAttributes.DataCaption     -> "",
-        TagAttributes.DataType        -> "standard"
+        TagAttribute.DataResource    -> ResourceType.Audio.toString,
+        TagAttribute.DataResource_Id -> "1234",
+        TagAttribute.DataCaption     -> "",
+        TagAttribute.DataType        -> "standard"
       )
     )
     embedTagValidator.validate("content", tag).size should be(0)
@@ -143,7 +143,7 @@ class EmbedTagValidatorTest extends UnitSuite {
   test(
     "validate should return validation error if embed tag does not contain required attributes for data-resource=h5p"
   ) {
-    val tag = generateTagWithAttrs(Map(TagAttributes.DataResource -> ResourceType.H5P.toString))
+    val tag = generateTagWithAttrs(Map(TagAttribute.DataResource -> ResourceType.H5P.toString))
     val res = embedTagValidator.validate("content", tag)
     findErrorByMessage(res, s"data-resource=${ResourceType.H5P} must contain the following attributes:").size should be(
       1
@@ -153,8 +153,8 @@ class EmbedTagValidatorTest extends UnitSuite {
   test("validate should return no validation errors if h5p embed-tag is used correctly") {
     val tag = generateTagWithAttrs(
       Map(
-        TagAttributes.DataResource -> ResourceType.H5P.toString,
-        TagAttributes.DataPath     -> "/h5p/embed/1234"
+        TagAttribute.DataResource -> ResourceType.H5P.toString,
+        TagAttribute.DataPath     -> "/h5p/embed/1234"
       )
     )
     val t = embedTagValidator.validate("content", tag)
@@ -164,7 +164,7 @@ class EmbedTagValidatorTest extends UnitSuite {
   test(
     "validate should return validation error if embed tag does not contain required attributes for data-resource=brightcove"
   ) {
-    val tag = generateTagWithAttrs(Map(TagAttributes.DataResource -> ResourceType.Brightcove.toString))
+    val tag = generateTagWithAttrs(Map(TagAttribute.DataResource -> ResourceType.Brightcove.toString))
     val res = embedTagValidator.validate("content", tag)
     findErrorByMessage(
       res,
@@ -175,11 +175,11 @@ class EmbedTagValidatorTest extends UnitSuite {
   test("validate should return no validation errors if brightcove embed-tag is used correctly") {
     val tag = generateTagWithAttrs(
       Map(
-        TagAttributes.DataResource -> ResourceType.Brightcove.toString,
-        TagAttributes.DataCaption  -> "here is a video",
-        TagAttributes.DataVideoId  -> "1234",
-        TagAttributes.DataAccount  -> "2183716",
-        TagAttributes.DataPlayer   -> "B28fas"
+        TagAttribute.DataResource -> ResourceType.Brightcove.toString,
+        TagAttribute.DataCaption  -> "here is a video",
+        TagAttribute.DataVideoId  -> "1234",
+        TagAttribute.DataAccount  -> "2183716",
+        TagAttribute.DataPlayer   -> "B28fas"
       )
     )
     embedTagValidator.validate("content", tag).size should be(0)
@@ -188,7 +188,7 @@ class EmbedTagValidatorTest extends UnitSuite {
   test(
     "validate should return validation error if embed tag does not contain required attributes for data-resource=content-link"
   ) {
-    val tag = generateTagWithAttrs(Map(TagAttributes.DataResource -> ResourceType.ContentLink.toString))
+    val tag = generateTagWithAttrs(Map(TagAttribute.DataResource -> ResourceType.ContentLink.toString))
     val res = embedTagValidator.validate("content", tag)
     findErrorByMessage(
       res,
@@ -199,9 +199,9 @@ class EmbedTagValidatorTest extends UnitSuite {
   test("validate should return no validation errors if content-link embed-tag is used correctly") {
     val tag = generateTagWithAttrsAndChildren(
       Map(
-        TagAttributes.DataResource  -> ResourceType.ContentLink.toString,
-        TagAttributes.DataContentId -> "54",
-        TagAttributes.DataOpenIn    -> "new-context"
+        TagAttribute.DataResource  -> ResourceType.ContentLink.toString,
+        TagAttribute.DataContentId -> "54",
+        TagAttribute.DataOpenIn    -> "new-context"
       ),
       "interesting article"
     )
@@ -211,9 +211,9 @@ class EmbedTagValidatorTest extends UnitSuite {
   test("validate should return validation errors if content-link embed-tag is used incorrectly") {
     val tag = generateTagWithAttrs(
       Map(
-        TagAttributes.DataResource  -> ResourceType.ContentLink.toString,
-        TagAttributes.DataContentId -> "54",
-        TagAttributes.DataOpenIn    -> "new-context"
+        TagAttribute.DataResource  -> ResourceType.ContentLink.toString,
+        TagAttribute.DataContentId -> "54",
+        TagAttribute.DataOpenIn    -> "new-context"
       )
     )
     embedTagValidator.validate("content", tag).size should be(1)
@@ -222,9 +222,9 @@ class EmbedTagValidatorTest extends UnitSuite {
   test("validate should return allow valid children for content-link") {
     val tag = generateTagWithAttrsAndChildren(
       Map(
-        TagAttributes.DataResource  -> ResourceType.ContentLink.toString,
-        TagAttributes.DataContentId -> "54",
-        TagAttributes.DataOpenIn    -> "new-context"
+        TagAttribute.DataResource  -> ResourceType.ContentLink.toString,
+        TagAttribute.DataContentId -> "54",
+        TagAttribute.DataOpenIn    -> "new-context"
       ),
       "<strong>Apekatt</strong> er kult"
     )
@@ -234,9 +234,9 @@ class EmbedTagValidatorTest extends UnitSuite {
   test("validate should return validation errors if content-link has invalid children") {
     val tag = generateTagWithAttrsAndChildren(
       Map(
-        TagAttributes.DataResource  -> ResourceType.ContentLink.toString,
-        TagAttributes.DataContentId -> "54",
-        TagAttributes.DataOpenIn    -> "new-context"
+        TagAttribute.DataResource  -> ResourceType.ContentLink.toString,
+        TagAttribute.DataContentId -> "54",
+        TagAttribute.DataOpenIn    -> "new-context"
       ),
       "<div><strong>Apekatt</strong> er kult</div>"
     )
@@ -246,7 +246,7 @@ class EmbedTagValidatorTest extends UnitSuite {
   test(
     "validate should return validation error if embed tag does not contain required attributes for data-resource=error"
   ) {
-    val tag = generateTagWithAttrs(Map(TagAttributes.DataResource -> ResourceType.Error.toString))
+    val tag = generateTagWithAttrs(Map(TagAttribute.DataResource -> ResourceType.Error.toString))
     val res = embedTagValidator.validate("content", tag)
     findErrorByMessage(
       res,
@@ -256,7 +256,7 @@ class EmbedTagValidatorTest extends UnitSuite {
 
   test("validate should return no validation errors if error embed-tag is used correctly") {
     val tag = generateTagWithAttrs(
-      Map(TagAttributes.DataResource -> ResourceType.Error.toString, TagAttributes.DataMessage -> "interesting article")
+      Map(TagAttribute.DataResource -> ResourceType.Error.toString, TagAttribute.DataMessage -> "interesting article")
     )
     embedTagValidator.validate("content", tag).size should be(0)
   }
@@ -264,7 +264,7 @@ class EmbedTagValidatorTest extends UnitSuite {
   test(
     "validate should return validation error if embed tag does not contain required attributes for data-resource=external"
   ) {
-    val tag = generateTagWithAttrs(Map(TagAttributes.DataResource -> ResourceType.ExternalContent.toString))
+    val tag = generateTagWithAttrs(Map(TagAttribute.DataResource -> ResourceType.ExternalContent.toString))
     val res = embedTagValidator.validate("content", tag)
     findErrorByMessage(
       res,
@@ -275,9 +275,9 @@ class EmbedTagValidatorTest extends UnitSuite {
   test("validate should return no validation errors if external embed-tag is used correctly") {
     val tag = generateTagWithAttrs(
       Map(
-        TagAttributes.DataResource -> ResourceType.ExternalContent.toString,
-        TagAttributes.DataUrl      -> "https://www.youtube.com/watch?v=pCZeVTMEsik",
-        TagAttributes.DataType     -> "iframe"
+        TagAttribute.DataResource -> ResourceType.ExternalContent.toString,
+        TagAttribute.DataUrl      -> "https://www.youtube.com/watch?v=pCZeVTMEsik",
+        TagAttribute.DataType     -> "iframe"
       )
     )
     embedTagValidator.validate("content", tag).size should be(0)
@@ -286,7 +286,7 @@ class EmbedTagValidatorTest extends UnitSuite {
   test(
     "validate should return validation error if embed tag does not contain required attributes for data-resource=nrk"
   ) {
-    val tag = generateTagWithAttrs(Map(TagAttributes.DataResource -> ResourceType.NRKContent.toString))
+    val tag = generateTagWithAttrs(Map(TagAttribute.DataResource -> ResourceType.NRKContent.toString))
     val res = embedTagValidator.validate("content", tag)
     findErrorByMessage(
       res,
@@ -297,9 +297,9 @@ class EmbedTagValidatorTest extends UnitSuite {
   test("validate should return no validation errors if nrk embed-tag is used correctly") {
     val tag = generateTagWithAttrs(
       Map(
-        TagAttributes.DataResource   -> ResourceType.NRKContent.toString,
-        TagAttributes.DataNRKVideoId -> "123",
-        TagAttributes.DataUrl        -> "http://nrk.no/video/123"
+        TagAttribute.DataResource   -> ResourceType.NRKContent.toString,
+        TagAttribute.DataNRKVideoId -> "123",
+        TagAttribute.DataUrl        -> "http://nrk.no/video/123"
       )
     )
     embedTagValidator.validate("content", tag).size should be(0)
@@ -310,26 +310,26 @@ class EmbedTagValidatorTest extends UnitSuite {
   ) {
     val tag = generateTagWithAttrs(
       Map(
-        TagAttributes.DataResource -> ResourceType.ConceptList.toString,
-        TagAttributes.DataTag      -> "Liste::"
+        TagAttribute.DataResource -> ResourceType.ConceptList.toString,
+        TagAttribute.DataTag      -> "Liste::"
       )
     )
     val res = embedTagValidator.validate("content", tag)
     findErrorByMessage(
       res,
-      s"data-resource=${ResourceType.ConceptList} must contain all or none of the attributes in the optional attribute groups"
+      s"data-resource=${ResourceType.ConceptList} must contain all or none of the attributes in the optional attribute group"
     ).size should be(1)
 
     val tag2 = generateTagWithAttrs(
       Map(
-        TagAttributes.DataResource    -> ResourceType.ConceptList.toString,
-        TagAttributes.DataResource_Id -> "1"
+        TagAttribute.DataResource    -> ResourceType.ConceptList.toString,
+        TagAttribute.DataResource_Id -> "1"
       )
     )
     val res2 = embedTagValidator.validate("content", tag2)
     findErrorByMessage(
       res2,
-      s"data-resource=${ResourceType.ConceptList} must contain all or none of the attributes in the optional attribute groups"
+      s"data-resource=${ResourceType.ConceptList} must contain all or none of the attributes in the optional attribute group"
     ).size should be(1)
 
   }
@@ -337,28 +337,28 @@ class EmbedTagValidatorTest extends UnitSuite {
   test("validate should return no validation errors if concept-list embed-tag is used correctly") {
     val tag = generateTagWithAttrs(
       Map(
-        TagAttributes.DataResource  -> ResourceType.ConceptList.toString,
-        TagAttributes.DataTitle     -> "Liste",
-        TagAttributes.DataTag       -> "Liste:kategori:kategori2",
-        TagAttributes.DataSubjectId -> "urn:subject:123"
+        TagAttribute.DataResource  -> ResourceType.ConceptList.toString,
+        TagAttribute.DataTitle     -> "Liste",
+        TagAttribute.DataTag       -> "Liste:kategori:kategori2",
+        TagAttribute.DataSubjectId -> "urn:subject:123"
       )
     )
     embedTagValidator.validate("content", tag).size should be(0)
 
     val tag2 = generateTagWithAttrs(
       Map(
-        TagAttributes.DataResource -> ResourceType.ConceptList.toString,
-        TagAttributes.DataTitle    -> "Liste",
-        TagAttributes.DataTag      -> "Liste:kategori:kategori2"
+        TagAttribute.DataResource -> ResourceType.ConceptList.toString,
+        TagAttribute.DataTitle    -> "Liste",
+        TagAttribute.DataTag      -> "Liste:kategori:kategori2"
       )
     )
     embedTagValidator.validate("content", tag2).size should be(0)
 
     val tag3 = generateTagWithAttrs(
       Map(
-        TagAttributes.DataResource    -> ResourceType.ConceptList.toString,
-        TagAttributes.DataResource_Id -> "1",
-        TagAttributes.DataRecursive   -> "false"
+        TagAttribute.DataResource    -> ResourceType.ConceptList.toString,
+        TagAttribute.DataResource_Id -> "1",
+        TagAttribute.DataRecursive   -> "false"
       )
     )
     embedTagValidator.validate("content", tag3).size should be(0)
@@ -367,35 +367,36 @@ class EmbedTagValidatorTest extends UnitSuite {
   test("validate should fail if only one optional attribute is specified") {
     val tag = generateTagWithAttrs(
       Map(
-        TagAttributes.DataResource    -> ResourceType.Image.toString,
-        TagAttributes.DataAlt         -> "123",
-        TagAttributes.DataCaption     -> "123",
-        TagAttributes.DataResource_Id -> "123",
-        TagAttributes.DataSize        -> "full",
-        TagAttributes.DataAlign       -> "left",
-        TagAttributes.DataUpperLeftX  -> "0",
-        TagAttributes.DataFocalX      -> "0"
+        TagAttribute.DataResource    -> ResourceType.Image.toString,
+        TagAttribute.DataAlt         -> "123",
+        TagAttribute.DataCaption     -> "123",
+        TagAttribute.DataResource_Id -> "123",
+        TagAttribute.DataSize        -> "full",
+        TagAttribute.DataAlign       -> "left",
+        TagAttribute.DataUpperLeftX  -> "0",
+        TagAttribute.DataFocalX      -> "0"
       )
     )
-    embedTagValidator.validate("content", tag).size should be(2)
+    val messages = embedTagValidator.validate("content", tag)
+    messages.size should be(2)
   }
 
   test("validate should succeed if all optional attributes are specified") {
     val tag = generateTagWithAttrs(
       Map(
-        TagAttributes.DataResource     -> ResourceType.Image.toString,
-        TagAttributes.DataAlt          -> "123",
-        TagAttributes.DataCaption      -> "123",
-        TagAttributes.DataResource_Id  -> "123",
-        TagAttributes.DataSize         -> "full",
-        TagAttributes.DataAlign        -> "left",
-        TagAttributes.DataUpperLeftX   -> "0",
-        TagAttributes.DataUpperLeftY   -> "0",
-        TagAttributes.DataLowerRightX  -> "1",
-        TagAttributes.DataLowerRightY  -> "1",
-        TagAttributes.DataFocalX       -> "0",
-        TagAttributes.DataFocalY       -> "1",
-        TagAttributes.DataIsDecorative -> "false"
+        TagAttribute.DataResource     -> ResourceType.Image.toString,
+        TagAttribute.DataAlt          -> "123",
+        TagAttribute.DataCaption      -> "123",
+        TagAttribute.DataResource_Id  -> "123",
+        TagAttribute.DataSize         -> "full",
+        TagAttribute.DataAlign        -> "left",
+        TagAttribute.DataUpperLeftX   -> "0",
+        TagAttribute.DataUpperLeftY   -> "0",
+        TagAttribute.DataLowerRightX  -> "1",
+        TagAttribute.DataLowerRightY  -> "1",
+        TagAttribute.DataFocalX       -> "0",
+        TagAttribute.DataFocalY       -> "1",
+        TagAttribute.DataIsDecorative -> "false"
       )
     )
 
@@ -405,14 +406,14 @@ class EmbedTagValidatorTest extends UnitSuite {
   test("validate should succeed if all attributes in an attribute group are specified") {
     val tagWithFocal = generateTagWithAttrs(
       Map(
-        TagAttributes.DataResource    -> ResourceType.Image.toString,
-        TagAttributes.DataAlt         -> "123",
-        TagAttributes.DataCaption     -> "123",
-        TagAttributes.DataResource_Id -> "123",
-        TagAttributes.DataSize        -> "full",
-        TagAttributes.DataAlign       -> "left",
-        TagAttributes.DataFocalX      -> "0",
-        TagAttributes.DataFocalY      -> "1"
+        TagAttribute.DataResource    -> ResourceType.Image.toString,
+        TagAttribute.DataAlt         -> "123",
+        TagAttribute.DataCaption     -> "123",
+        TagAttribute.DataResource_Id -> "123",
+        TagAttribute.DataSize        -> "full",
+        TagAttribute.DataAlign       -> "left",
+        TagAttribute.DataFocalX      -> "0",
+        TagAttribute.DataFocalY      -> "1"
       )
     )
 
@@ -420,17 +421,17 @@ class EmbedTagValidatorTest extends UnitSuite {
 
     val tagWithCrop = generateTagWithAttrs(
       Map(
-        TagAttributes.DataResource     -> ResourceType.Image.toString,
-        TagAttributes.DataAlt          -> "123",
-        TagAttributes.DataCaption      -> "123",
-        TagAttributes.DataResource_Id  -> "123",
-        TagAttributes.DataSize         -> "full",
-        TagAttributes.DataAlign        -> "left",
-        TagAttributes.DataUpperLeftX   -> "0",
-        TagAttributes.DataUpperLeftY   -> "0",
-        TagAttributes.DataLowerRightX  -> "1",
-        TagAttributes.DataLowerRightY  -> "1",
-        TagAttributes.DataIsDecorative -> "false"
+        TagAttribute.DataResource     -> ResourceType.Image.toString,
+        TagAttribute.DataAlt          -> "123",
+        TagAttribute.DataCaption      -> "123",
+        TagAttribute.DataResource_Id  -> "123",
+        TagAttribute.DataSize         -> "full",
+        TagAttribute.DataAlign        -> "left",
+        TagAttribute.DataUpperLeftX   -> "0",
+        TagAttribute.DataUpperLeftY   -> "0",
+        TagAttribute.DataLowerRightX  -> "1",
+        TagAttribute.DataLowerRightY  -> "1",
+        TagAttribute.DataIsDecorative -> "false"
       )
     )
 
@@ -438,13 +439,13 @@ class EmbedTagValidatorTest extends UnitSuite {
 
     val tagWithDecor = generateTagWithAttrs(
       Map(
-        TagAttributes.DataResource     -> ResourceType.Image.toString,
-        TagAttributes.DataAlt          -> "123",
-        TagAttributes.DataCaption      -> "123",
-        TagAttributes.DataResource_Id  -> "123",
-        TagAttributes.DataSize         -> "full",
-        TagAttributes.DataAlign        -> "left",
-        TagAttributes.DataIsDecorative -> "false"
+        TagAttribute.DataResource     -> ResourceType.Image.toString,
+        TagAttribute.DataAlt          -> "123",
+        TagAttribute.DataCaption      -> "123",
+        TagAttribute.DataResource_Id  -> "123",
+        TagAttribute.DataSize         -> "full",
+        TagAttribute.DataAlign        -> "left",
+        TagAttribute.DataIsDecorative -> "false"
       )
     )
 
@@ -454,22 +455,22 @@ class EmbedTagValidatorTest extends UnitSuite {
   test("validate should succeed if source url is from a legal domain") {
     val tag = generateTagWithAttrs(
       Map(
-        TagAttributes.DataResource -> ResourceType.IframeContent.toString,
-        TagAttributes.DataType     -> ResourceType.IframeContent.toString,
-        TagAttributes.DataUrl      -> "https://prezi.com",
-        TagAttributes.DataWidth    -> "1",
-        TagAttributes.DataHeight   -> "1"
+        TagAttribute.DataResource -> ResourceType.IframeContent.toString,
+        TagAttribute.DataType     -> ResourceType.IframeContent.toString,
+        TagAttribute.DataUrl      -> "https://prezi.com",
+        TagAttribute.DataWidth    -> "1",
+        TagAttribute.DataHeight   -> "1"
       )
     )
     embedTagValidator.validate("content", tag).size should be(0)
 
     val tag2 = generateTagWithAttrs(
       Map(
-        TagAttributes.DataResource -> ResourceType.IframeContent.toString,
-        TagAttributes.DataType     -> ResourceType.IframeContent.toString,
-        TagAttributes.DataUrl      -> "https://statisk.test.ndla.no",
-        TagAttributes.DataWidth    -> "1",
-        TagAttributes.DataHeight   -> "1"
+        TagAttribute.DataResource -> ResourceType.IframeContent.toString,
+        TagAttribute.DataType     -> ResourceType.IframeContent.toString,
+        TagAttribute.DataUrl      -> "https://statisk.test.ndla.no",
+        TagAttribute.DataWidth    -> "1",
+        TagAttribute.DataHeight   -> "1"
       )
     )
     embedTagValidator.validate("content", tag2).size should be(0)
@@ -478,28 +479,28 @@ class EmbedTagValidatorTest extends UnitSuite {
   test("validate should fail if source url is from an illlegal domain") {
     val tag = generateTagWithAttrs(
       Map(
-        TagAttributes.DataResource -> ResourceType.IframeContent.toString,
-        TagAttributes.DataType     -> ResourceType.IframeContent.toString,
-        TagAttributes.DataUrl      -> "https://evilprezi.com",
-        TagAttributes.DataWidth    -> "1",
-        TagAttributes.DataHeight   -> "1"
+        TagAttribute.DataResource -> ResourceType.IframeContent.toString,
+        TagAttribute.DataType     -> ResourceType.IframeContent.toString,
+        TagAttribute.DataUrl      -> "https://evilprezi.com",
+        TagAttribute.DataWidth    -> "1",
+        TagAttribute.DataHeight   -> "1"
       )
     )
 
     val result = embedTagValidator.validate("content", tag)
     result.size should be(1)
     result.head.message
-      .contains(s"can only contain ${TagAttributes.DataUrl} urls from the following domains:") should be(true)
+      .contains(s"can only contain ${TagAttribute.DataUrl} urls from the following domains:") should be(true)
   }
 
   test("validate should succeed if source url is from a legal wildcard domain") {
     val tag = generateTagWithAttrs(
       Map(
-        TagAttributes.DataResource -> ResourceType.IframeContent.toString,
-        TagAttributes.DataType     -> ResourceType.IframeContent.toString,
-        TagAttributes.DataUrl      -> "https://thisisatest.khanacademy.org",
-        TagAttributes.DataWidth    -> "1",
-        TagAttributes.DataHeight   -> "1"
+        TagAttribute.DataResource -> ResourceType.IframeContent.toString,
+        TagAttribute.DataType     -> ResourceType.IframeContent.toString,
+        TagAttribute.DataUrl      -> "https://thisisatest.khanacademy.org",
+        TagAttribute.DataWidth    -> "1",
+        TagAttribute.DataHeight   -> "1"
       )
     )
 
@@ -685,14 +686,14 @@ class EmbedTagValidatorTest extends UnitSuite {
     val attrs = generateAttributes(
       Map(
         // Iframe Required
-        TagAttributes.DataResource.toString -> ResourceType.IframeContent.toString,
-        TagAttributes.DataType.toString     -> ResourceType.IframeContent.toString,
-        TagAttributes.DataUrl.toString      -> "https://google.ndla.no/",
+        TagAttribute.DataResource.toString -> ResourceType.IframeContent.toString,
+        TagAttribute.DataType.toString     -> ResourceType.IframeContent.toString,
+        TagAttribute.DataUrl.toString      -> "https://google.ndla.no/",
         // Iframe Optional-1
-        TagAttributes.DataWidth.toString  -> "700",
-        TagAttributes.DataHeight.toString -> "500",
+        TagAttribute.DataWidth.toString  -> "700",
+        TagAttribute.DataHeight.toString -> "500",
         // Iframe Optional that i want to test
-        TagAttributes.DataTitle.toString -> "Min tittel"
+        TagAttribute.DataTitle.toString -> "Min tittel"
       )
     )
 
@@ -703,14 +704,14 @@ class EmbedTagValidatorTest extends UnitSuite {
   test("validate should return no errors when data-title is used in a group in iframe") {
     val attrs = generateAttributes(
       Map(
-        TagAttributes.DataResource.toString -> ResourceType.IframeContent.toString,
-        TagAttributes.DataType.toString     -> ResourceType.IframeContent.toString,
-        TagAttributes.DataUrl.toString      -> "https://google.ndla.no/",
-        TagAttributes.DataWidth.toString    -> "700",
-        TagAttributes.DataHeight.toString   -> "500",
-        TagAttributes.DataTitle.toString    -> "Min tittel",
-        TagAttributes.DataCaption.toString  -> "heyho",
-        TagAttributes.DataImageId.toString  -> "123"
+        TagAttribute.DataResource.toString -> ResourceType.IframeContent.toString,
+        TagAttribute.DataType.toString     -> ResourceType.IframeContent.toString,
+        TagAttribute.DataUrl.toString      -> "https://google.ndla.no/",
+        TagAttribute.DataWidth.toString    -> "700",
+        TagAttribute.DataHeight.toString   -> "500",
+        TagAttribute.DataTitle.toString    -> "Min tittel",
+        TagAttribute.DataCaption.toString  -> "heyho",
+        TagAttribute.DataImageId.toString  -> "123"
       )
     )
 

--- a/validation/src/test/scala/no/ndla/validation/HtmlTagRulesTest.scala
+++ b/validation/src/test/scala/no/ndla/validation/HtmlTagRulesTest.scala
@@ -14,7 +14,7 @@ class HtmlTagRulesTest extends UnitSuite {
   test("embed tag should be an allowed tag and contain data attributes") {
     HtmlTagRules.isTagValid("ndlaembed") should equal(true)
     val dataAttrs =
-      TagAttributes.values.map(_.toString).filter(x => x.startsWith("data-"))
+      TagAttribute.values.map(_.toString).filter(x => x.startsWith("data-"))
     val legalEmbedAttrs = HtmlTagRules.legalAttributesForTag(EmbedTagName)
     legalEmbedAttrs.foreach(x => dataAttrs should contain(x))
   }
@@ -38,7 +38,7 @@ class HtmlTagRulesTest extends UnitSuite {
   test("span tag should be an allowed tag and contain one lang attribute") {
     HtmlTagRules.isTagValid("span")
     val dataAttrs =
-      TagAttributes.values.map(_.toString).filter(x => x.startsWith("lang") && x != TagAttributes.DataType.toString)
+      TagAttribute.values.map(_.toString).filter(x => x.startsWith("lang") && x != TagAttribute.DataType.toString)
     val legalEmbedAttrs = HtmlTagRules.legalAttributesForTag("span")
     dataAttrs.foreach(x => legalEmbedAttrs should contain(x))
   }

--- a/validation/src/test/scala/no/ndla/validation/HtmlTagRulesTest.scala
+++ b/validation/src/test/scala/no/ndla/validation/HtmlTagRulesTest.scala
@@ -8,7 +8,6 @@
 package no.ndla.validation
 
 import no.ndla.common.configuration.Constants.EmbedTagName
-import no.ndla.mapping.UnitSuite
 
 class HtmlTagRulesTest extends UnitSuite {
   test("embed tag should be an allowed tag and contain data attributes") {

--- a/validation/src/test/scala/no/ndla/validation/HtmlValidatorTest.scala
+++ b/validation/src/test/scala/no/ndla/validation/HtmlValidatorTest.scala
@@ -2,10 +2,8 @@ package no.ndla.validation
 
 import no.ndla.common.configuration.Constants.EmbedTagName
 import no.ndla.common.errors.ValidationMessage
-import no.ndla.mapping.UnitSuite
 
 class HtmlValidatorTest extends UnitSuite {
-  val htmlValidator = new TextValidator()
 
   private val getValidImageEmbed = (id: String) => {
     s"""<$EmbedTagName data-caption="some capt" data-align="" data-resource_id="$id" data-resource="image" data-alt="some alt" data-size="full" />"""
@@ -15,21 +13,21 @@ class HtmlValidatorTest extends UnitSuite {
     val mathContent =
       "<section><p>Formel: <math style=\"font-family:'Courier New'\" xmlns=\"http://www.w3.org/1998/Math/MathML\"><mmultiscripts><mn>22</mn><mprescripts/><mn>22</mn><mn>22</mn></mmultiscripts><mo>&#xA0;</mo><mi>h</mi><mi>a</mi><mi>l</mi><mi>l</mi><mi>o</mi><mrow style=\"font-family:'Courier New'\"><mi>a</mi><mi>s</mi><mi>d</mi><mi>f</mi></mrow></math></p></section>"
     val messages =
-      htmlValidator.validate(fieldPath = "content", text = mathContent, HtmlTagRules.allLegalTags)
+      TextValidator.validate(fieldPath = "content", text = mathContent, HtmlTagRules.allLegalTags)
     messages.length should be(0)
   }
 
   test("Validating visual elements should fail if the tag is not an embed") {
-    htmlValidator.validateVisualElement("test", "") should be(
+    TextValidator.validateVisualElement("test", "") should be(
       Seq(ValidationMessage("test", "The root html element for visual elements needs to be `embed`."))
     )
-    htmlValidator.validateVisualElement("test", "apekatt") should be(
+    TextValidator.validateVisualElement("test", "apekatt") should be(
       Seq(ValidationMessage("test", "The root html element for visual elements needs to be `embed`."))
     )
   }
 
   test("Passing multiple embeds when validating visual element should fail") {
-    htmlValidator.validateVisualElement(
+    TextValidator.validateVisualElement(
       "test",
       s"""${getValidImageEmbed("1")}${getValidImageEmbed("2")}"""
     ) should be(
@@ -38,7 +36,7 @@ class HtmlValidatorTest extends UnitSuite {
   }
 
   test("Passing a single valid embed should work") {
-    htmlValidator.validateVisualElement(
+    TextValidator.validateVisualElement(
       "test",
       getValidImageEmbed("1")
     ) should be(

--- a/validation/src/test/scala/no/ndla/validation/HtmlValidatorTest.scala
+++ b/validation/src/test/scala/no/ndla/validation/HtmlValidatorTest.scala
@@ -5,7 +5,7 @@ import no.ndla.common.errors.ValidationMessage
 import no.ndla.mapping.UnitSuite
 
 class HtmlValidatorTest extends UnitSuite {
-  val htmlValidator = new TextValidator(allowHtml = true)
+  val htmlValidator = new TextValidator()
 
   private val getValidImageEmbed = (id: String) => {
     s"""<$EmbedTagName data-caption="some capt" data-align="" data-resource_id="$id" data-resource="image" data-alt="some alt" data-size="full" />"""
@@ -15,7 +15,7 @@ class HtmlValidatorTest extends UnitSuite {
     val mathContent =
       "<section><p>Formel: <math style=\"font-family:'Courier New'\" xmlns=\"http://www.w3.org/1998/Math/MathML\"><mmultiscripts><mn>22</mn><mprescripts/><mn>22</mn><mn>22</mn></mmultiscripts><mo>&#xA0;</mo><mi>h</mi><mi>a</mi><mi>l</mi><mi>l</mi><mi>o</mi><mrow style=\"font-family:'Courier New'\"><mi>a</mi><mi>s</mi><mi>d</mi><mi>f</mi></mrow></math></p></section>"
     val messages =
-      htmlValidator.validate(fieldPath = "content", text = mathContent)
+      htmlValidator.validate(fieldPath = "content", text = mathContent, HtmlTagRules.allLegalTags)
     messages.length should be(0)
   }
 

--- a/validation/src/test/scala/no/ndla/validation/UnitSuite.scala
+++ b/validation/src/test/scala/no/ndla/validation/UnitSuite.scala
@@ -1,12 +1,12 @@
 /*
- * Part of NDLA mapping.
- * Copyright (C) 2016 NDLA
+ * Part of NDLA validation.
+ * Copyright (C) 2017 NDLA
  *
  * See LICENSE
  *
  */
 
-package no.ndla.mapping
+package no.ndla.validation
 
 import org.scalatest._
 import org.scalatest.funsuite.AnyFunSuite


### PR DESCRIPTION
Nytt format på valideringskode. Støtter html i utvalgte embed-attributter.

På litt sikt kan vi legge inn feks validering av url og epost i valideringskoden ved å spesifisere regex i validation-feltet.