### PR TITLE
Add data-alt attribute to iframe embed

### DIFF
--- a/validation/src/main/resources/embed-tag-rules.json
+++ b/validation/src/main/resources/embed-tag-rules.json
@@ -563,6 +563,15 @@
               "data-height"
             ]
           }
+        },
+        {
+          "name": "data-alt",
+          "validation": {
+            "required": false,
+            "mustCoexistWith": [
+              "data-imageid"
+            ]
+          }
         }
       ]
     },


### PR DESCRIPTION
https://trello.com/c/3ZHUqmuT/84-kan-ikke-redigere-alt-tekst-for-bilde-som-settes-i-boks-for-ekstern-ressurs

Satt kun opp `imageid` som dependant. Blir det riktig at jeg ikke lister opp `data-alt` i `mustCoexistWith` på de andre attributene? Den er tross alt ikke required.