### PR TITLE
#3785: Lowercase slugs in draft-api & article-api

### DIFF
--- a/article-api/src/main/resources/no/ndla/articleapi/db/migration/V44_SlugsToLowercase.sql
+++ b/article-api/src/main/resources/no/ndla/articleapi/db/migration/V44_SlugsToLowercase.sql
@@ -1,0 +1,2 @@
+UPDATE contentdata
+SET slug = LOWER(slug);

--- a/article-api/src/test/scala/no/ndla/articleapi/repository/ArticleRepositoryTest.scala
+++ b/article-api/src/test/scala/no/ndla/articleapi/repository/ArticleRepositoryTest.scala
@@ -280,9 +280,9 @@ class ArticleRepositoryTest
 
     repository.updateArticleFromDraftApi(article1, List.empty).get
     repository.updateArticleFromDraftApi(article2, List.empty).get
-    repository.updateArticleFromDraftApi(article3, List.empty).get
+    val inserted3 = repository.updateArticleFromDraftApi(article3, List.empty).get
 
-    repository.withSlug("Detti-er-ein-slug").get.article.get should be(article3)
+    repository.withSlug("Detti-er-ein-slug").get.article.get should be(inserted3)
   }
 
 }

--- a/draft-api/src/main/resources/no/ndla/draftapi/db/migration/V51__SlugsToLowercase.sql
+++ b/draft-api/src/main/resources/no/ndla/draftapi/db/migration/V51__SlugsToLowercase.sql
@@ -1,0 +1,2 @@
+UPDATE articledata
+SET slug = LOWER(slug);

--- a/draft-api/src/test/scala/no/ndla/draftapi/repository/DraftRepositoryTest.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/repository/DraftRepositoryTest.scala
@@ -417,4 +417,12 @@ class DraftRepositoryTest extends IntegrationSuite(EnablePostgresContainer = tru
     relatedId should be(2L)
 
   }
+
+  test("That slugs are stored and extracted as lowercase") {
+    val article = sampleArticle.copy(id = Some(1), slug = Some("ApeKaTt"))
+
+    val inserted = repository.insert(article)(AutoSession)
+    val fetched  = repository.withSlug("aPEkAtT")(ReadOnlyAutoSession).get
+    fetched should be(inserted)
+  }
 }


### PR DESCRIPTION
Fixes NDLANO/Issues#3785

Gjør at alle slugs lagres i lowercase og vi konverterer alle oppslag til lowercase før oppslag i databasen.
Tror ikke det trenger endringer noen annen plass.