### PR TITLE
frontpage-api: Add V9 migration that does the same as V8

### DIFF
--- a/frontpage-api/src/main/scala/no/ndla/frontpageapi/db/migration/V9__add_missing_fields.scala
+++ b/frontpage-api/src/main/scala/no/ndla/frontpageapi/db/migration/V9__add_missing_fields.scala
@@ -1,0 +1,72 @@
+/*
+ * Part of NDLA frontpage-api
+ * Copyright (C) 2023 NDLA
+ *
+ * See LICENSE
+ */
+
+package no.ndla.frontpageapi.db.migration
+
+import io.circe.parser.parse
+import io.circe.{Json, JsonObject}
+import no.ndla.frontpageapi.repository._
+import org.flywaydb.core.api.migration.{BaseJavaMigration, Context}
+import org.postgresql.util.PGobject
+import scalikejdbc._
+
+import scala.util.{Failure, Success}
+
+class V9__add_missing_fields extends BaseJavaMigration {
+  override def migrate(context: Context): Unit = DB(context.getConnection)
+    .autoClose(false)
+    .withinTx { implicit session =>
+      subjectPageData
+        .map(convertSubjectpage)
+        .foreach(update)
+    }
+
+  private def subjectPageData(implicit session: DBSession): List[DBSubjectPage] = {
+    sql"select id, document from subjectpage"
+      .map(rs => DBSubjectPage(rs.long("id"), rs.string("document")))
+      .list()
+  }
+
+  implicit class JsonObjectOps(obj: JsonObject) {
+    def addIfNotExists(key: String, value: Json): JsonObject = {
+      if (obj.contains(key)) obj
+      else obj.add(key, value)
+    }
+  }
+
+  def convertSubjectpage(subjectPageData: DBSubjectPage): DBSubjectPage =
+    parse(subjectPageData.document).toTry match {
+      case Success(value) =>
+        val newSubjectPage = value.mapObject(obj => {
+          obj
+            .addIfNotExists("connectedTo", Json.arr())
+            .addIfNotExists("buildsOn", Json.arr())
+            .addIfNotExists("leadsTo", Json.arr())
+            .remove("topical")
+            .remove("mostRead")
+            .remove("latestContent")
+            .remove("filters")
+            .remove("layout")
+            .remove("twitter")
+            .remove("facebook")
+            .remove("goTo")
+        })
+        DBSubjectPage(subjectPageData.id, newSubjectPage.noSpacesDropNull)
+      case Failure(ex) =>
+        println(s"Failed to parse subject page data for id '${subjectPageData.id}': ${ex.getMessage}")
+        throw ex
+    }
+
+  private def update(subjectPageData: DBSubjectPage)(implicit session: DBSession) = {
+    val dataObject = new PGobject()
+    dataObject.setType("jsonb")
+    dataObject.setValue(subjectPageData.document)
+
+    sql"update subjectpage set document = $dataObject where id = ${subjectPageData.id}"
+      .update()
+  }
+}

--- a/frontpage-api/src/test/scala/no/ndla/frontpageapi/db/migration/V9__add_missing_fields_Test.scala
+++ b/frontpage-api/src/test/scala/no/ndla/frontpageapi/db/migration/V9__add_missing_fields_Test.scala
@@ -1,0 +1,24 @@
+/*
+ * Part of NDLA frontpage-api
+ * Copyright (C) 2023 NDLA
+ *
+ * See LICENSE
+ */
+
+package no.ndla.frontpageapi.db.migration
+
+import no.ndla.frontpageapi.{TestEnvironment, UnitSuite}
+
+class V9__add_missing_fields_Test extends UnitSuite with TestEnvironment {
+  val migration = new V9__add_missing_fields
+
+  test("that empty empty lists for connectedTo, buildsOn and leadsTo is added, and unused attributes are removed") {
+    val before =
+      """{"name":"Kinesisk","layout":"double","bannerImage":{"desktopImageId":65},"about":[{"title":"Om kinesisk","description":"Kinesiskfaget gir en grunnleggende innsikt i levemåter og tankesett i Kina.","language":"nb","visualElement":{"type":"brightcove","id":"182071"}}],"metaDescription":[],"mostRead":["urn:resource:1:148063"],"editorsChoices":["urn:resource:1:163488"],"goTo":[]}"""
+
+    val after =
+      """{"name":"Kinesisk","bannerImage":{"desktopImageId":65},"about":[{"title":"Om kinesisk","description":"Kinesiskfaget gir en grunnleggende innsikt i levemåter og tankesett i Kina.","language":"nb","visualElement":{"type":"brightcove","id":"182071"}}],"metaDescription":[],"editorsChoices":["urn:resource:1:163488"],"connectedTo":[],"buildsOn":[],"leadsTo":[]}"""
+
+    migration.convertSubjectpage(DBSubjectPage(1, before)).document should be(after)
+  }
+}


### PR DESCRIPTION
Noen subjectpages feiler i test etter nyeste migreringen (Feks [198](https://api.test.ndla.no/frontpage-api/v1/subjectpage/198)).
Dette er fordi den forrige migreringen brukte litt utdaterte klasser for å parse det som lå i databasen (Påkrevd `mobileImageId` i `BannerImage` feks).

Denne PR'en legger til en migrering som ikke bruker noen case classer men bare bruker circe for å manipulere json :smile: 
