### PR TITLE
Sets responsible to the cloner

### DIFF
--- a/draft-api/src/main/scala/no/ndla/draftapi/service/WriteService.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/service/WriteService.scala
@@ -17,6 +17,7 @@ import no.ndla.common.ContentURIUtil.parseArticleIdAndRevision
 import no.ndla.common.configuration.Constants.EmbedTagName
 import no.ndla.common.errors.ValidationException
 import no.ndla.common.implicits.TryQuestionMark
+import no.ndla.common.model.domain.Responsible
 import no.ndla.common.model.domain.draft.DraftStatus.{IN_PROGRESS, PLANNED, PUBLISHED}
 import no.ndla.common.model.domain.draft.{Draft, DraftStatus}
 import no.ndla.common.model.{NDLADate, domain => common}
@@ -109,6 +110,7 @@ trait WriteService {
               )
               newTitles = if (usePostFix) article.title.map(t => t.copy(title = t.title + " (Kopi)")) else article.title
               newContents <- contentWithClonedFiles(article.content.toList)
+              newResponsible = Some(Responsible(userInfo.id, clock.now()))
               articleToInsert = article.copy(
                 id = Some(newId),
                 title = newTitles,
@@ -118,6 +120,7 @@ trait WriteService {
                 created = clock.now(),
                 published = clock.now(),
                 updatedBy = userInfo.id,
+                responsible = newResponsible,
                 status = status,
                 notes = notes
               )

--- a/draft-api/src/test/scala/no/ndla/draftapi/service/WriteServiceTest.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/service/WriteServiceTest.scala
@@ -548,6 +548,7 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
       created = today,
       published = today,
       updatedBy = userinfo.id,
+      responsible = Some(Responsible(userinfo.id, today)),
       status = Status(DraftStatus.PLANNED, Set.empty),
       notes = article.notes ++
         converterService
@@ -596,6 +597,7 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
       created = today,
       published = today,
       updatedBy = userinfo.id,
+      responsible = Some(Responsible(userinfo.id, today)),
       status = Status(DraftStatus.PLANNED, Set.empty),
       notes = article.notes ++
         converterService


### PR DESCRIPTION
Fixes NDLANO/Issues#3776

Setter ansvarlig ved kloning. Dette er fordi at når du kloner en artikkel så får du ikkje lov å lagre før du har oppdatert taksonomi. Men siden oppdatering av taksonomi lagrer artikkelen i bakkant, og lagringa feiler fordi ansvarlig ikkje er satt, så blir ikkje lagreknapp i taksonomiblokk grønn. Så derfor trur brukere av ed at alt feila, og lager ny kopi!

Test:
Sjekk at ansvarlig blir satt ved kloning av artikkel.