### PR TITLE
Add support for saving an article-id to info article

### DIFF
--- a/frontpage-api/src/main/scala/no/ndla/frontpageapi/model/api/FilmFrontPageData.scala
+++ b/frontpage-api/src/main/scala/no/ndla/frontpageapi/model/api/FilmFrontPageData.scala
@@ -11,5 +11,6 @@ case class FilmFrontPageData(
     name: String,
     about: Seq[AboutFilmSubject],
     movieThemes: Seq[MovieTheme],
-    slideShow: Seq[String]
+    slideShow: Seq[String],
+    article: Option[String]
 )

--- a/frontpage-api/src/main/scala/no/ndla/frontpageapi/model/api/NewOrUpdatedFilmFrontPageData.scala
+++ b/frontpage-api/src/main/scala/no/ndla/frontpageapi/model/api/NewOrUpdatedFilmFrontPageData.scala
@@ -11,5 +11,6 @@ case class NewOrUpdatedFilmFrontPageData(
     name: String,
     about: Seq[NewOrUpdatedAboutSubject],
     movieThemes: Seq[NewOrUpdatedMovieTheme],
-    slideShow: Seq[String]
+    slideShow: Seq[String],
+    article: Option[String]
 )

--- a/frontpage-api/src/main/scala/no/ndla/frontpageapi/model/domain/FilmFrontPageData.scala
+++ b/frontpage-api/src/main/scala/no/ndla/frontpageapi/model/domain/FilmFrontPageData.scala
@@ -21,7 +21,8 @@ case class FilmFrontPageData(
     name: String,
     about: Seq[AboutSubject],
     movieThemes: Seq[MovieTheme],
-    slideShow: Seq[String]
+    slideShow: Seq[String],
+    article: Option[String]
 )
 
 object FilmFrontPageData {

--- a/frontpage-api/src/main/scala/no/ndla/frontpageapi/service/ConverterService.scala
+++ b/frontpage-api/src/main/scala/no/ndla/frontpageapi/service/ConverterService.scala
@@ -39,7 +39,8 @@ trait ConverterService {
         page.name,
         toApiAboutFilmSubject(page.about, language),
         toApiMovieThemes(page.movieThemes, language),
-        page.slideShow
+        page.slideShow,
+        page.article
       )
     }
 
@@ -196,7 +197,7 @@ trait ConverterService {
 
     def toDomainFilmFrontPage(page: api.NewOrUpdatedFilmFrontPageData): Try[domain.FilmFrontPageData] = {
       val withoutAboutSubject =
-        domain.FilmFrontPageData(page.name, Seq(), toDomainMovieThemes(page.movieThemes), page.slideShow)
+        domain.FilmFrontPageData(page.name, Seq(), toDomainMovieThemes(page.movieThemes), page.slideShow, page.article)
 
       toDomainAboutSubject(page.about) match {
         case Failure(ex)    => Failure(ex)

--- a/frontpage-api/src/test/scala/no/ndla/frontpageapi/TestData.scala
+++ b/frontpage-api/src/test/scala/no/ndla/frontpageapi/TestData.scala
@@ -145,8 +145,9 @@ object TestData {
         Seq("movieref1", "movieref2")
       )
     ),
-    Seq()
+    Seq(),
+    None
   )
 
-  val apiFilmFrontPage: api.FilmFrontPageData = api.FilmFrontPageData("", Seq(), Seq(), Seq())
+  val apiFilmFrontPage: api.FilmFrontPageData = api.FilmFrontPageData("", Seq(), Seq(), Seq(), None)
 }


### PR DESCRIPTION
NDLANO/Issues#3821

Legger på støtte for å lagre informasjonsartikkel på ndla-film-sida.