### PR TITLE
concept-api: Add gloss to index and summary

### DIFF
--- a/concept-api/src/main/scala/no/ndla/conceptapi/model/api/ConceptSummary.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/model/api/ConceptSummary.scala
@@ -34,5 +34,6 @@ case class ConceptSummary(
     @(ApiModelProperty @field)(description = "URL for the source of the concept") source: Option[String],
     @(ApiModelProperty @field)(description = "Object with data representing the editor responsible for this concept") responsible: Option[ConceptResponsible],
     @(ApiModelProperty @field)(description = "Type of concept. 'concept', or 'gloss'") conceptType: String,
+    @(ApiModelProperty @field)(description = "Information about the gloss") glossData: Option[GlossData]
 )
 // format: on

--- a/concept-api/src/main/scala/no/ndla/conceptapi/model/domain/Concept.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/model/domain/Concept.scala
@@ -17,7 +17,7 @@ import no.ndla.language.Language.getSupportedLanguages
 import org.json4s.FieldSerializer._
 import org.json4s.ext.{EnumNameSerializer, JavaTimeSerializers}
 import org.json4s.native.Serialization._
-import org.json4s.{DefaultFormats, FieldSerializer, Formats}
+import org.json4s.{DefaultFormats, FieldSerializer, Formats, Serializer}
 import scalikejdbc._
 
 import scala.util.{Failure, Success, Try}
@@ -84,13 +84,14 @@ trait DBConcept {
         meta.glossData
       )
     }
-
-    val jsonEncoder: Formats = DefaultFormats +
-      Json4s.serializer(ConceptStatus) +
-      new EnumNameSerializer(ConceptType) +
-      new EnumNameSerializer(WordClass) ++
-      JavaTimeSerializers.all +
+    val serializers: List[Serializer[_]] = List(
+      Json4s.serializer(ConceptStatus),
+      new EnumNameSerializer(ConceptType),
+      new EnumNameSerializer(WordClass),
       NDLADate.Json4sSerializer
+    ) ++ JavaTimeSerializers.all
+
+    val jsonEncoder: Formats = DefaultFormats ++ serializers
 
     val repositorySerializer: Formats = jsonEncoder +
       FieldSerializer[Concept](

--- a/concept-api/src/main/scala/no/ndla/conceptapi/model/search/SearchableConcept.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/model/search/SearchableConcept.scala
@@ -33,5 +33,7 @@ case class SearchableConcept(
     articleIds: Seq[Long],
     created: NDLADate,
     source: Option[String],
-    responsible: Option[Responsible]
+    responsible: Option[Responsible],
+    gloss: Option[String],
+    domainObject: domain.Concept
 )

--- a/concept-api/src/main/scala/no/ndla/conceptapi/service/search/DraftConceptSearchService.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/service/search/DraftConceptSearchService.scala
@@ -117,6 +117,7 @@ trait DraftConceptSearchService {
                 simpleStringQuery(query).field(s"title.$language", 2),
                 simpleStringQuery(query).field(s"content.$language", 1),
                 simpleStringQuery(query).field(s"tags.$language", 1),
+                simpleStringQuery(query).field(s"gloss", 1),
                 idsQuery(query)
               ) ++
                 buildNestedEmbedField(Some(query), None, settings.searchLanguage, settings.fallback) ++

--- a/concept-api/src/main/scala/no/ndla/conceptapi/service/search/PublishedConceptSearchService.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/service/search/PublishedConceptSearchService.scala
@@ -121,6 +121,7 @@ trait PublishedConceptSearchService {
                 List(
                   simpleStringQuery(query).field(s"title.$language", 2),
                   simpleStringQuery(query).field(s"content.$language", 1),
+                  simpleStringQuery(query).field(s"gloss", 1),
                   idsQuery(query)
                 ) ++
                   buildNestedEmbedField(Some(query), None, settings.searchLanguage, settings.fallback) ++

--- a/concept-api/src/test/scala/no/ndla/conceptapi/service/search/DraftConceptSearchServiceTest.scala
+++ b/concept-api/src/test/scala/no/ndla/conceptapi/service/search/DraftConceptSearchServiceTest.scala
@@ -203,7 +203,7 @@ class DraftConceptSearchServiceTest extends IntegrationSuite(EnableElasticsearch
     conceptType = ConceptType.GLOSS,
     glossData = Some(
       GlossData(
-        gloss = "gloss",
+        gloss = "glossorama",
         wordClass = WordClass.NOUN,
         originalLanguage = "de",
         transcriptions = Map.empty,
@@ -859,5 +859,11 @@ class DraftConceptSearchServiceTest extends IntegrationSuite(EnableElasticsearch
       val Success(search) = draftConceptSearchService.all(searchSettings.copy(conceptType = Some("gloss")))
       search.totalCount should be(1)
     }
+  }
+
+  test("That searching for gloss data matches") {
+    val Success(search) = draftConceptSearchService.matchingQuery("glossorama", searchSettings)
+    search.totalCount should be(1)
+    search.results.head.id should be(13)
   }
 }

--- a/concept-api/src/test/scala/no/ndla/conceptapi/service/search/PublishedConceptSearchServiceTest.scala
+++ b/concept-api/src/test/scala/no/ndla/conceptapi/service/search/PublishedConceptSearchServiceTest.scala
@@ -181,7 +181,7 @@ class PublishedConceptSearchServiceTest
     conceptType = ConceptType.GLOSS,
     glossData = Some(
       GlossData(
-        gloss = "gloss",
+        gloss = "glossorama",
         wordClass = WordClass.NOUN,
         originalLanguage = "de",
         transcriptions = Map.empty,
@@ -781,6 +781,12 @@ class PublishedConceptSearchServiceTest
       val Success(search) = publishedConceptSearchService.all(searchSettings.copy(conceptType = Some("gloss")))
       search.totalCount should be(1)
     }
+  }
+
+  test("That searching for gloss data matches") {
+    val Success(search) = publishedConceptSearchService.matchingQuery("glossorama", searchSettings)
+    search.totalCount should be(1)
+    search.results.head.id should be(12)
   }
 
 }


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/3791

Glemte å sjekke assignees så jeg stjal denne fra @rauboti :sweat_smile: 
Legger til et uindeksert felt `domainObject` til `SearchableConcept` på samme måte som vi har på images.
Legger også til indeksert felt for `gloss` for søkbarhet.