### PR TITLE
Search api memory antics

### DIFF
--- a/search-api/src/main/scala/no/ndla/searchapi/controller/InternController.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/controller/InternController.scala
@@ -252,6 +252,8 @@ trait InternController {
             Accepted("Starting indexing process...")
           } else {
             val out = resolveResultFutures(indexes)
+            taxonomyBundleDraft.close()
+            taxonomyBundlePublished.close()
             logger.info(s"Reindexing all indexes took ${System.currentTimeMillis() - start} ms...")
             out
           }

--- a/search-api/src/main/scala/no/ndla/searchapi/integration/TaxonomyApiClient.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/integration/TaxonomyApiClient.scala
@@ -121,14 +121,17 @@ trait TaxonomyApiClient {
             fetchPage(params :+ ("page" -> s"$pageNum")).map(page =>
               page.results.foreach(n =>
                 n.contentUri.foreach(uri => {
-                  val pub         = if (published) "published" else "draft"
-                  val path        = s"$tmpDir/${uri}_$pub.json"
-                  val f           = new java.io.File(path)
-                  lazy val stream = new FileOutputStream(f)
+                  val pub        = if (published) "published" else "draft"
+                  val path       = s"$tmpDir/${uri}_$pub.json"
+                  val f          = new java.io.File(path)
+                  val fileExists = f.exists()
+                  val stream     = new FileOutputStream(f, true)
 
-                  if (f.exists()) stream.write('\n')
+                  if (fileExists) stream.write('\n')
                   val json = Serialization.write(n)
                   stream.write(json.getBytes)
+                  stream.flush()
+                  stream.close()
                 })
               )
             )

--- a/search-api/src/main/scala/no/ndla/searchapi/integration/TaxonomyApiClient.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/integration/TaxonomyApiClient.scala
@@ -117,29 +117,28 @@ trait TaxonomyApiClient {
           ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(numThreads))
 
         val pages = pageRange.map(pageNum =>
-          Future {
-            fetchPage(params :+ ("page" -> s"$pageNum")).map(page =>
-              page.results.foreach(n =>
-                n.contentUri.foreach(uri => {
-                  val pub        = if (published) "published" else "draft"
-                  val path       = s"$tmpDir/${uri}_$pub.json"
-                  val f          = new java.io.File(path)
-                  val fileExists = f.exists()
-                  val stream     = new FileOutputStream(f, true)
+          fetchPage(params :+ ("page" -> s"$pageNum")).map(page =>
+            page.results.foreach(n =>
+              n.contentUri.foreach(uri => {
+                val pub        = if (published) "published" else "draft"
+                val path       = s"$tmpDir/${uri}_$pub.json"
+                val f          = new java.io.File(path)
+                val fileExists = f.exists()
+                val stream     = new FileOutputStream(f, true)
 
-                  if (fileExists) stream.write('\n')
-                  val json = Serialization.write(n)
-                  stream.write(json.getBytes)
-                  stream.flush()
-                  stream.close()
-                })
-              )
+                if (fileExists) stream.write('\n')
+                val json = Serialization.write(n)
+                stream.write(json.getBytes)
+                stream.flush()
+                stream.close()
+              })
             )
-          }
+          )
         )
-        val mergedFuture = Future.sequence(pages)
-        val awaited      = Await.result(mergedFuture, timeoutSeconds)
-        awaited.toList.sequence.map(_ => ())
+        pages.toList.sequence.map(_ => ())
+//        val mergedFuture = Future.sequence(pages)
+//        val awaited      = Await.result(mergedFuture, timeoutSeconds)
+//        awaited.toList.sequence.map(_ => ())
       })
     }
   }

--- a/search-api/src/main/scala/no/ndla/searchapi/integration/TaxonomyApiClient.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/integration/TaxonomyApiClient.scala
@@ -12,10 +12,8 @@ import com.typesafe.scalalogging.StrictLogging
 import enumeratum.Json4s
 import no.ndla.network.NdlaClient
 import no.ndla.network.TaxonomyData.{TAXONOMY_VERSION_HEADER, defaultVersion}
-import no.ndla.network.model.RequestInfo
 import no.ndla.search.model.SearchableLanguageFormats
 import no.ndla.searchapi.Props
-import no.ndla.searchapi.caching.Memoize
 import no.ndla.searchapi.model.api.TaxonomyException
 import no.ndla.searchapi.model.taxonomy._
 import org.json4s.Formats
@@ -24,9 +22,8 @@ import sttp.client3.quick._
 
 import java.io.{File, FileOutputStream}
 import java.util.concurrent.Executors
-import scala.collection.mutable.ListBuffer
 import scala.concurrent._
-import scala.concurrent.duration.{Duration, DurationInt}
+import scala.concurrent.duration.DurationInt
 import scala.util.{Failure, Success, Try}
 
 trait TaxonomyApiClient {
@@ -128,8 +125,8 @@ trait TaxonomyApiClient {
                   val path        = s"$tmpDir/${uri}_$pub.json"
                   val f           = new java.io.File(path)
                   lazy val stream = new FileOutputStream(f)
-                  if (f.exists())
-                    stream.write('\n')
+
+                  if (f.exists()) stream.write('\n')
                   val json = Serialization.write(n)
                   stream.write(json.getBytes)
                 })

--- a/search-api/src/main/scala/no/ndla/searchapi/model/taxonomy/TaxonomyBundle.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/model/taxonomy/TaxonomyBundle.scala
@@ -37,7 +37,7 @@ case class TmpNodes(tmpDir: String, isPublished: Boolean) extends NodeStorage wi
     val f    = new java.io.File(path)
     if (f.exists()) {
       val stream = new FileInputStream(f)
-      val strs   = new String(stream.readAllBytes()).split("\n").toList
+      val strs   = new String(stream.readAllBytes()).split("\n").filter(_.nonEmpty).toList
       val nodes = strs.traverse(str => {
         Try(Serialization.read[Node](str)(TaxonomyBundle.formats, implicitly[Manifest[Node]]))
       })

--- a/search-api/src/main/scala/no/ndla/searchapi/model/taxonomy/TaxonomyBundle.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/model/taxonomy/TaxonomyBundle.scala
@@ -7,12 +7,19 @@
 
 package no.ndla.searchapi.model.taxonomy
 
-case class TaxonomyBundle(
-    nodes: List[Node]
-) {
+import scala.collection.mutable
 
-  val nodeByContentUri: Map[String, List[Node]] = {
-    val contentUriToNodes = nodes.flatMap(t => t.contentUri.map(cu => cu -> t))
-    contentUriToNodes.groupMap(_._1)(_._2)
+case class TaxonomyBundle(nodeByContentUri: Map[String, List[Node]]) {}
+
+object TaxonomyBundle {
+  def apply(nodes: List[Node]): TaxonomyBundle = {
+    val map = mutable.Map.empty[String, List[Node]]
+    for (n <- nodes) {
+      n.contentUri.foreach(cu => {
+        val existing = map.getOrElseUpdate(cu, List.empty)
+        map.update(cu, existing :+ n)
+      })
+    }
+    new TaxonomyBundle(map.toMap)
   }
 }

--- a/search-api/src/main/scala/no/ndla/searchapi/model/taxonomy/TaxonomyBundle.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/model/taxonomy/TaxonomyBundle.scala
@@ -7,6 +7,7 @@
 
 package no.ndla.searchapi.model.taxonomy
 
+import com.typesafe.scalalogging.StrictLogging
 import enumeratum.Json4s
 import no.ndla.search.model.SearchableLanguageFormats
 import org.json4s.Formats
@@ -27,7 +28,7 @@ case class TaxonomyBundle(nodeByContentUri: NodeStorage) extends AutoCloseable {
   }
 }
 
-case class TmpNodes(tmpDir: String, isPublished: Boolean) extends NodeStorage with AutoCloseable {
+case class TmpNodes(tmpDir: String, isPublished: Boolean) extends NodeStorage with AutoCloseable with StrictLogging {
   override def contains(contentUri: String): Boolean = getOrElse(contentUri, Nil).nonEmpty
   override def getOrElse(contentUri: String, default: => List[Node]): List[Node] = {
     val pub  = if (isPublished) "published" else "draft"
@@ -45,11 +46,11 @@ case class TmpNodes(tmpDir: String, isPublished: Boolean) extends NodeStorage wi
   }
 
   override def close(): Unit = {
-    println("CLEANING UP TAXONOMYBUNDLE FILES YOLO")
+    logger.info(s"Cleaning up TaxonomyBundle tmp files in '$tmpDir'")
     val dir = new java.io.File(tmpDir)
     if (dir.exists()) {
       dir.listFiles().foreach(_.delete())
-      dir.delete(): Boolean
+      dir.delete(): Unit
     }
   }
 }

--- a/search-api/src/main/scala/no/ndla/searchapi/model/taxonomy/TaxonomyBundle.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/model/taxonomy/TaxonomyBundle.scala
@@ -7,19 +7,75 @@
 
 package no.ndla.searchapi.model.taxonomy
 
-import scala.collection.mutable
+import enumeratum.Json4s
+import no.ndla.search.model.SearchableLanguageFormats
+import org.json4s.Formats
+import org.json4s.native.Serialization
 
-case class TaxonomyBundle(nodeByContentUri: Map[String, List[Node]]) {}
+import java.io.FileInputStream
+import scala.util.{Failure, Success, Try}
+
+sealed trait NodeStorage {
+  def getOrElse(contentUri: String, default: => List[Node]): List[Node]
+  def contains(contentUri: String): Boolean
+}
+
+case class TaxonomyBundle(nodeByContentUri: NodeStorage) extends AutoCloseable {
+  override def close(): Unit = nodeByContentUri match {
+    case tmpNodes: TmpNodes => tmpNodes.close()
+    case _                  =>
+  }
+}
+
+case class TmpNodes(tmpDir: String, isPublished: Boolean) extends NodeStorage with AutoCloseable {
+  override def contains(contentUri: String): Boolean = getOrElse(contentUri, Nil).nonEmpty
+  override def getOrElse(contentUri: String, default: => List[Node]): List[Node] = {
+    val pub  = if (isPublished) "published" else "draft"
+    val path = s"$tmpDir/${contentUri}_$pub.json"
+    val f    = new java.io.File(path)
+    if (f.exists()) {
+      val stream = new FileInputStream(f)
+      val str    = new String(stream.readAllBytes())
+      Try(Serialization.read[List[Node]](str)(TaxonomyBundle.formats, implicitly[Manifest[List[Node]]])) match {
+        case Success(value) => return value
+        case Failure(_)     =>
+      }
+    }
+    default
+  }
+
+  override def close(): Unit = {
+    println("CLEANING UP TAXONOMYBUNDLE FILES YOLO")
+    val dir = new java.io.File(tmpDir)
+    if (dir.exists()) {
+      dir.listFiles().foreach(_.delete())
+      dir.delete(): Boolean
+    }
+  }
+}
+
+case class InMemoryNodeStorage(nodes: List[Node]) extends NodeStorage {
+  private val nodeMap = {
+    nodes
+      .flatMap(t => t.contentUri.map(cu => cu -> t))
+      .groupMap(_._1)(_._2)
+  }
+
+  override def contains(contentUri: String): Boolean = nodeMap.contains(contentUri)
+  override def getOrElse(contentUri: String, default: => List[Node]): List[Node] = {
+    nodeMap.getOrElse(contentUri, default)
+  }
+}
 
 object TaxonomyBundle {
+  implicit val formats: Formats = SearchableLanguageFormats.JSonFormatsWithMillis + Json4s.serializer(NodeType)
+  def apply(tmpDir: String, isPublished: Boolean): TaxonomyBundle = {
+    val storage = TmpNodes(tmpDir, isPublished)
+    new TaxonomyBundle(storage)
+  }
+
   def apply(nodes: List[Node]): TaxonomyBundle = {
-    val map = mutable.Map.empty[String, List[Node]]
-    for (n <- nodes) {
-      n.contentUri.foreach(cu => {
-        val existing = map.getOrElseUpdate(cu, List.empty)
-        map.update(cu, existing :+ n)
-      })
-    }
-    new TaxonomyBundle(map.toMap)
+    val storage = InMemoryNodeStorage(nodes)
+    new TaxonomyBundle(storage)
   }
 }

--- a/search-api/src/test/scala/no/ndla/searchapi/TestData.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/TestData.scala
@@ -1532,7 +1532,7 @@ object TestData {
     resource_13
   )
 
-  val taxonomyTestBundle: TaxonomyBundle = TaxonomyBundle(nodes = nodes)
+  val taxonomyTestBundle: TaxonomyBundle = TaxonomyBundle(nodes)
 
   val emptyGrepBundle: GrepBundle = GrepBundle(
     kjerneelementer = List.empty,

--- a/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceTest.scala
@@ -79,10 +79,10 @@ class MultiSearchServiceTest
   }
 
   def hasTaxonomy(lp: LearningPath): Boolean =
-    taxonomyTestBundle.nodes.map(_.contentUri.get).contains(s"urn:learningpath:${lp.id.get}")
+    taxonomyTestBundle.nodeByContentUri.contains(s"urn:learningpath:${lp.id.get}")
 
   def hasTaxonomy(ar: Article): Boolean =
-    taxonomyTestBundle.nodes.map(_.contentUri.get).contains(s"urn:article:${ar.id.get}")
+    taxonomyTestBundle.nodeByContentUri.contains(s"urn:article:${ar.id.get}")
 
   private def expectedAllPublicArticles(language: String) = {
     val x = if (language == "*") { TestData.articlesToIndex.filter(_.availability == Availability.everyone) }

--- a/search-api/src/test/scala/no/ndla/searchapi/service/search/SearchConverterServiceTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/service/search/SearchConverterServiceTest.scala
@@ -256,7 +256,7 @@ class SearchConverterServiceTest extends UnitSuite with TestEnvironment {
   }
 
   test("That invisible contexts are not indexed") {
-    val taxonomyBundleInvisibleMetadata = TestData.taxonomyTestBundle.copy(nodes =
+    val taxonomyBundleInvisibleMetadata = TaxonomyBundle(
       nodes
         .filter(node => node.nodeType == NodeType.RESOURCE)
         .map(resource => resource.copy(metadata = invisibleMetadata))
@@ -287,7 +287,7 @@ class SearchConverterServiceTest extends UnitSuite with TestEnvironment {
 
   test("That invisible subjects are not indexed") {
     val taxonomyBundleInvisibleMetadata =
-      TestData.taxonomyTestBundle.copy(nodes =
+      TaxonomyBundle(
         nodes
           .filter(node => node.nodeType == NodeType.SUBJECT)
           .map(subject => subject.copy(metadata = invisibleMetadata))

--- a/search-api/src/test/scala/no/ndla/searchapi/service/search/SearchConverterServiceTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/service/search/SearchConverterServiceTest.scala
@@ -94,8 +94,7 @@ class SearchConverterServiceTest extends UnitSuite with TestEnvironment {
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    when(taxonomyApiClient.getTaxonomyBundle)
-      .thenReturn(new Memoize[Boolean, Try[TaxonomyBundle]](0, _ => Success(emptyBundle)))
+    when(taxonomyApiClient.getTaxonomyBundle(any)).thenReturn(Success(emptyBundle))
   }
 
   test("That asSearchableArticle converts titles with correct language") {

--- a/search-api/src/test/scala/no/ndla/searchapi/service/search/SearchConverterServiceTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/service/search/SearchConverterServiceTest.scala
@@ -11,13 +11,12 @@ import no.ndla.common.configuration.Constants.EmbedTagName
 import no.ndla.common.model.domain.article.Article
 import no.ndla.common.model.domain.{ArticleContent, Tag, Title}
 import no.ndla.search.model.{LanguageValue, SearchableLanguageList, SearchableLanguageValues}
-import no.ndla.searchapi.caching.Memoize
 import no.ndla.searchapi.model.grep.{GrepElement, GrepTitle}
 import no.ndla.searchapi.model.search.{SearchableArticle, SearchableGrepContext}
 import no.ndla.searchapi.model.taxonomy._
 import no.ndla.searchapi.{TestData, TestEnvironment, UnitSuite}
 
-import scala.util.{Success, Try}
+import scala.util.Success
 
 class SearchConverterServiceTest extends UnitSuite with TestEnvironment {
 


### PR DESCRIPTION
Depends on https://github.com/NDLANO/deploy/pull/606

Gjør et par ting:
  - Legger til `JAVA_OPTS` variabel til docker-byggene
    - Denne bør gjøre det litt enklere å prøve ut `-Xmx` verdier uten å bygge på nytt hver gang.
  - Mellom-lagrer noder på disk istedetfor å holde `TaxonomyBundle` i minnet hele veien.
    - Den nye måten å hente taksonomi på er bittelitt tregere på min maskin, _men_ total indeksering går ganske mye raskere.
      - På youtube-pcen så går indekseringen fra 6.5min -> 4.1min
      - På jobb-pcen så går den fra  4.5min -> 3.5min

Dersom initial load av taksonomi fetching fortsatt bruker for mye minne så kan vi enten redusere antall sider vi laster samtidig, eller så kan vi øke minne for bare cronjobben med `JAVA_OPTS` flagget.