### PR TITLE
draft-api: Update priority field

### DIFF
--- a/common/src/main/scala/no/ndla/common/model/domain/Priority.scala
+++ b/common/src/main/scala/no/ndla/common/model/domain/Priority.scala
@@ -1,3 +1,10 @@
+/*
+ * Part of NDLA common.
+ * Copyright (C) 2023 NDLA
+ *
+ * See LICENSE
+ */
+
 package no.ndla.common.model.domain
 import enumeratum._
 import no.ndla.common.errors.ValidationException

--- a/common/src/main/scala/no/ndla/common/model/domain/Priority.scala
+++ b/common/src/main/scala/no/ndla/common/model/domain/Priority.scala
@@ -1,0 +1,28 @@
+package no.ndla.common.model.domain
+import enumeratum._
+import no.ndla.common.errors.ValidationException
+
+import scala.util.{Failure, Success, Try}
+
+sealed abstract class Priority(override val entryName: String) extends EnumEntry
+
+object Priority extends Enum[Priority] {
+  case object Prioritized extends Priority("prioritized")
+  case object OnHold      extends Priority("on-hold")
+  case object Unspecified extends Priority("unspecified")
+
+  val values: IndexedSeq[Priority] = findValues
+
+  def all: Seq[String]                     = Priority.values.map(_.entryName)
+  def valueOf(s: String): Option[Priority] = Priority.withNameOption(s)
+
+  def valueOfOrError(s: String): Try[Priority] =
+    valueOf(s) match {
+      case Some(p) => Success(p)
+      case None =>
+        val validPriorities = values.map(_.toString).mkString(", ")
+        Failure(
+          ValidationException("priority", s"'$s' is not a valid priority. Must be one of $validPriorities")
+        )
+    }
+}

--- a/common/src/main/scala/no/ndla/common/model/domain/draft/Draft.scala
+++ b/common/src/main/scala/no/ndla/common/model/domain/draft/Draft.scala
@@ -57,6 +57,7 @@ object Draft {
     Json4s.serializer(DraftStatus),
     Json4s.serializer(ArticleType),
     Json4s.serializer(RevisionStatus),
+    Json4s.serializer(Priority),
     NDLADate.Json4sSerializer
   ) ++
     JavaTimeSerializers.all ++

--- a/common/src/main/scala/no/ndla/common/model/domain/draft/Draft.scala
+++ b/common/src/main/scala/no/ndla/common/model/domain/draft/Draft.scala
@@ -43,7 +43,7 @@ case class Draft(
     responsible: Option[Responsible],
     slug: Option[String],
     comments: Seq[Comment],
-    prioritized: Boolean,
+    priority: Priority,
     started: Boolean
 ) extends Content {
 

--- a/draft-api/src/main/scala/no/ndla/draftapi/db/migration/V52__UpdatePrioritizedField.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/db/migration/V52__UpdatePrioritizedField.scala
@@ -1,0 +1,72 @@
+/*
+ * Part of NDLA draft-api.
+ * Copyright (C) 2023 NDLA
+ *
+ * See LICENSE
+ */
+
+package no.ndla.draftapi.db.migration
+
+import io.circe.syntax.EncoderOps
+import io.circe.{parser}
+import org.flywaydb.core.api.migration.{BaseJavaMigration, Context}
+import org.postgresql.util.PGobject
+import scalikejdbc.{DB, DBSession, _}
+
+class V52__UpdatePrioritizedField extends BaseJavaMigration {
+
+  def countAllRows(implicit session: DBSession): Option[Long] = {
+    sql"select count(*) from articledata where document is not NULL"
+      .map(rs => rs.long("count"))
+      .single()
+  }
+
+  def allRows(offset: Long)(implicit session: DBSession): Seq[(Long, String)] = {
+    sql"select id, document, article_id from articledata where document is not null order by id limit 1000 offset $offset"
+      .map(rs => {
+        (rs.long("id"), rs.string("document"))
+      })
+      .list()
+  }
+
+  def updateRow(document: String, id: Long)(implicit session: DBSession): Int = {
+    val dataObject = new PGobject()
+    dataObject.setType("jsonb")
+    dataObject.setValue(document)
+
+    sql"update articledata set document = $dataObject where id = $id"
+      .update()
+  }
+
+  override def migrate(context: Context): Unit = DB(context.getConnection)
+    .autoClose(false)
+    .withinTx { session => migrateRows(session) }
+
+  def migrateRows(implicit session: DBSession): Unit = {
+    val count        = countAllRows.get
+    var numPagesLeft = (count / 1000) + 1
+    var offset       = 0L
+
+    while (numPagesLeft > 0) {
+      allRows(offset * 1000).map { case (id, document) =>
+        updateRow(convertDocument(document), id)
+      }: Unit
+      numPagesLeft -= 1
+      offset += 1
+    }
+  }
+
+  private[migration] def convertDocument(document: String): String = {
+    val oldArticle     = parser.parse(document).toTry.get
+    val cursor         = oldArticle.hcursor
+    val oldPrioritized = cursor.downField("prioritized").as[Boolean].toTry.get
+    val newValue = if (oldPrioritized) {
+      "prioritized"
+    } else {
+      "unspecified"
+    }
+    val newJson = cursor.withFocus(_.mapObject(obj => obj.add("priority", newValue.asJson).remove("prioritized")))
+    newJson.top.get.noSpaces
+  }
+
+}

--- a/draft-api/src/main/scala/no/ndla/draftapi/integration/SearchApiClient.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/integration/SearchApiClient.scala
@@ -10,7 +10,7 @@ package no.ndla.draftapi.integration
 import com.typesafe.scalalogging.StrictLogging
 import enumeratum.Json4s
 import no.ndla.common.model.NDLADate
-import no.ndla.common.model.domain.{ArticleType, Availability}
+import no.ndla.common.model.domain.{ArticleType, Availability, Priority}
 import no.ndla.common.model.domain.draft.{Draft, DraftStatus, RevisionStatus}
 import no.ndla.draftapi.Props
 import no.ndla.draftapi.service.ConverterService
@@ -41,6 +41,7 @@ trait SearchApiClient {
         new EnumNameSerializer(Availability) +
         Json4s.serializer(DraftStatus) +
         Json4s.serializer(ArticleType) +
+        Json4s.serializer(Priority) +
         Json4s.serializer(RevisionStatus) ++
         JavaTimeSerializers.all ++
         JavaTypesSerializers.all +

--- a/draft-api/src/main/scala/no/ndla/draftapi/model/api/Article.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/model/api/Article.scala
@@ -46,6 +46,6 @@ case class Article(
     @(ApiModelProperty @field)(description = "Object with data representing the editor responsible for this article") responsible: Option[DraftResponsible],
     @(ApiModelProperty @field)(description = "The path to the frontpage article") slug: Option[String],
     @(ApiModelProperty @field)(description = "Information about comments attached to the article") comments: Seq[Comment],
-    @(ApiModelProperty @field)(description = "If the article should be prioritized. Possible values are prioritized, on-hold, undefined") priority: String,
+    @(ApiModelProperty @field)(description = "If the article should be prioritized. Possible values are prioritized, on-hold, unspecified") priority: String,
     @(ApiModelProperty @field)(description = "If the article has been edited after last status or responsible change") started: Boolean
 )

--- a/draft-api/src/main/scala/no/ndla/draftapi/model/api/Article.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/model/api/Article.scala
@@ -46,6 +46,7 @@ case class Article(
     @(ApiModelProperty @field)(description = "Object with data representing the editor responsible for this article") responsible: Option[DraftResponsible],
     @(ApiModelProperty @field)(description = "The path to the frontpage article") slug: Option[String],
     @(ApiModelProperty @field)(description = "Information about comments attached to the article") comments: Seq[Comment],
+    @(ApiModelProperty @field)(description = "If the article should be prioritized") prioritized: Boolean,
     @(ApiModelProperty @field)(description = "If the article should be prioritized. Possible values are prioritized, on-hold, unspecified") priority: String,
     @(ApiModelProperty @field)(description = "If the article has been edited after last status or responsible change") started: Boolean
 )

--- a/draft-api/src/main/scala/no/ndla/draftapi/model/api/Article.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/model/api/Article.scala
@@ -46,6 +46,6 @@ case class Article(
     @(ApiModelProperty @field)(description = "Object with data representing the editor responsible for this article") responsible: Option[DraftResponsible],
     @(ApiModelProperty @field)(description = "The path to the frontpage article") slug: Option[String],
     @(ApiModelProperty @field)(description = "Information about comments attached to the article") comments: Seq[Comment],
-    @(ApiModelProperty @field)(description = "If the article should be prioritized") prioritized: Boolean,
+    @(ApiModelProperty @field)(description = "If the article should be prioritized. Possible values are prioritized, on-hold, undefined") priority: String,
     @(ApiModelProperty @field)(description = "If the article has been edited after last status or responsible change") started: Boolean
 )

--- a/draft-api/src/main/scala/no/ndla/draftapi/model/api/NewArticle.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/model/api/NewArticle.scala
@@ -38,5 +38,5 @@ case class NewArticle(
     @(ApiModelProperty @field)(description = "NDLA ID representing the editor responsible for this article") responsibleId: Option[String],
     @(ApiModelProperty @field)(description = "The path to the frontpage article") slug: Option[String],
     @(ApiModelProperty @field)(description = "Information about a comment attached to an article") comments: List[NewComment],
-    @(ApiModelProperty @field)(description = "If the article should be prioritized. Possible values are prioritized, on-hold, undefined") priority: Option[String]
+    @(ApiModelProperty @field)(description = "If the article should be prioritized. Possible values are prioritized, on-hold, unspecified") priority: Option[String]
 )

--- a/draft-api/src/main/scala/no/ndla/draftapi/model/api/NewArticle.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/model/api/NewArticle.scala
@@ -38,5 +38,6 @@ case class NewArticle(
     @(ApiModelProperty @field)(description = "NDLA ID representing the editor responsible for this article") responsibleId: Option[String],
     @(ApiModelProperty @field)(description = "The path to the frontpage article") slug: Option[String],
     @(ApiModelProperty @field)(description = "Information about a comment attached to an article") comments: List[NewComment],
+    @(ApiModelProperty @field)(description = "If the article should be prioritized") prioritized: Option[Boolean],
     @(ApiModelProperty @field)(description = "If the article should be prioritized. Possible values are prioritized, on-hold, unspecified") priority: Option[String]
 )

--- a/draft-api/src/main/scala/no/ndla/draftapi/model/api/NewArticle.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/model/api/NewArticle.scala
@@ -38,5 +38,5 @@ case class NewArticle(
     @(ApiModelProperty @field)(description = "NDLA ID representing the editor responsible for this article") responsibleId: Option[String],
     @(ApiModelProperty @field)(description = "The path to the frontpage article") slug: Option[String],
     @(ApiModelProperty @field)(description = "Information about a comment attached to an article") comments: List[NewComment],
-    @(ApiModelProperty @field)(description = "If the article should be prioritized") prioritized: Option[Boolean]
+    @(ApiModelProperty @field)(description = "If the article should be prioritized. Possible values are prioritized, on-hold, undefined") priority: Option[String]
 )

--- a/draft-api/src/main/scala/no/ndla/draftapi/model/api/UpdatedArticle.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/model/api/UpdatedArticle.scala
@@ -41,5 +41,6 @@ case class UpdatedArticle(
     @(ApiModelProperty @field)(description = "NDLA ID representing the editor responsible for this article") responsibleId: Deletable[String],
     @(ApiModelProperty @field)(description = "The path to the frontpage article") slug: Option[String],
     @(ApiModelProperty @field)(description = "Information about a comment attached to an article") comments: Option[List[UpdatedComment]],
+    @(ApiModelProperty @field)(description = "If the article should be prioritized") prioritized: Option[Boolean],
     @(ApiModelProperty @field)(description = "If the article should be prioritized. Possible values are prioritized, on-hold, unspecified") priority: Option[String]
 )

--- a/draft-api/src/main/scala/no/ndla/draftapi/model/api/UpdatedArticle.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/model/api/UpdatedArticle.scala
@@ -41,5 +41,5 @@ case class UpdatedArticle(
     @(ApiModelProperty @field)(description = "NDLA ID representing the editor responsible for this article") responsibleId: Deletable[String],
     @(ApiModelProperty @field)(description = "The path to the frontpage article") slug: Option[String],
     @(ApiModelProperty @field)(description = "Information about a comment attached to an article") comments: Option[List[UpdatedComment]],
-    @(ApiModelProperty @field)(description = "If the article should be prioritized. Possible values are prioritized, on-hold, undefined") priority: Option[String]
+    @(ApiModelProperty @field)(description = "If the article should be prioritized. Possible values are prioritized, on-hold, unspecified") priority: Option[String]
 )

--- a/draft-api/src/main/scala/no/ndla/draftapi/model/api/UpdatedArticle.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/model/api/UpdatedArticle.scala
@@ -41,5 +41,5 @@ case class UpdatedArticle(
     @(ApiModelProperty @field)(description = "NDLA ID representing the editor responsible for this article") responsibleId: Deletable[String],
     @(ApiModelProperty @field)(description = "The path to the frontpage article") slug: Option[String],
     @(ApiModelProperty @field)(description = "Information about a comment attached to an article") comments: Option[List[UpdatedComment]],
-    @(ApiModelProperty @field)(description = "If the article should be prioritized") prioritized: Option[Boolean]
+    @(ApiModelProperty @field)(description = "If the article should be prioritized. Possible values are prioritized, on-hold, undefined") priority: Option[String]
 )

--- a/draft-api/src/main/scala/no/ndla/draftapi/repository/DraftRepository.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/repository/DraftRepository.scala
@@ -10,7 +10,7 @@ package no.ndla.draftapi.repository
 import com.typesafe.scalalogging.StrictLogging
 import no.ndla.common.Clock
 import no.ndla.common.errors.RollbackException
-import no.ndla.common.model.domain.EditorNote
+import no.ndla.common.model.domain.{EditorNote, Priority}
 import no.ndla.common.model.domain.draft.{Draft, DraftStatus}
 import no.ndla.draftapi.integration.DataSource
 import no.ndla.draftapi.model.api.{ArticleVersioningException, ErrorHelpers, GenerateIDException, NotFoundException}
@@ -118,7 +118,7 @@ trait DraftRepository {
                 .toList,
               previousVersionsNotes = article.previousVersionsNotes ++ article.notes,
               responsible = if (keepDraftData) article.responsible else None,
-              prioritized = if (keepDraftData) article.prioritized else false,
+              priority = if (keepDraftData) article.priority else Priority.Unspecified,
               comments = if (keepDraftData) article.comments else Seq.empty
             )
 

--- a/draft-api/src/test/scala/no/ndla/draftapi/TestData.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/TestData.scala
@@ -10,6 +10,7 @@ package no.ndla.draftapi
 import no.ndla.common.configuration.Constants.EmbedTagName
 import no.ndla.common.model
 import no.ndla.common.model.api.DraftCopyright
+import no.ndla.common.model.domain.Priority
 import no.ndla.common.model.domain.draft.Draft
 import no.ndla.common.model.domain.draft.DraftStatus._
 import no.ndla.common.model.{NDLADate, api => commonApi, domain => common}
@@ -107,8 +108,8 @@ object TestData {
     responsible = None,
     None,
     Seq.empty,
-    false,
-    false
+    priority = Priority.Unspecified.entryName,
+    started = false
   )
 
   val blankUpdatedArticle: UpdatedArticle = api.UpdatedArticle(
@@ -222,7 +223,7 @@ object TestData {
     None,
     None,
     Seq.empty,
-    false,
+    Priority.Unspecified.entryName,
     false
   )
 
@@ -273,7 +274,7 @@ object TestData {
     None,
     None,
     Seq.empty,
-    false,
+    Priority.Unspecified.entryName,
     false
   )
 
@@ -306,7 +307,7 @@ object TestData {
     None,
     None,
     Seq.empty,
-    false,
+    Priority.Unspecified,
     false
   )
 
@@ -339,7 +340,7 @@ object TestData {
     None,
     None,
     Seq.empty,
-    false,
+    Priority.Unspecified,
     false
   )
 
@@ -374,7 +375,7 @@ object TestData {
     None,
     None,
     Seq.empty,
-    false,
+    Priority.Unspecified,
     false
   )
 
@@ -460,7 +461,7 @@ object TestData {
     None,
     None,
     Seq.empty,
-    false,
+    Priority.Unspecified,
     false
   )
 
@@ -514,7 +515,7 @@ object TestData {
     None,
     None,
     Seq.empty,
-    false,
+    Priority.Unspecified.entryName,
     false
   )
 

--- a/draft-api/src/test/scala/no/ndla/draftapi/TestData.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/TestData.scala
@@ -109,36 +109,38 @@ object TestData {
     None,
     Seq.empty,
     priority = Priority.Unspecified.entryName,
-    started = false
+    started = false,
+    prioritized = false
   )
 
   val blankUpdatedArticle: UpdatedArticle = api.UpdatedArticle(
-    1,
-    None,
-    None,
-    None,
-    None,
-    None,
-    None,
-    None,
-    None,
-    Right(None),
-    None,
-    None,
-    None,
-    None,
-    None,
-    None,
-    None,
-    None,
-    None,
-    None,
-    None,
-    None,
-    Right(None),
-    None,
-    None,
-    None
+    revision = 1,
+    language = None,
+    title = None,
+    status = None,
+    published = None,
+    content = None,
+    tags = None,
+    introduction = None,
+    metaDescription = None,
+    metaImage = Right(None),
+    visualElement = None,
+    copyright = None,
+    requiredLibraries = None,
+    articleType = None,
+    notes = None,
+    editorLabels = None,
+    grepCodes = None,
+    conceptIds = None,
+    createNewVersion = None,
+    availability = None,
+    relatedContent = None,
+    revisionMeta = None,
+    responsibleId = Right(None),
+    slug = None,
+    comments = None,
+    prioritized = None,
+    priority = None
   )
 
   val sampleApiUpdateArticle: UpdatedArticle = blankUpdatedArticle.copy(
@@ -223,6 +225,7 @@ object TestData {
     None,
     None,
     Seq.empty,
+    false,
     Priority.Unspecified.entryName,
     false
   )
@@ -274,6 +277,7 @@ object TestData {
     None,
     None,
     Seq.empty,
+    false,
     Priority.Unspecified.entryName,
     false
   )
@@ -413,6 +417,7 @@ object TestData {
     None,
     None,
     List.empty,
+    None,
     None
   )
 
@@ -422,66 +427,66 @@ object TestData {
     sampleArticleWithPublicDomain.copy(copyright = Some(copyrighted))
 
   val sampleDomainArticleWithHtmlFault: Draft = Draft(
-    Option(articleId),
-    Option(2),
-    common.Status(PLANNED, Set.empty),
-    Seq(common.Title("test", "en")),
-    Seq(
+    id = Option(articleId),
+    revision = Option(2),
+    status = common.Status(PLANNED, Set.empty),
+    title = Seq(common.Title("test", "en")),
+    content = Seq(
       common.ArticleContent(
         """<ul><li><h1>Det er ikke lov å gjøre dette.</h1> Tekst utenfor.</li><li>Dette er helt ok</li></ul>
-      |<ul><li><h2>Det er ikke lov å gjøre dette.</h2></li><li>Dette er helt ok</li></ul>
-      |<ol><li><h3>Det er ikke lov å gjøre dette.</h3></li><li>Dette er helt ok</li></ol>
-      |<ol><li><h4>Det er ikke lov å gjøre dette.</h4></li><li>Dette er helt ok</li></ol>
+          |<ul><li><h2>Det er ikke lov å gjøre dette.</h2></li><li>Dette er helt ok</li></ul>
+          |<ol><li><h3>Det er ikke lov å gjøre dette.</h3></li><li>Dette er helt ok</li></ol>
+          |<ol><li><h4>Det er ikke lov å gjøre dette.</h4></li><li>Dette er helt ok</li></ol>
     """.stripMargin,
         "en"
       )
     ),
-    Some(
+    copyright = Some(
       common.draft.DraftCopyright(Some("publicdomain"), Some(""), Seq.empty, Seq.empty, Seq.empty, None, None, false)
     ),
-    Seq.empty,
-    Seq.empty,
-    Seq.empty,
-    Seq.empty,
-    Seq(common.Description("meta description", "nb")),
-    Seq.empty,
-    today,
-    today,
-    "ndalId54321",
-    today,
-    common.ArticleType.Standard,
-    Seq.empty,
-    Seq.empty,
-    Seq.empty,
-    Seq.empty,
-    Seq.empty,
-    common.Availability.everyone,
-    Seq.empty,
-    Seq.empty,
-    None,
-    None,
-    Seq.empty,
-    Priority.Unspecified,
-    false
+    tags = Seq.empty,
+    requiredLibraries = Seq.empty,
+    visualElement = Seq.empty,
+    introduction = Seq.empty,
+    metaDescription = Seq(common.Description("meta description", "nb")),
+    metaImage = Seq.empty,
+    created = today,
+    updated = today,
+    updatedBy = "ndalId54321",
+    published = today,
+    articleType = common.ArticleType.Standard,
+    notes = Seq.empty,
+    previousVersionsNotes = Seq.empty,
+    editorLabels = Seq.empty,
+    grepCodes = Seq.empty,
+    conceptIds = Seq.empty,
+    availability = common.Availability.everyone,
+    relatedContent = Seq.empty,
+    revisionMeta = Seq.empty,
+    responsible = None,
+    slug = None,
+    comments = Seq.empty,
+    priority = Priority.Unspecified,
+    started = false
   )
 
   val apiArticleWithHtmlFaultV2: api.Article = api.Article(
-    1,
-    None,
-    1,
-    api.Status(PLANNED.toString, Seq.empty),
-    Some(api.ArticleTitle("test", "en")),
-    Some(
+    id = 1,
+    oldNdlaUrl = None,
+    revision = 1,
+    status = api.Status(PLANNED.toString, Seq.empty),
+    title = Some(api.ArticleTitle("test", "en")),
+    content = Some(
       api.ArticleContent(
         """<ul><li><h1>Det er ikke lov å gjøre dette.</h1> Tekst utenfor.</li><li>Dette er helt ok</li></ul>
-        |<ul><li><h2>Det er ikke lov å gjøre dette.</h2></li><li>Dette er helt ok</li></ul>
-        |<ol><li><h3>Det er ikke lov å gjøre dette.</h3></li><li>Dette er helt ok</li></ol>
-        |<ol><li><h4>Det er ikke lov å gjøre dette.</h4></li><li>Dette er helt ok</li></ol>
+          |<ul><li><h2>Det er ikke lov å gjøre dette.</h2></li><li>Dette er helt ok</li></ul>
+          |<ol><li><h3>Det er ikke lov å gjøre dette.</h3></li><li>Dette er helt ok</li></ol>
+          |<ol><li><h4>Det er ikke lov å gjøre dette.</h4></li><li>Dette er helt ok</li></ol>
       """.stripMargin,
         "en"
       )
     ),
-    Some(
+    copyright = Some(
       model.api.DraftCopyright(
         Some(commonApi.License("publicdomain", None, None)),
         Some(""),
@@ -493,30 +498,31 @@ object TestData {
         false
       )
     ),
-    Some(api.ArticleTag(Seq.empty, "en")),
-    Seq.empty,
-    None,
-    None,
-    Some(api.ArticleMetaDescription("so meta", "en")),
-    None,
-    NDLADate.now().minusDays(4),
-    NDLADate.now().minusDays(2),
-    "ndalId54321",
-    NDLADate.now().minusDays(2),
-    "standard",
-    Seq("en"),
-    Seq.empty,
-    Seq.empty,
-    Seq.empty,
-    Seq.empty,
+    tags = Some(api.ArticleTag(Seq.empty, "en")),
+    requiredLibraries = Seq.empty,
+    visualElement = None,
+    introduction = None,
+    metaDescription = Some(api.ArticleMetaDescription("so meta", "en")),
+    metaImage = None,
+    created = NDLADate.now().minusDays(4),
+    updated = NDLADate.now().minusDays(2),
+    updatedBy = "ndalId54321",
+    published = NDLADate.now().minusDays(2),
+    articleType = "standard",
+    supportedLanguages = Seq("en"),
+    notes = Seq.empty,
+    editorLabels = Seq.empty,
+    grepCodes = Seq.empty,
+    conceptIds = Seq.empty,
     availability = "everyone",
-    Seq.empty,
-    Seq.empty,
-    None,
-    None,
-    Seq.empty,
-    Priority.Unspecified.entryName,
-    false
+    relatedContent = Seq.empty,
+    revisions = Seq.empty,
+    responsible = None,
+    slug = None,
+    comments = Seq.empty,
+    prioritized = false,
+    priority = Priority.Unspecified.entryName,
+    started = false
   )
 
   val (nodeId, nodeId2)         = ("1234", "4321")

--- a/draft-api/src/test/scala/no/ndla/draftapi/db/migration/V52__UpdatePrioritizedFieldTest.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/db/migration/V52__UpdatePrioritizedFieldTest.scala
@@ -1,0 +1,23 @@
+/*
+ * Part of NDLA draft-api
+ * Copyright (C) 2023 NDLA
+ *
+ * See LICENSE
+ */
+
+package no.ndla.draftapi.db.migration
+
+import no.ndla.draftapi.{TestEnvironment, UnitSuite}
+
+class V52__UpdatePrioritizedFieldTest extends UnitSuite with TestEnvironment {
+
+  test("That prioritized is updated to priority and that value is mapped to correct priority type") {
+    val oldDocument =
+      """{"prioritized":true,"title":[{"title":"hei","language":"nb"}],"articleType":"standard"}"""
+    val expectedDocument =
+      """{"title":[{"title":"hei","language":"nb"}],"articleType":"standard","priority":"prioritized"}"""
+    val migration = new V52__UpdatePrioritizedField
+    val result    = migration.convertDocument(oldDocument)
+    result should be(expectedDocument)
+  }
+}

--- a/draft-api/src/test/scala/no/ndla/draftapi/service/ConverterServiceTest.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/service/ConverterServiceTest.scala
@@ -311,7 +311,7 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
       responsible = None,
       slug = None,
       comments = Seq.empty,
-      prioritized = false,
+      priority = Priority.Unspecified,
       started = false
     )
 
@@ -354,7 +354,7 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
       responsible = None,
       slug = None,
       comments = Seq.empty,
-      prioritized = false,
+      priority = Priority.Unspecified,
       started = false
     )
 
@@ -387,7 +387,7 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
       responsible = None,
       slug = None,
       comments = Seq.empty,
-      prioritized = false,
+      priority = Priority.Unspecified,
       started = false
     )
 
@@ -448,7 +448,7 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
       responsible = None,
       slug = None,
       comments = Seq.empty,
-      prioritized = false,
+      priority = Priority.Unspecified,
       started = false
     )
 
@@ -481,7 +481,7 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
       responsible = None,
       slug = None,
       comments = Seq.empty,
-      prioritized = false,
+      priority = Priority.Unspecified,
       started = false
     )
 
@@ -1080,7 +1080,7 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
       responsible = None,
       slug = Some("kjempe-slug"),
       comments = Seq.empty,
-      prioritized = false,
+      priority = Priority.Unspecified,
       started = false
     )
     val article = common.model.domain.article.Article(

--- a/draft-api/src/test/scala/no/ndla/draftapi/service/StateTransitionRulesTest.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/service/StateTransitionRulesTest.scala
@@ -9,7 +9,7 @@ package no.ndla.draftapi.service
 
 import cats.effect.unsafe.implicits.global
 import no.ndla.common.errors.{ValidationException, ValidationMessage}
-import no.ndla.common.model.domain.Responsible
+import no.ndla.common.model.domain.{Priority, Responsible}
 import no.ndla.common.model.domain.draft.Draft
 import no.ndla.common.model.domain.draft.DraftStatus._
 import no.ndla.common.model.{NDLADate, domain => common}
@@ -357,7 +357,7 @@ class StateTransitionRulesTest extends UnitSuite with TestEnvironment {
       responsible = Some(Responsible("hei", clock.now())),
       slug = None,
       comments = Seq.empty,
-      prioritized = false,
+      priority = Priority.Unspecified,
       started = false
     )
     val article = common.article.Article(
@@ -478,7 +478,7 @@ class StateTransitionRulesTest extends UnitSuite with TestEnvironment {
       responsible = Some(beforeResponsible),
       slug = None,
       comments = Seq.empty,
-      prioritized = false,
+      priority = Priority.Unspecified,
       started = false
     )
     val status            = common.Status(PLANNED, Set.empty)
@@ -534,7 +534,7 @@ class StateTransitionRulesTest extends UnitSuite with TestEnvironment {
       responsible = Some(beforeResponsible),
       slug = None,
       comments = Seq.empty,
-      prioritized = false,
+      priority = Priority.Unspecified,
       started = false
     )
     val status            = common.Status(PLANNED, Set.empty)
@@ -595,7 +595,7 @@ class StateTransitionRulesTest extends UnitSuite with TestEnvironment {
       responsible = Some(beforeResponsible),
       slug = None,
       comments = Seq.empty,
-      prioritized = false,
+      priority = Priority.Unspecified,
       started = false
     )
     val status            = common.Status(PLANNED, Set.empty)
@@ -658,7 +658,7 @@ class StateTransitionRulesTest extends UnitSuite with TestEnvironment {
       responsible = None,
       slug = None,
       comments = Seq.empty,
-      prioritized = false,
+      priority = Priority.Unspecified,
       started = false
     )
     val status                            = common.Status(PUBLISHED, Set.empty)

--- a/integration-tests/src/test/scala/no/ndla/integrationtests/draftapi/articleapi/ArticleApiClientTest.scala
+++ b/integration-tests/src/test/scala/no/ndla/integrationtests/draftapi/articleapi/ArticleApiClientTest.scala
@@ -9,6 +9,7 @@ package no.ndla.integrationtests.draftapi.articleapi
 
 import cats.effect.unsafe
 import no.ndla.articleapi.ArticleApiProperties
+import no.ndla.common.model.domain.Priority
 import no.ndla.common.model.domain.draft.Draft
 import no.ndla.common.model.{NDLADate, domain => common}
 import no.ndla.draftapi.model.api.ContentId
@@ -124,7 +125,7 @@ class ArticleApiClientTest
     responsible = None,
     slug = None,
     comments = Seq.empty,
-    prioritized = false,
+    priority = Priority.Unspecified,
     started = false
   )
 

--- a/integration-tests/src/test/scala/no/ndla/integrationtests/draftapi/articleapi/ArticleApiClientTest.scala
+++ b/integration-tests/src/test/scala/no/ndla/integrationtests/draftapi/articleapi/ArticleApiClientTest.scala
@@ -126,7 +126,7 @@ class ArticleApiClientTest
     slug = None,
     comments = Seq.empty,
     priority = Priority.Unspecified,
-    started = false
+    started = false,
   )
 
   val exampleToken =

--- a/search-api/src/main/scala/no/ndla/searchapi/controller/NdlaController.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/controller/NdlaController.scala
@@ -13,7 +13,7 @@ import no.ndla.common.errors.AccessDeniedException
 import no.ndla.common.model.NDLADate
 import no.ndla.common.model.domain.draft.{DraftStatus, RevisionStatus}
 import no.ndla.common.model.domain.learningpath.EmbedType
-import no.ndla.common.model.domain.{ArticleType, Availability}
+import no.ndla.common.model.domain.{ArticleType, Availability, Priority}
 import no.ndla.network.scalatra.NdlaControllerBase
 import no.ndla.search.{IndexNotFoundException, NdlaSearchException}
 import no.ndla.searchapi.Props
@@ -44,6 +44,7 @@ trait NdlaController {
         Json4s.serializer(ArticleType) +
         Json4s.serializer(RevisionStatus) +
         Json4s.serializer(DraftStatus) +
+        Json4s.serializer(Priority) +
         NDLADate.Json4sSerializer
 
     before() {

--- a/search-api/src/main/scala/no/ndla/searchapi/controller/SearchController.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/controller/SearchController.scala
@@ -8,6 +8,7 @@
 
 package no.ndla.searchapi.controller
 
+import enumeratum.Json4s
 import no.ndla.common.model.NDLADate
 import no.ndla.common.model.domain.draft.DraftStatus
 import no.ndla.common.model.domain.{ArticleType, Availability, Priority}
@@ -59,6 +60,7 @@ trait SearchController {
     protected implicit override val jsonFormats: Formats =
       DefaultFormats ++
         JavaTimeSerializers.all +
+        Json4s.serializer(Priority) +
         NDLADate.Json4sSerializer
 
     protected val applicationDescription = "API for searching across NDLA APIs"
@@ -209,6 +211,9 @@ trait SearchController {
       "responsible-ids",
       "List of responsible ids to filter by (OR filter)."
     )
+
+    private val prioritizedFilter =
+      Param[Option[Boolean]]("prioritized", "Set to true to only return prioritized articles")
 
     private val priorityFilter =
       Param[Option[Seq[String]]](
@@ -486,6 +491,7 @@ trait SearchController {
       val excludeRevisionHistory   = booleanOrDefault(this.excludeRevisionLog.paramName, default = false)
       val responsibleIds           = paramAsListOfString(this.responsibleIdFilter.paramName)
       val filterInactive           = booleanOrDefault(this.filterInactive.paramName, default = false)
+      val prioritized              = booleanOrNone(this.prioritizedFilter.paramName)
       val priority                 = paramAsListOfString(this.priorityFilter.paramName)
 
       MultiDraftSearchSettings(
@@ -519,6 +525,7 @@ trait SearchController {
         responsibleIdFilter = responsibleIds,
         articleTypes = articleTypes,
         filterInactive = filterInactive,
+        prioritized = prioritized,
         priority = priority
       )
     }
@@ -637,6 +644,7 @@ trait SearchController {
             asQueryParam(excludeRevisionLog),
             asQueryParam(responsibleIdFilter),
             asQueryParam(filterInactive),
+            asQueryParam(prioritizedFilter),
             asQueryParam(priorityFilter)
           )
           .authorizations("oauth2")

--- a/search-api/src/main/scala/no/ndla/searchapi/integration/SearchApiClient.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/integration/SearchApiClient.scala
@@ -13,7 +13,7 @@ import io.lemonlabs.uri.typesafe.dsl._
 import no.ndla.common.model.NDLADate
 import no.ndla.common.model.domain.draft.{DraftStatus, RevisionStatus}
 import no.ndla.common.model.domain.learningpath.EmbedType
-import no.ndla.common.model.domain.{ArticleType, Availability}
+import no.ndla.common.model.domain.{ArticleType, Availability, Priority}
 import no.ndla.network.NdlaClient
 import no.ndla.network.model.RequestInfo
 import no.ndla.searchapi.Props
@@ -107,7 +107,8 @@ trait SearchApiClient {
           JavaTypesSerializers.all +
           Json4s.serializer(ArticleType) +
           Json4s.serializer(DraftStatus) +
-          Json4s.serializer(RevisionStatus)
+          Json4s.serializer(RevisionStatus) +
+          Json4s.serializer(Priority)
       val url     = s"$baseUrl/$path"
       val request = quickRequest.get(uri"$url?$params").readTimeout(timeout.millis)
       ndlaClient.fetchWithForwardedAuth[T](request, None)

--- a/search-api/src/main/scala/no/ndla/searchapi/model/api/MultiSearchSummary.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/model/api/MultiSearchSummary.scala
@@ -41,6 +41,7 @@ case class MultiSearchSummary(
     @(ApiModelProperty @field)(description = "A list of revisions planned for the article") revisions: Seq[RevisionMeta],
     @(ApiModelProperty @field)(description = "Responsible field") responsible: Option[DraftResponsible],
     @(ApiModelProperty @field)(description = "Information about comments attached to the article") comments: Option[Seq[Comment]],
+    @(ApiModelProperty @field)(description ="If the article should be prioritized" ) prioritized: Option[Boolean],
     @(ApiModelProperty @field)(description ="If the article should be prioritized" ) priority: Option[Priority]
 )
 // format: on

--- a/search-api/src/main/scala/no/ndla/searchapi/model/api/MultiSearchSummary.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/model/api/MultiSearchSummary.scala
@@ -9,7 +9,6 @@ package no.ndla.searchapi.model.api
 
 import no.ndla.common.model.NDLADate
 import no.ndla.common.model.api.draft.Comment
-import no.ndla.common.model.domain.Priority
 import org.scalatra.swagger.annotations.{ApiModel, ApiModelProperty}
 
 import scala.annotation.meta.field
@@ -41,7 +40,7 @@ case class MultiSearchSummary(
     @(ApiModelProperty @field)(description = "A list of revisions planned for the article") revisions: Seq[RevisionMeta],
     @(ApiModelProperty @field)(description = "Responsible field") responsible: Option[DraftResponsible],
     @(ApiModelProperty @field)(description = "Information about comments attached to the article") comments: Option[Seq[Comment]],
-    @(ApiModelProperty @field)(description ="If the article should be prioritized" ) prioritized: Option[Boolean],
-    @(ApiModelProperty @field)(description ="If the article should be prioritized" ) priority: Option[Priority]
+    @(ApiModelProperty @field)(description = "If the article should be prioritized" ) prioritized: Option[Boolean],
+    @(ApiModelProperty @field)(description = "If the article should be prioritized. Possible values are prioritized, on-hold, unspecified") priority: Option[String]
 )
 // format: on

--- a/search-api/src/main/scala/no/ndla/searchapi/model/api/MultiSearchSummary.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/model/api/MultiSearchSummary.scala
@@ -9,6 +9,7 @@ package no.ndla.searchapi.model.api
 
 import no.ndla.common.model.NDLADate
 import no.ndla.common.model.api.draft.Comment
+import no.ndla.common.model.domain.Priority
 import org.scalatra.swagger.annotations.{ApiModel, ApiModelProperty}
 
 import scala.annotation.meta.field
@@ -40,6 +41,6 @@ case class MultiSearchSummary(
     @(ApiModelProperty @field)(description = "A list of revisions planned for the article") revisions: Seq[RevisionMeta],
     @(ApiModelProperty @field)(description = "Responsible field") responsible: Option[DraftResponsible],
     @(ApiModelProperty @field)(description = "Information about comments attached to the article") comments: Option[Seq[Comment]],
-    @(ApiModelProperty @field)(description ="If the article should be prioritized" ) prioritized: Option[Boolean]
+    @(ApiModelProperty @field)(description ="If the article should be prioritized" ) priority: Priority
 )
 // format: on

--- a/search-api/src/main/scala/no/ndla/searchapi/model/api/MultiSearchSummary.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/model/api/MultiSearchSummary.scala
@@ -41,6 +41,6 @@ case class MultiSearchSummary(
     @(ApiModelProperty @field)(description = "A list of revisions planned for the article") revisions: Seq[RevisionMeta],
     @(ApiModelProperty @field)(description = "Responsible field") responsible: Option[DraftResponsible],
     @(ApiModelProperty @field)(description = "Information about comments attached to the article") comments: Option[Seq[Comment]],
-    @(ApiModelProperty @field)(description ="If the article should be prioritized" ) priority: Priority
+    @(ApiModelProperty @field)(description ="If the article should be prioritized" ) priority: Option[Priority]
 )
 // format: on

--- a/search-api/src/main/scala/no/ndla/searchapi/model/domain/Sort.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/model/domain/Sort.scala
@@ -34,8 +34,6 @@ object Sort extends Enum[Sort] {
   case object ByResponsibleLastUpdatedDesc extends Sort("-responsibleLastUpdated")
   case object ByStatusAsc                  extends Sort("status")
   case object ByStatusDesc                 extends Sort("-status")
-  case object ByPrioritizedDesc            extends Sort("-prioritized")
-  case object ByPrioritizedAsc             extends Sort("prioritized")
 
   def valueOf(s: String): Option[Sort] = Sort.values.find(_.entryName == s)
 

--- a/search-api/src/main/scala/no/ndla/searchapi/model/domain/Sort.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/model/domain/Sort.scala
@@ -34,6 +34,8 @@ object Sort extends Enum[Sort] {
   case object ByResponsibleLastUpdatedDesc extends Sort("-responsibleLastUpdated")
   case object ByStatusAsc                  extends Sort("status")
   case object ByStatusDesc                 extends Sort("-status")
+  case object ByPrioritizedDesc            extends Sort("-prioritized")
+  case object ByPrioritizedAsc             extends Sort("prioritized")
 
   def valueOf(s: String): Option[Sort] = Sort.values.find(_.entryName == s)
 

--- a/search-api/src/main/scala/no/ndla/searchapi/model/search/SearchableDraft.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/model/search/SearchableDraft.scala
@@ -8,7 +8,7 @@
 package no.ndla.searchapi.model.search
 
 import no.ndla.common.model.NDLADate
-import no.ndla.common.model.domain.Responsible
+import no.ndla.common.model.domain.{Priority, Responsible}
 import no.ndla.common.model.domain.draft.{Draft, RevisionMeta}
 import no.ndla.search.model.domain.EmbedValues
 import no.ndla.search.model.{SearchableLanguageList, SearchableLanguageValues}
@@ -40,5 +40,5 @@ case class SearchableDraft(
     nextRevision: Option[RevisionMeta],
     responsible: Option[Responsible],
     domainObject: Draft,
-    prioritized: Option[Boolean]
+    priority: Priority
 )

--- a/search-api/src/main/scala/no/ndla/searchapi/model/search/settings/MultiDraftSearchSettings.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/model/search/settings/MultiDraftSearchSettings.scala
@@ -42,5 +42,5 @@ case class MultiDraftSearchSettings(
     responsibleIdFilter: List[String],
     articleTypes: List[String],
     filterInactive: Boolean,
-    prioritized: Option[Boolean]
+    priority: List[String]
 )

--- a/search-api/src/main/scala/no/ndla/searchapi/model/search/settings/MultiDraftSearchSettings.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/model/search/settings/MultiDraftSearchSettings.scala
@@ -42,5 +42,6 @@ case class MultiDraftSearchSettings(
     responsibleIdFilter: List[String],
     articleTypes: List[String],
     filterInactive: Boolean,
+    prioritized: Option[Boolean],
     priority: List[String]
 )

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/DraftIndexService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/DraftIndexService.scala
@@ -95,6 +95,7 @@ trait DraftIndexService {
         keywordField("nextRevision.status"),
         textField("nextRevision.note"),
         dateField("nextRevision.revisionDate"),
+        booleanField("prioritized"),
         keywordField("priority")
       )
       val dynamics = generateLanguageSupportedDynamicTemplates("title", keepRaw = true) ++

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/DraftIndexService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/DraftIndexService.scala
@@ -95,7 +95,7 @@ trait DraftIndexService {
         keywordField("nextRevision.status"),
         textField("nextRevision.note"),
         dateField("nextRevision.revisionDate"),
-        booleanField("prioritized")
+        keywordField("priority")
       )
       val dynamics = generateLanguageSupportedDynamicTemplates("title", keepRaw = true) ++
         generateLanguageSupportedDynamicTemplates("metaDescription") ++

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/DraftIndexService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/DraftIndexService.scala
@@ -95,7 +95,6 @@ trait DraftIndexService {
         keywordField("nextRevision.status"),
         textField("nextRevision.note"),
         dateField("nextRevision.revisionDate"),
-        booleanField("prioritized"),
         keywordField("priority")
       )
       val dynamics = generateLanguageSupportedDynamicTemplates("title", keepRaw = true) ++

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/MultiDraftSearchService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/MultiDraftSearchService.scala
@@ -180,9 +180,9 @@ trait MultiDraftSearchService {
         termsQuery("responsible.responsibleId", settings.responsibleIdFilter)
       }
 
-      val prioritizedFilter = settings.prioritized.map { prioritized =>
-        termQuery("prioritized", prioritized)
-      }
+      val priorityFilter = Option.when(settings.priority.nonEmpty)(
+        boolQuery().should(settings.priority.map(termQuery("priority", _)))
+      )
 
       val articleTypeFilter = Some(
         boolQuery().should(settings.articleTypes.map(articleType => termQuery("articleType", articleType)))
@@ -212,7 +212,7 @@ trait MultiDraftSearchService {
         embedResourceAndIdFilter,
         dateFilter,
         responsibleIdFilter,
-        prioritizedFilter
+        priorityFilter
       ).flatten
     }
 

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/MultiDraftSearchService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/MultiDraftSearchService.scala
@@ -12,6 +12,7 @@ import com.sksamuel.elastic4s.requests.searches.queries.compound.BoolQuery
 import com.sksamuel.elastic4s.requests.searches.queries.{Query, RangeQuery}
 import com.typesafe.scalalogging.StrictLogging
 import no.ndla.common.model.NDLADate
+import no.ndla.common.model.domain.Priority
 import no.ndla.common.model.domain.draft.DraftStatus
 import no.ndla.language.Language.AllLanguages
 import no.ndla.language.model.Iso639
@@ -180,6 +181,10 @@ trait MultiDraftSearchService {
         termsQuery("responsible.responsibleId", settings.responsibleIdFilter)
       }
 
+      val prioritizedFilter = settings.prioritized.map { priority =>
+        termQuery("priority", if (priority) Priority.Prioritized.entryName else Priority.Unspecified.entryName)
+      }
+
       val priorityFilter = Option.when(settings.priority.nonEmpty)(
         boolQuery().should(settings.priority.map(termQuery("priority", _)))
       )
@@ -212,6 +217,7 @@ trait MultiDraftSearchService {
         embedResourceAndIdFilter,
         dateFilter,
         responsibleIdFilter,
+        prioritizedFilter,
         priorityFilter
       ).flatten
     }

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
@@ -545,7 +545,7 @@ trait SearchConverterService {
         revisions = revisions,
         responsible = responsible,
         comments = Some(comments),
-        priority = Some(searchableDraft.priority),
+        priority = Some(searchableDraft.priority.entryName),
         prioritized = Some(searchableDraft.priority == Priority.Prioritized)
       )
     }

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
@@ -15,7 +15,7 @@ import no.ndla.common.model.api.{Author, License}
 import no.ndla.common.model.api.draft.Comment
 import no.ndla.common.model.domain.article.Article
 import no.ndla.common.model.domain.draft.{Draft, RevisionStatus}
-import no.ndla.common.model.domain.{ArticleContent, ArticleMetaImage, VisualElement}
+import no.ndla.common.model.domain.{ArticleContent, ArticleMetaImage, Priority, VisualElement}
 import no.ndla.language.Language.{UnknownLanguage, findByLanguageOrBestEffort, getSupportedLanguages}
 import no.ndla.language.model.Iso639
 import no.ndla.mapping.ISO639
@@ -372,7 +372,7 @@ trait SearchConverterService {
           nextRevision = nextRevision,
           responsible = draft.responsible,
           domainObject = draft,
-          prioritized = Some(draft.prioritized)
+          priority = draft.priority
         )
       )
 
@@ -488,7 +488,7 @@ trait SearchConverterService {
         revisions = Seq.empty,
         responsible = None,
         comments = None,
-        prioritized = None
+        priority = Priority.Unspecified
       )
     }
 
@@ -544,7 +544,7 @@ trait SearchConverterService {
         revisions = revisions,
         responsible = responsible,
         comments = Some(comments),
-        prioritized = searchableDraft.prioritized
+        priority = searchableDraft.priority
       )
     }
 
@@ -595,7 +595,7 @@ trait SearchConverterService {
         revisions = Seq.empty,
         responsible = None,
         comments = None,
-        prioritized = Some(false)
+        priority = Priority.Unspecified
       )
     }
 

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
@@ -488,6 +488,7 @@ trait SearchConverterService {
         revisions = Seq.empty,
         responsible = None,
         comments = None,
+        prioritized = None,
         priority = Some(Priority.Unspecified)
       )
     }
@@ -544,7 +545,8 @@ trait SearchConverterService {
         revisions = revisions,
         responsible = responsible,
         comments = Some(comments),
-        priority = Some(searchableDraft.priority)
+        priority = Some(searchableDraft.priority),
+        prioritized = Some(searchableDraft.priority == Priority.Prioritized)
       )
     }
 
@@ -595,6 +597,7 @@ trait SearchConverterService {
         revisions = Seq.empty,
         responsible = None,
         comments = None,
+        prioritized = None,
         priority = Some(Priority.Unspecified)
       )
     }

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
@@ -488,7 +488,7 @@ trait SearchConverterService {
         revisions = Seq.empty,
         responsible = None,
         comments = None,
-        priority = Priority.Unspecified
+        priority = Some(Priority.Unspecified)
       )
     }
 
@@ -544,7 +544,7 @@ trait SearchConverterService {
         revisions = revisions,
         responsible = responsible,
         comments = Some(comments),
-        priority = searchableDraft.priority
+        priority = Some(searchableDraft.priority)
       )
     }
 
@@ -595,7 +595,7 @@ trait SearchConverterService {
         revisions = Seq.empty,
         responsible = None,
         comments = None,
-        priority = Priority.Unspecified
+        priority = Some(Priority.Unspecified)
       )
     }
 

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
@@ -489,7 +489,7 @@ trait SearchConverterService {
         responsible = None,
         comments = None,
         prioritized = None,
-        priority = Some(Priority.Unspecified)
+        priority = None
       )
     }
 
@@ -598,7 +598,7 @@ trait SearchConverterService {
         responsible = None,
         comments = None,
         prioritized = None,
-        priority = Some(Priority.Unspecified)
+        priority = None
       )
     }
 

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/SearchService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/SearchService.scala
@@ -379,7 +379,8 @@ trait SearchService {
           fieldSort("responsible.lastUpdated").sortOrder(SortOrder.Asc).missing("_last")
         case Sort.ByResponsibleLastUpdatedDesc =>
           fieldSort("responsible.lastUpdated").sortOrder(SortOrder.Desc).missing("_last")
-
+        case Sort.ByPrioritizedAsc  => fieldSort("prioritized").order(SortOrder.Asc).missing("_last")
+        case Sort.ByPrioritizedDesc => fieldSort("prioritized").order(SortOrder.Desc).missing("_last")
       }
     }
 

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/SearchService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/SearchService.scala
@@ -379,8 +379,7 @@ trait SearchService {
           fieldSort("responsible.lastUpdated").sortOrder(SortOrder.Asc).missing("_last")
         case Sort.ByResponsibleLastUpdatedDesc =>
           fieldSort("responsible.lastUpdated").sortOrder(SortOrder.Desc).missing("_last")
-        case Sort.ByPrioritizedAsc  => fieldSort("prioritized").order(SortOrder.Asc).missing("_last")
-        case Sort.ByPrioritizedDesc => fieldSort("prioritized").order(SortOrder.Desc).missing("_last")
+
       }
     }
 

--- a/search-api/src/test/scala/no/ndla/searchapi/TestData.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/TestData.scala
@@ -1610,6 +1610,7 @@ object TestData {
     responsibleIdFilter = List.empty,
     articleTypes = List.empty,
     filterInactive = false,
+    prioritized = None,
     priority = List.empty
   )
 

--- a/search-api/src/test/scala/no/ndla/searchapi/TestData.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/TestData.scala
@@ -8,20 +8,7 @@
 package no.ndla.searchapi
 
 import no.ndla.common.configuration.Constants.EmbedTagName
-import no.ndla.common.model.domain.{
-  ArticleContent,
-  ArticleMetaImage,
-  ArticleType,
-  Author,
-  Availability,
-  EditorNote,
-  Introduction,
-  Status,
-  Tag,
-  Title,
-  VisualElement,
-  draft
-}
+import no.ndla.common.model.domain.{ArticleContent, ArticleMetaImage, ArticleType, Author, Availability, EditorNote, Introduction, Priority, Status, Tag, Title, VisualElement, draft}
 import no.ndla.common.model.domain.article.{Article, Copyright}
 import no.ndla.common.model.domain.draft.{Draft, DraftCopyright, DraftStatus}
 import no.ndla.common.model.domain.learningpath.LearningpathCopyright
@@ -544,7 +531,7 @@ object TestData {
     responsible = None,
     slug = None,
     comments = Seq.empty,
-    prioritized = false,
+    priority = Priority.Unspecified,
     started = false
   )
 
@@ -605,7 +592,7 @@ object TestData {
     responsible = None,
     slug = None,
     comments = Seq.empty,
-    prioritized = false,
+    priority = Priority.Unspecified,
     started = false
   )
 
@@ -1609,7 +1596,7 @@ object TestData {
     responsibleIdFilter = List.empty,
     articleTypes = List.empty,
     filterInactive = false,
-    prioritized = None
+    priority = Priority.Unspecified,
   )
 
   val searchableResourceTypes: List[SearchableTaxonomyResourceType] = List(

--- a/search-api/src/test/scala/no/ndla/searchapi/TestData.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/TestData.scala
@@ -8,7 +8,21 @@
 package no.ndla.searchapi
 
 import no.ndla.common.configuration.Constants.EmbedTagName
-import no.ndla.common.model.domain.{ArticleContent, ArticleMetaImage, ArticleType, Author, Availability, EditorNote, Introduction, Priority, Status, Tag, Title, VisualElement, draft}
+import no.ndla.common.model.domain.{
+  ArticleContent,
+  ArticleMetaImage,
+  ArticleType,
+  Author,
+  Availability,
+  EditorNote,
+  Introduction,
+  Priority,
+  Status,
+  Tag,
+  Title,
+  VisualElement,
+  draft
+}
 import no.ndla.common.model.domain.article.{Article, Copyright}
 import no.ndla.common.model.domain.draft.{Draft, DraftCopyright, DraftStatus}
 import no.ndla.common.model.domain.learningpath.LearningpathCopyright
@@ -1596,7 +1610,7 @@ object TestData {
     responsibleIdFilter = List.empty,
     articleTypes = List.empty,
     filterInactive = false,
-    priority = Priority.Unspecified,
+    priority = List.empty
   )
 
   val searchableResourceTypes: List[SearchableTaxonomyResourceType] = List(

--- a/search-api/src/test/scala/no/ndla/searchapi/model/search/SearchableDraftTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/model/search/SearchableDraftTest.scala
@@ -9,7 +9,7 @@ package no.ndla.searchapi.model.search
 
 import no.ndla.common.model.NDLADate
 import no.ndla.common.model.domain.draft.{DraftStatus, RevisionMeta, RevisionStatus}
-import no.ndla.common.model.domain.{EditorNote, Responsible, Status => CommonStatus}
+import no.ndla.common.model.domain.{EditorNote, Priority, Responsible, Status => CommonStatus}
 import no.ndla.search.model.domain.EmbedValues
 import no.ndla.search.model.{LanguageValue, SearchableLanguageFormats, SearchableLanguageList, SearchableLanguageValues}
 import no.ndla.searchapi.TestData._
@@ -123,7 +123,7 @@ class SearchableDraftTest extends UnitSuite with TestEnvironment {
           )
         )
       ),
-      prioritized = Some(false)
+      priority = Priority.Unspecified
     )
 
     implicit val formats: Formats = SearchableLanguageFormats.JSonFormatsWithMillis

--- a/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceAtomicTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceAtomicTest.scala
@@ -797,7 +797,7 @@ class MultiDraftSearchServiceAtomicTest
       id = Some(4)
     )
     val draft5 = TestData.draft1.copy(
-      id = Some(4),
+      id = Some(5),
       priority = Priority.OnHold
     )
     draftIndexService.indexDocument(draft1, Some(taxonomyTestBundle), Some(grepBundle)).get
@@ -836,6 +836,16 @@ class MultiDraftSearchServiceAtomicTest
       .get
       .results
       .map(_.id) should be(Seq(5))
+
+    multiDraftSearchService
+      .matchingQuery(
+        multiDraftSearchSettings.copy(
+          priority = List.empty
+        )
+      )
+      .get
+      .results
+      .map(_.id) should be(Seq(1, 2, 3, 4, 5))
   }
 
   test("That search on embed id supports video embed with timestamp resources") {

--- a/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceAtomicTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceAtomicTest.scala
@@ -778,79 +778,40 @@ class MultiDraftSearchServiceAtomicTest
       .results
       .map(_.id) should be(Seq(2, 1, 3, 4))
   }
-  test("That sorting by prioritized works as expected") {
-    val draft1 = TestData.draft1.copy(
-      id = Some(1),
-      prioritized = false
-    )
-    val draft2 = TestData.draft1.copy(
-      id = Some(2),
-      prioritized = true
-    )
-    val draft3 = TestData.draft1.copy(
-      id = Some(3),
-      prioritized = true
-    )
-    val draft4 = TestData.draft1.copy(
-      id = Some(4),
-      prioritized = false
-    )
 
-    draftIndexService.indexDocument(draft1, Some(taxonomyTestBundle), Some(grepBundle)).failIfFailure
-    draftIndexService.indexDocument(draft2, Some(taxonomyTestBundle), Some(grepBundle)).failIfFailure
-    draftIndexService.indexDocument(draft3, Some(taxonomyTestBundle), Some(grepBundle)).failIfFailure
-    draftIndexService.indexDocument(draft4, Some(taxonomyTestBundle), Some(grepBundle)).failIfFailure
-
-    blockUntil(() => draftIndexService.countDocuments == 4)
-
-    multiDraftSearchService
-      .matchingQuery(
-        multiDraftSearchSettings.copy(
-          sort = Sort.ByPrioritizedAsc
-        )
-      )
-      .get
-      .results
-      .map(_.id) should be(Seq(1, 4, 2, 3))
-
-    multiDraftSearchService
-      .matchingQuery(
-        multiDraftSearchSettings.copy(
-          sort = Sort.ByPrioritizedDesc
-        )
-      )
-      .get
-      .results
-      .map(_.id) should be(Seq(2, 3, 1, 4))
-  }
   test("Test that filtering prioritized works as expected") {
 
     val draft1 = TestData.draft1.copy(
       id = Some(1),
-      prioritized = false
+      priority = Priority.Unspecified
     )
     val draft2 = TestData.draft1.copy(
       id = Some(2),
-      prioritized = true
+      priority = Priority.Prioritized
     )
     val draft3 = TestData.draft1.copy(
       id = Some(3),
-      prioritized = true
+      priority = Priority.Prioritized
     )
     val draft4 = TestData.draft1.copy(
       id = Some(4)
+    )
+    val draft5 = TestData.draft1.copy(
+      id = Some(4),
+      priority = Priority.OnHold
     )
     draftIndexService.indexDocument(draft1, Some(taxonomyTestBundle), Some(grepBundle)).get
     draftIndexService.indexDocument(draft2, Some(taxonomyTestBundle), Some(grepBundle)).get
     draftIndexService.indexDocument(draft3, Some(taxonomyTestBundle), Some(grepBundle)).get
     draftIndexService.indexDocument(draft4, Some(taxonomyTestBundle), Some(grepBundle)).get
+    draftIndexService.indexDocument(draft5, Some(taxonomyTestBundle), Some(grepBundle)).get
 
-    blockUntil(() => draftIndexService.countDocuments == 4)
+    blockUntil(() => draftIndexService.countDocuments == 5)
 
     multiDraftSearchService
       .matchingQuery(
         multiDraftSearchSettings.copy(
-          prioritized = Some(true)
+          priority = List(Priority.Prioritized.entryName)
         )
       )
       .get
@@ -860,7 +821,7 @@ class MultiDraftSearchServiceAtomicTest
     multiDraftSearchService
       .matchingQuery(
         multiDraftSearchSettings.copy(
-          prioritized = Some(false)
+          priority = List(Priority.Unspecified.entryName)
         )
       )
       .get
@@ -869,12 +830,12 @@ class MultiDraftSearchServiceAtomicTest
     multiDraftSearchService
       .matchingQuery(
         multiDraftSearchSettings.copy(
-          prioritized = None
+          priority = List(Priority.OnHold.entryName)
         )
       )
       .get
       .results
-      .map(_.id) should be(Seq(1, 2, 3, 4))
+      .map(_.id) should be(Seq(5))
   }
 
   test("That search on embed id supports video embed with timestamp resources") {

--- a/typescript/draft-api.ts
+++ b/typescript/draft-api.ts
@@ -32,7 +32,7 @@ export interface IArticle {
   responsible?: IDraftResponsible
   slug?: string
   comments: IComment[]
-  prioritized: boolean
+  priority: string
   started: boolean
 }
 
@@ -156,7 +156,7 @@ export interface INewArticle {
   responsibleId?: string
   slug?: string
   comments: INewComment[]
-  prioritized?: boolean
+  priority?: boolean
 }
 
 export interface INewArticleMetaImage {
@@ -234,7 +234,7 @@ export interface IUpdatedArticle {
   responsibleId?: (null | string)
   slug?: string
   comments?: IUpdatedComment[]
-  prioritized?: boolean
+  priority?: boolean
 }
 
 export interface IUpdatedComment {

--- a/typescript/draft-api.ts
+++ b/typescript/draft-api.ts
@@ -157,7 +157,7 @@ export interface INewArticle {
   responsibleId?: string
   slug?: string
   comments: INewComment[]
-  prioritized?: boolean;
+  prioritized?: boolean
   priority?: string
 }
 

--- a/typescript/draft-api.ts
+++ b/typescript/draft-api.ts
@@ -32,6 +32,7 @@ export interface IArticle {
   responsible?: IDraftResponsible
   slug?: string
   comments: IComment[]
+  prioritized: boolean
   priority: string
   started: boolean
 }
@@ -156,7 +157,8 @@ export interface INewArticle {
   responsibleId?: string
   slug?: string
   comments: INewComment[]
-  priority?: boolean
+  prioritized?: boolean;
+  priority?: string
 }
 
 export interface INewArticleMetaImage {
@@ -234,7 +236,8 @@ export interface IUpdatedArticle {
   responsibleId?: (null | string)
   slug?: string
   comments?: IUpdatedComment[]
-  priority?: boolean
+  prioritized?: boolean
+  priority?: string
 }
 
 export interface IUpdatedComment {

--- a/typescript/search-api.ts
+++ b/typescript/search-api.ts
@@ -176,7 +176,7 @@ export interface IMultiSearchSummary {
   revisions: IRevisionMeta[]
   responsible?: IDraftResponsible
   comments?: IComment[]
-  prioritized?: boolean
+  priority?: boolean
 }
 
 export interface IMultiSearchTermsAggregation {

--- a/typescript/search-api.ts
+++ b/typescript/search-api.ts
@@ -176,7 +176,8 @@ export interface IMultiSearchSummary {
   revisions: IRevisionMeta[]
   responsible?: IDraftResponsible
   comments?: IComment[]
-  priority?: boolean
+  prioritized?: boolean
+  priority?: string
 }
 
 export interface IMultiSearchTermsAggregation {

--- a/typescript/search-api.ts
+++ b/typescript/search-api.ts
@@ -177,7 +177,7 @@ export interface IMultiSearchSummary {
   responsible?: IDraftResponsible
   comments?: IComment[]
   prioritized?: boolean
-  priority?: string
+  priority?: Priority
 }
 
 export interface IMultiSearchTermsAggregation {
@@ -185,6 +185,14 @@ export interface IMultiSearchTermsAggregation {
   sumOtherDocCount: number
   docCountErrorUpperBound: number
   values: ITermValue[]
+}
+
+export interface IOnHold {
+  type: "OnHold"
+}
+
+export interface IPrioritized {
+  type: "Prioritized"
 }
 
 export interface IRevisionMeta {
@@ -231,6 +239,10 @@ export interface ITitle {
   language: string
 }
 
+export interface IUnspecified {
+  type: "Unspecified"
+}
+
 export interface IValidationError {
   code: string
   description: string
@@ -242,3 +254,5 @@ export interface IValidationMessage {
   field: string
   message: string
 }
+
+export type Priority = (IOnHold | IPrioritized | IUnspecified)

--- a/typescript/search-api.ts
+++ b/typescript/search-api.ts
@@ -177,7 +177,7 @@ export interface IMultiSearchSummary {
   responsible?: IDraftResponsible
   comments?: IComment[]
   prioritized?: boolean
-  priority?: Priority
+  priority?: string
 }
 
 export interface IMultiSearchTermsAggregation {
@@ -185,14 +185,6 @@ export interface IMultiSearchTermsAggregation {
   sumOtherDocCount: number
   docCountErrorUpperBound: number
   values: ITermValue[]
-}
-
-export interface IOnHold {
-  type: "OnHold"
-}
-
-export interface IPrioritized {
-  type: "Prioritized"
 }
 
 export interface IRevisionMeta {
@@ -239,10 +231,6 @@ export interface ITitle {
   language: string
 }
 
-export interface IUnspecified {
-  type: "Unspecified"
-}
-
 export interface IValidationError {
   code: string
   description: string
@@ -254,5 +242,3 @@ export interface IValidationMessage {
   field: string
   message: string
 }
-
-export type Priority = (IOnHold | IPrioritized | IUnspecified)


### PR DESCRIPTION
- Oppdaterer prioritized navngivning til priority
- Oppdaterer priority til å kunne ta følgende verdier: prioritized, on-hold(parkert) eller unspecified
- Legger til migrering som oppdaterer prioritized-felt
