### PR TITLE
draft-api: Set file threshold for `FileController`

### DIFF
--- a/draft-api/src/main/scala/no/ndla/draftapi/controller/FileController.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/controller/FileController.scala
@@ -12,9 +12,8 @@ import no.ndla.draftapi.model.api
 import no.ndla.draftapi.model.api._
 import no.ndla.draftapi.service.WriteService
 import no.ndla.network.tapir.auth.Permission.DRAFT_API_WRITE
-import org.json4s.{DefaultFormats, Formats}
 import org.scalatra.NoContent
-import org.scalatra.servlet.FileUploadSupport
+import org.scalatra.servlet.{FileUploadSupport, MultipartConfig}
 import org.scalatra.swagger.{ResponseMessage, Swagger}
 
 import scala.util.{Failure, Success}
@@ -24,8 +23,9 @@ trait FileController {
   val fileController: FileController
 
   class FileController(implicit val swagger: Swagger) extends NdlaController with FileUploadSupport {
-    protected implicit override val jsonFormats: Formats = DefaultFormats
-    protected val applicationDescription                 = "API for uploading files to ndla.no."
+    protected val applicationDescription        = "API for uploading files to ndla.no."
+    private val multipartFileSizeThresholdBytes = 1024 * 1024 * 30 // 30MB
+    configureMultipartHandling(MultipartConfig(fileSizeThreshold = Some(multipartFileSizeThresholdBytes)))
 
     // Additional models used in error responses
     registerModel[ValidationError]()

--- a/draft-api/src/main/scala/no/ndla/draftapi/service/FileStorageService.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/service/FileStorageService.scala
@@ -30,16 +30,15 @@ trait FileStorageService {
         contentType: String,
         size: Long
     ): Try[String] = {
-      val metadata = new ObjectMetadata()
+      val uploadPath = s"$resourceDirectory/$storageKey"
+      val metadata   = new ObjectMetadata()
       metadata.setContentType(contentType)
       metadata.setContentLength(size)
 
-      val uploadPath = s"$resourceDirectory/$storageKey"
-
-      Try(
-        amazonClient
-          .putObject(new PutObjectRequest(AttachmentStorageName, uploadPath, stream, metadata))
-      ).map(_ => uploadPath)
+      Try {
+        val request = new PutObjectRequest(AttachmentStorageName, uploadPath, stream, metadata)
+        amazonClient.putObject(request)
+      }.map(_ => uploadPath)
     }
 
     def resourceExists(storageKey: String): Boolean = resourceWithPathExists(s"$resourceDirectory/$storageKey")


### PR DESCRIPTION
Sets threshold before streaming file to disk rather than memory to avoid heap ooms when uploading big files :^)
Ser ut til å løse problemet med opplastning av filer. Jeg prøvde med en på 279MB og det gikk fra å ikke fungere til å fungere :smile: 