### PR TITLE
validation: Allow `data-alt` for h5p elements

### DIFF
--- a/validation/src/main/resources/embed-tag-rules.json
+++ b/validation/src/main/resources/embed-tag-rules.json
@@ -26,6 +26,13 @@
             "required": false,
             "dataType": "URL"
           }
+        },
+        {
+          "name": "data-alt",
+          "validation": {
+            "required": false,
+            "dataType": "STRING"
+          }
         }
       ]
     },


### PR DESCRIPTION
Relates to https://github.com/NDLANO/Issues/issues/3758

Legger til støtte for `data-alt` på `h5p` `ndlaembed`'s
