### PR TITLE
article-api: Fix swagger mount point :^)

### DIFF
--- a/article-api/src/main/scala/no/ndla/articleapi/controller/SwaggerDocControllerConfig.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/controller/SwaggerDocControllerConfig.scala
@@ -10,6 +10,7 @@ package no.ndla.articleapi.controller
 import no.ndla.articleapi.Props
 import no.ndla.network.tapir.auth.Permission
 import no.ndla.network.tapir.{SwaggerControllerConfig, SwaggerInfo}
+import sttp.tapir._
 
 trait SwaggerDocControllerConfig extends SwaggerControllerConfig {
   this: Props =>
@@ -20,7 +21,7 @@ trait SwaggerDocControllerConfig extends SwaggerControllerConfig {
     )
 
     val swaggerInfo: SwaggerInfo = SwaggerInfo(
-      mountPoint = "/article-api/api-docs",
+      mountPoint = "article-api" / "api-docs",
       description = "Searching and fetching all articles published on the NDLA platform.\n\n" +
         "The Article API provides an endpoint for searching and fetching articles. Different meta-data is attached to the " +
         "returned articles, and typical examples of this are language and license.\n" +

--- a/frontpage-api/src/main/scala/no/ndla/frontpageapi/controller/SwaggerDocControllerConfig.scala
+++ b/frontpage-api/src/main/scala/no/ndla/frontpageapi/controller/SwaggerDocControllerConfig.scala
@@ -10,6 +10,7 @@ package no.ndla.frontpageapi.controller
 import no.ndla.frontpageapi.Props
 import no.ndla.network.tapir.auth.Permission
 import no.ndla.network.tapir.{SwaggerControllerConfig, SwaggerInfo}
+import sttp.tapir._
 
 trait SwaggerDocControllerConfig extends SwaggerControllerConfig {
   this: Props =>
@@ -18,7 +19,7 @@ trait SwaggerDocControllerConfig extends SwaggerControllerConfig {
     private val scopes = Permission.toSwaggerMap(Permission.thatStartsWith("frontpage"))
 
     val swaggerInfo: SwaggerInfo = SwaggerInfo(
-      mountPoint = "/frontpage-api/api-docs",
+      mountPoint = "frontpage-api" / "api-docs",
       description = "Service for fetching frontpage data",
       authUrl = props.Auth0LoginEndpoint,
       scopes = scopes

--- a/oembed-proxy/src/main/scala/no/ndla/oembedproxy/controller/SwaggerDocControllerConfig.scala
+++ b/oembed-proxy/src/main/scala/no/ndla/oembedproxy/controller/SwaggerDocControllerConfig.scala
@@ -9,6 +9,7 @@ package no.ndla.oembedproxy.controller
 
 import no.ndla.network.tapir.{SwaggerControllerConfig, SwaggerInfo}
 import no.ndla.oembedproxy.Props
+import sttp.tapir._
 
 import scala.collection.immutable.ListMap
 
@@ -17,7 +18,7 @@ trait SwaggerDocControllerConfig extends SwaggerControllerConfig {
 
   object SwaggerDocControllerConfig {
     val swaggerInfo: SwaggerInfo = SwaggerInfo(
-      mountPoint = "/oembed-proxy/api-docs",
+      mountPoint = "oembed-proxy" / "api-docs",
       description = "Convert any NDLA resource to an oEmbed embeddable resource.",
       authUrl = props.Auth0LoginEndpoint,
       scopes = ListMap.empty


### PR DESCRIPTION
Må bruke tapir syntax/dsl for å lage `EndpointInput` typen når det er mer enn én part.