### PR TITLE
Share name on folder

### DIFF
--- a/learningpath-api/src/main/resources/no/ndla/learningpathapi/db/migration/V34__AddShareNameToUser.sql
+++ b/learningpath-api/src/main/resources/no/ndla/learningpathapi/db/migration/V34__AddShareNameToUser.sql
@@ -1,0 +1,6 @@
+UPDATE my_ndla_users mnu
+SET document=(
+    SELECT document || jsonb_build_object('shareName', false, 'displayName', '')
+    FROM my_ndla_users mnu2
+    WHERE mnu.id = mnu2.id
+)

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/model/api/Folder.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/model/api/Folder.scala
@@ -16,6 +16,10 @@ import org.scalatra.swagger.runtime.annotations.ApiModelProperty
 import scala.annotation.meta.field
 import scala.annotation.unused
 
+case class Owner(
+    @(ApiModelProperty @field)(description = "Name of the owner") name: String
+)
+
 // format: off
 case class Folder(
     @(ApiModelProperty @field)(description = "UUID of the folder") id: String,
@@ -29,7 +33,8 @@ case class Folder(
     @(ApiModelProperty @field)(description = "When the folder was created") created: NDLADate,
     @(ApiModelProperty @field)(description = "When the folder was updated") updated: NDLADate,
     @(ApiModelProperty @field)(description = "When the folder was last shared") shared: Option[NDLADate],
-    @(ApiModelProperty @field)(description = "Description of the folder") description: Option[String]
+    @(ApiModelProperty @field)(description = "Description of the folder") description: Option[String],
+    @(ApiModelProperty @field)(description = "Owner of the folder, if the owner have opted in to share their name") owner: Option[Owner],
 ) extends FolderData with CopyableFolder
 // format: on
 
@@ -59,7 +64,8 @@ object FolderData {
       created: NDLADate,
       updated: NDLADate,
       shared: Option[NDLADate],
-      description: Option[String]
+      description: Option[String],
+      username: Option[String]
   ): FolderData = {
     Folder(
       id,
@@ -73,7 +79,8 @@ object FolderData {
       created,
       updated,
       shared,
-      description
+      description,
+      username.map(name => Owner(name))
     )
   }
 

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/model/api/MyNDLAUser.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/model/api/MyNDLAUser.scala
@@ -16,11 +16,13 @@ case class MyNDLAUser(
     @(ApiModelProperty @field)(description = "Favorite subjects of the user") favoriteSubjects: Seq[String],
     @(ApiModelProperty @field)(description = "User role") role: String,
     @(ApiModelProperty @field)(description = "User organization") organization: String,
-    @(ApiModelProperty @field)(description = "Whether arena is explicitly enabled for the user") arenaEnabled: Boolean
+    @(ApiModelProperty @field)(description = "Whether arena is explicitly enabled for the user") arenaEnabled: Boolean,
+    @(ApiModelProperty @field)(description = "Whether users name is shared with folders or not") shareName: Boolean
 )
 
 // format: off
 case class UpdatedMyNDLAUser(
     @(ApiModelProperty @field)(description = "Favorite subjects of the user") favoriteSubjects: Option[Seq[String]],
-    @(ApiModelProperty @field)(description = "Whether arena should explicitly be enabled for the user") arenaEnabled: Option[Boolean]
+    @(ApiModelProperty @field)(description = "Whether arena should explicitly be enabled for the user") arenaEnabled: Option[Boolean],
+    @(ApiModelProperty @field)(description = "Whether users name should be shared with folder or not") shareName: Option[Boolean]
 )

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/model/domain/MyNDLAUser.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/model/domain/MyNDLAUser.scala
@@ -21,8 +21,10 @@ case class MyNDLAUserDocument(
     userRole: UserRole.Value,
     lastUpdated: NDLADate,
     organization: String,
+    displayName: String,
     email: String,
-    arenaEnabled: Boolean
+    arenaEnabled: Boolean,
+    shareName: Boolean
 ) {
   def toFullUser(
       id: Long,
@@ -35,8 +37,10 @@ case class MyNDLAUserDocument(
       userRole = userRole,
       lastUpdated = lastUpdated,
       organization = organization,
+      displayName = displayName,
       email = email,
-      arenaEnabled = arenaEnabled
+      arenaEnabled = arenaEnabled,
+      shareName = shareName
     )
   }
 }
@@ -48,8 +52,10 @@ case class MyNDLAUser(
     userRole: UserRole.Value,
     lastUpdated: NDLADate,
     organization: String,
+    displayName: String,
     email: String,
-    arenaEnabled: Boolean
+    arenaEnabled: Boolean,
+    shareName: Boolean
 ) {
   // Keeping FEIDE and our data in sync
   def wasUpdatedLast24h: Boolean = NDLADate.now().isBefore(lastUpdated.minusSeconds(10))

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/ReadService.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/ReadService.scala
@@ -423,7 +423,6 @@ trait ReadService {
     ): Try[domain.MyNDLAUser] = {
       val feideUser    = feideApiClient.getFeideExtendedUser(feideAccessToken).?
       val organization = feideApiClient.getOrganization(feideAccessToken).?
-      val displayName  = if (userData.shareName) feideUser.displayName else ""
       val updatedMyNDLAUser = domain.MyNDLAUser(
         id = userData.id,
         feideId = userData.feideId,
@@ -434,7 +433,7 @@ trait ReadService {
         email = feideUser.email,
         arenaEnabled = userData.arenaEnabled,
         shareName = userData.shareName,
-        displayName = displayName
+        displayName = feideUser.displayName
       )
       userRepository.updateUser(feideId, updatedMyNDLAUser)(session)
     }

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/ReadService.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/ReadService.scala
@@ -295,8 +295,9 @@ trait ReadService {
         feideId           <- feideApiClient.getFeideID(feideAccessToken)
         folderWithContent <- getSingleFolderWithContent(id, includeSubfolders, includeResources)
         _                 <- folderWithContent.isOwner(feideId)
+        feideUser         <- userRepository.userWithFeideId(feideId)
         breadcrumbs       <- getBreadcrumbs(folderWithContent)
-        converted         <- converterService.toApiFolder(folderWithContent, breadcrumbs)
+        converted         <- converterService.toApiFolder(folderWithContent, breadcrumbs, feideUser)
       } yield converted
     }
 
@@ -370,9 +371,10 @@ trait ReadService {
         topFolders   <- folderRepository.foldersWithFeideAndParentID(None, feideId)
         withFavorite <- mergeWithFavorite(topFolders, feideId)
         withData     <- getSubfolders(withFavorite, includeSubfolders, includeResources)
+        feideUser    <- userRepository.userWithFeideId(feideId)
         apiFolders <- converterService.domainToApiModel(
           withData,
-          v => converterService.toApiFolder(v, List(api.Breadcrumb(id = v.id.toString, name = v.name)))
+          v => converterService.toApiFolder(v, List(api.Breadcrumb(id = v.id.toString, name = v.name)), feideUser)
         )
         sorted = apiFolders.sortBy(_.rank)
       } yield sorted
@@ -386,7 +388,8 @@ trait ReadService {
         _ <- if (folderWithContent.isShared) Success(()) else Failure(NotFoundException("Folder does not exist"))
         folderAsTopFolder = folderWithContent.copy(parentId = None)
         breadcrumbs <- getBreadcrumbs(folderAsTopFolder)
-        converted   <- converterService.toApiFolder(folderAsTopFolder, breadcrumbs)
+        feideUser   <- userRepository.userWithFeideId(folderWithContent.feideId)
+        converted   <- converterService.toApiFolder(folderAsTopFolder, breadcrumbs, feideUser)
       } yield converted
     }
 
@@ -403,7 +406,9 @@ trait ReadService {
             lastUpdated = clock.now().plusDays(1),
             organization = organization,
             email = feideExtendedUserData.email,
-            arenaEnabled = false
+            arenaEnabled = false,
+            shareName = false,
+            displayName = ""
           )
         inserted <- userRepository.insertUser(feideId, newUser)(session)
       } yield inserted
@@ -418,6 +423,7 @@ trait ReadService {
     ): Try[domain.MyNDLAUser] = {
       val feideUser    = feideApiClient.getFeideExtendedUser(feideAccessToken).?
       val organization = feideApiClient.getOrganization(feideAccessToken).?
+      val displayName = if(userData.shareName) feideUser.displayName else ""
       val updatedMyNDLAUser = domain.MyNDLAUser(
         id = userData.id,
         feideId = userData.feideId,
@@ -426,7 +432,9 @@ trait ReadService {
         lastUpdated = clock.now().plusDays(1),
         organization = organization,
         email = feideUser.email,
-        arenaEnabled = userData.arenaEnabled
+        arenaEnabled = userData.arenaEnabled,
+        shareName = userData.shareName,
+        displayName = displayName
       )
       userRepository.updateUser(feideId, updatedMyNDLAUser)(session)
     }

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/ReadService.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/ReadService.scala
@@ -295,7 +295,7 @@ trait ReadService {
         feideId           <- feideApiClient.getFeideID(feideAccessToken)
         folderWithContent <- getSingleFolderWithContent(id, includeSubfolders, includeResources)
         _                 <- folderWithContent.isOwner(feideId)
-        feideUser         <- userRepository.userWithFeideId(feideId)
+        feideUser         <- userRepository.userWithFeideId(folderWithContent.feideId)
         breadcrumbs       <- getBreadcrumbs(folderWithContent)
         converted         <- converterService.toApiFolder(folderWithContent, breadcrumbs, feideUser)
       } yield converted
@@ -408,7 +408,7 @@ trait ReadService {
             email = feideExtendedUserData.email,
             arenaEnabled = false,
             shareName = false,
-            displayName = ""
+            displayName = feideExtendedUserData.displayName
           )
         inserted <- userRepository.insertUser(feideId, newUser)(session)
       } yield inserted

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/ReadService.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/ReadService.scala
@@ -423,7 +423,7 @@ trait ReadService {
     ): Try[domain.MyNDLAUser] = {
       val feideUser    = feideApiClient.getFeideExtendedUser(feideAccessToken).?
       val organization = feideApiClient.getOrganization(feideAccessToken).?
-      val displayName = if(userData.shareName) feideUser.displayName else ""
+      val displayName  = if (userData.shareName) feideUser.displayName else ""
       val updatedMyNDLAUser = domain.MyNDLAUser(
         id = userData.id,
         feideId = userData.feideId,

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/UpdateService.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/UpdateService.scala
@@ -1063,7 +1063,7 @@ trait UpdateService {
         updatedFeideUser = api.UpdatedMyNDLAUser(
           favoriteSubjects = Some(newFavorites),
           arenaEnabled = None,
-          shareName = None
+          shareName = Some(existingUser.shareName)
         )
         updated <- updateFeideUserDataAuthenticated(updatedFeideUser, feideId, feideAccessToken)(session)
       } yield updated

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/UpdateService.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/UpdateService.scala
@@ -630,11 +630,12 @@ trait UpdateService {
     def newFolder(newFolder: api.NewFolder, feideAccessToken: Option[FeideAccessToken]): Try[api.Folder] = {
       implicit val session: DBSession = folderRepository.getSession(readOnly = false)
       for {
-        feideId  <- feideApiClient.getFeideID(feideAccessToken)
-        _        <- canWriteDuringMyNDLAWriteRestrictionsOrAccessDenied(feideId, feideAccessToken)
-        inserted <- createNewFolder(newFolder, feideId, makeUniqueNamePostfix = None, isCloning = false)
-        crumbs   <- readService.getBreadcrumbs(inserted)(ReadOnlyAutoSession)
-        api      <- converterService.toApiFolder(inserted, crumbs)
+        feideId   <- feideApiClient.getFeideID(feideAccessToken)
+        _         <- canWriteDuringMyNDLAWriteRestrictionsOrAccessDenied(feideId, feideAccessToken)
+        inserted  <- createNewFolder(newFolder, feideId, makeUniqueNamePostfix = None, isCloning = false)
+        crumbs    <- readService.getBreadcrumbs(inserted)(ReadOnlyAutoSession)
+        feideUser <- userRepository.userWithFeideId(feideId)
+        api       <- converterService.toApiFolder(inserted, crumbs, feideUser)
       } yield api
     }
 
@@ -723,7 +724,8 @@ trait UpdateService {
         _              <- validateUpdatedFolder(converted.name, converted.parentId, maybeSiblings, converted)
         updated        <- folderRepository.updateFolder(id, feideId, converted)
         crumbs         <- readService.getBreadcrumbs(updated)(ReadOnlyAutoSession)
-        api            <- converterService.toApiFolder(updated, crumbs)
+        feideUser      <- userRepository.userWithFeideId(feideId)
+        api            <- converterService.toApiFolder(updated, crumbs, feideUser)
       } yield api
     }
 
@@ -1039,7 +1041,8 @@ trait UpdateService {
           _            <- sourceFolder.isClonable
           clonedFolder <- cloneRecursively(sourceFolder, destinationId, feideId, "_Kopi".some)(session)
           breadcrumbs  <- readService.getBreadcrumbs(clonedFolder)
-          converted    <- converterService.toApiFolder(clonedFolder, breadcrumbs)
+          feideUser    <- userRepository.userWithFeideId(feideId)
+          converted    <- converterService.toApiFolder(clonedFolder, breadcrumbs, feideUser)
         } yield converted
       }
     }
@@ -1056,8 +1059,12 @@ trait UpdateService {
     ): Try[api.MyNDLAUser] =
       for {
         existingUser <- readService.getOrCreateMyNDLAUserIfNotExist(feideId, feideAccessToken)(session)
-        newFavorites     = (existingUser.favoriteSubjects ++ userData.favoriteSubjects).distinct
-        updatedFeideUser = api.UpdatedMyNDLAUser(favoriteSubjects = Some(newFavorites), arenaEnabled = None)
+        newFavorites = (existingUser.favoriteSubjects ++ userData.favoriteSubjects).distinct
+        updatedFeideUser = api.UpdatedMyNDLAUser(
+          favoriteSubjects = Some(newFavorites),
+          arenaEnabled = None,
+          shareName = None
+        )
         updated <- updateFeideUserDataAuthenticated(updatedFeideUser, feideId, feideAccessToken)(session)
       } yield updated
 

--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/TestData.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/TestData.scala
@@ -162,7 +162,8 @@ object TestData {
     created = today,
     updated = today,
     shared = None,
-    description = None
+    description = None,
+    owner = None
   )
 
   val emptyMyNDLAUser: domain.MyNDLAUser = domain.MyNDLAUser(
@@ -173,7 +174,9 @@ object TestData {
     lastUpdated = today,
     organization = "",
     email = "",
-    arenaEnabled = false
+    arenaEnabled = false,
+    displayName = "",
+    shareName = false
   )
 
 }

--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/e2e/CloneFolderTest.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/e2e/CloneFolderTest.scala
@@ -173,7 +173,8 @@ class CloneFolderTest
       created = testClock.now(),
       updated = testClock.now(),
       shared = None,
-      description = Some("samling 1")
+      description = Some("samling 1"),
+      owner = None
     )
 
     val parentChild2 = api.Folder(
@@ -189,7 +190,8 @@ class CloneFolderTest
       created = testClock.now(),
       updated = testClock.now(),
       shared = None,
-      description = Some("samling 2")
+      description = Some("samling 2"),
+      owner = None
     )
 
     val parentChild3 = api.Resource(
@@ -214,7 +216,8 @@ class CloneFolderTest
       created = testClock.now(),
       updated = testClock.now(),
       shared = None,
-      description = Some("samling 0")
+      description = Some("samling 0"),
+      owner = None
     )
 
     val destinationFoldersBefore = folderRepository.foldersWithFeideAndParentID(None, destinationFeideId)
@@ -281,7 +284,8 @@ class CloneFolderTest
       created = testClock.now(),
       updated = testClock.now(),
       shared = None,
-      description = Some("samling 1")
+      description = Some("samling 1"),
+      owner = None
     )
 
     val parentChild2 = api.Folder(
@@ -297,7 +301,8 @@ class CloneFolderTest
       created = testClock.now(),
       updated = testClock.now(),
       shared = None,
-      description = Some("samling 2")
+      description = Some("samling 2"),
+      owner = None
     )
 
     val parentChild3 = api.Resource(
@@ -322,7 +327,8 @@ class CloneFolderTest
       created = testClock.now(),
       updated = testClock.now(),
       shared = None,
-      description = Some("samling 0")
+      description = Some("samling 0"),
+      owner = None
     )
 
     val destinationFoldersBefore = folderRepository.foldersWithFeideAndParentID(None, destinationFeideId)
@@ -378,7 +384,8 @@ class CloneFolderTest
       created = testClock.now(),
       updated = testClock.now(),
       shared = None,
-      description = Some("samling 1")
+      description = Some("samling 1"),
+      owner = None
     )
 
     val parentChild2 = api.Folder(
@@ -397,7 +404,8 @@ class CloneFolderTest
       created = testClock.now(),
       updated = testClock.now(),
       shared = None,
-      description = Some("samling 2")
+      description = Some("samling 2"),
+      owner = None
     )
 
     val parentChild3 = api.Resource(
@@ -425,7 +433,8 @@ class CloneFolderTest
       created = testClock.now(),
       updated = testClock.now(),
       shared = None,
-      description = Some("samling 0")
+      description = Some("samling 0"),
+      owner = None
     )
 
     val response = simpleHttpClient.send(

--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/ConverterServiceTest.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/ConverterServiceTest.scala
@@ -642,7 +642,8 @@ class ConverterServiceTest extends UnitSuite with UnitTestEnvironment {
       created = created,
       updated = created,
       shared = None,
-      description = Some("folderData1")
+      description = Some("folderData1"),
+      owner = None
     )
     val apiData2 = api.Folder(
       id = subFolder2UUID.toString,
@@ -659,7 +660,8 @@ class ConverterServiceTest extends UnitSuite with UnitTestEnvironment {
       created = created,
       updated = created,
       shared = None,
-      description = Some("folderData2")
+      description = Some("folderData2"),
+      owner = None
     )
     val apiData3 = api.Folder(
       id = subFolder3UUID.toString,
@@ -676,7 +678,8 @@ class ConverterServiceTest extends UnitSuite with UnitTestEnvironment {
       created = created,
       updated = created,
       shared = None,
-      description = Some("folderData3")
+      description = Some("folderData3"),
+      owner = None
     )
     val expected = api.Folder(
       id = mainFolderUUID.toString,
@@ -692,11 +695,12 @@ class ConverterServiceTest extends UnitSuite with UnitTestEnvironment {
       created = created,
       updated = created,
       shared = None,
-      description = Some("mainFolder")
+      description = Some("mainFolder"),
+      owner = None
     )
 
     val Success(result) =
-      service.toApiFolder(mainFolder, List(api.Breadcrumb(id = mainFolderUUID.toString, name = "mainFolder")))
+      service.toApiFolder(mainFolder, List(api.Breadcrumb(id = mainFolderUUID.toString, name = "mainFolder")), None)
     result should be(expected)
   }
 
@@ -851,7 +855,7 @@ class ConverterServiceTest extends UnitSuite with UnitTestEnvironment {
       TestData.emptyDomainFolder.copy(id = folder3UUID)
     )
 
-    val result = service.domainToApiModel(folderDomainList, f => converterService.toApiFolder(f, List.empty))
+    val result = service.domainToApiModel(folderDomainList, f => converterService.toApiFolder(f, List.empty, None))
     result.get.length should be(3)
     result should be(
       Success(
@@ -874,7 +878,9 @@ class ConverterServiceTest extends UnitSuite with UnitTestEnvironment {
         lastUpdated = clock.now(),
         organization = "oslo",
         email = "example@email.com",
-        arenaEnabled = false
+        arenaEnabled = false,
+        displayName = "Feide",
+        shareName = false
       )
     val expectedUserData =
       api.MyNDLAUser(
@@ -882,7 +888,8 @@ class ConverterServiceTest extends UnitSuite with UnitTestEnvironment {
         favoriteSubjects = Seq("a", "b"),
         role = "student",
         organization = "oslo",
-        arenaEnabled = false
+        arenaEnabled = false,
+        shareName = false
       )
 
     service.toApiUserData(domainUserData, List.empty) should be(expectedUserData)
@@ -897,11 +904,15 @@ class ConverterServiceTest extends UnitSuite with UnitTestEnvironment {
       lastUpdated = clock.now(),
       organization = "oslo",
       email = "example@email.com",
-      arenaEnabled = false
+      arenaEnabled = false,
+      displayName = "Feide",
+      shareName = false
     )
-    val updatedUserData1 = api.UpdatedMyNDLAUser(favoriteSubjects = None, arenaEnabled = None)
-    val updatedUserData2 = api.UpdatedMyNDLAUser(favoriteSubjects = Some(Seq.empty), arenaEnabled = None)
-    val updatedUserData3 = api.UpdatedMyNDLAUser(favoriteSubjects = Some(Seq("x", "y", "z")), arenaEnabled = None)
+    val updatedUserData1 = api.UpdatedMyNDLAUser(favoriteSubjects = None, arenaEnabled = None, shareName = None)
+    val updatedUserData2 =
+      api.UpdatedMyNDLAUser(favoriteSubjects = Some(Seq.empty), arenaEnabled = None, shareName = None)
+    val updatedUserData3 =
+      api.UpdatedMyNDLAUser(favoriteSubjects = Some(Seq("x", "y", "z")), arenaEnabled = None, shareName = None)
 
     val expectedUserData1 = domain.MyNDLAUser(
       id = 42,
@@ -911,7 +922,9 @@ class ConverterServiceTest extends UnitSuite with UnitTestEnvironment {
       lastUpdated = clock.now(),
       organization = "oslo",
       email = "example@email.com",
-      arenaEnabled = false
+      arenaEnabled = false,
+      displayName = "Feide",
+      shareName = false
     )
     val expectedUserData2 = domain.MyNDLAUser(
       id = 42,
@@ -921,7 +934,9 @@ class ConverterServiceTest extends UnitSuite with UnitTestEnvironment {
       lastUpdated = clock.now(),
       organization = "oslo",
       email = "example@email.com",
-      arenaEnabled = false
+      arenaEnabled = false,
+      displayName = "Feide",
+      shareName = false
     )
     val expectedUserData3 = domain.MyNDLAUser(
       id = 42,
@@ -931,7 +946,9 @@ class ConverterServiceTest extends UnitSuite with UnitTestEnvironment {
       lastUpdated = clock.now(),
       organization = "oslo",
       email = "example@email.com",
-      arenaEnabled = false
+      arenaEnabled = false,
+      displayName = "Feide",
+      shareName = false
     )
 
     service.mergeUserData(domainUserData, updatedUserData1, None) should be(expectedUserData1)

--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/ReadServiceTest.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/ReadServiceTest.scala
@@ -451,7 +451,8 @@ class ReadServiceTest extends UnitSuite with UnitTestEnvironment {
           created = created,
           updated = created,
           shared = None,
-          description = None
+          description = None,
+          owner = None
         ),
         api.Folder(
           id = subFolder2UUID.toString,
@@ -468,14 +469,16 @@ class ReadServiceTest extends UnitSuite with UnitTestEnvironment {
           created = created,
           updated = created,
           shared = None,
-          description = None
+          description = None,
+          owner = None
         )
       ),
       rank = None,
       created = created,
       updated = created,
       shared = None,
-      description = None
+      description = None,
+      owner = None
     )
 
     val whgaterh = mainFolder.copy(
@@ -498,6 +501,7 @@ class ReadServiceTest extends UnitSuite with UnitTestEnvironment {
     when(folderRepository.getFolderResources(eqTo(subFolder1UUID))(any)).thenReturn(Success(List.empty))
     when(folderRepository.getFolderResources(eqTo(subFolder2UUID))(any)).thenReturn(Success(List.empty))
     when(folderRepository.getFolderAndChildrenSubfoldersWithResources(any)(any)).thenReturn(Success(Some(whgaterh)))
+    when(userRepository.userWithFeideId(any)(any[DBSession])).thenReturn(Success(None))
 
     val result = service.getSingleFolder(mainFolderUUID, includeSubfolders = true, includeResources = true, None)
     result should be(Success(expected))
@@ -532,6 +536,7 @@ class ReadServiceTest extends UnitSuite with UnitTestEnvironment {
     when(folderRepository.insertFolder(any, any)(any)).thenReturn(Success(favoriteDomainFolder))
     when(folderRepository.foldersWithFeideAndParentID(eqTo(None), eqTo(feideId))(any)).thenReturn(Success(List.empty))
     when(folderRepository.folderWithId(eqTo(favoriteUUID))(any)).thenReturn(Success(favoriteDomainFolder))
+    when(userRepository.userWithFeideId(any)(any[DBSession])).thenReturn(Success(None))
 
     val result = service.getFolders(includeSubfolders = false, includeResources = false, Some("token"))
     result.get.length should be(1)
@@ -558,11 +563,10 @@ class ReadServiceTest extends UnitSuite with UnitTestEnvironment {
     when(feideApiClient.getFeideID(Some("token"))).thenReturn(Success(feideId))
     when(folderRepository.foldersWithFeideAndParentID(eqTo(None), eqTo(feideId))(any))
       .thenReturn(Success(List(folderWithId, folderWithId)))
-
     when(folderRepository.folderWithId(eqTo(folderWithId.id))(any)).thenReturn(Success(folderWithId))
-
     when(folderRepository.getFolderResources(any)(any))
       .thenReturn(folderResourcesResponse1, folderResourcesResponse2, folderResourcesResponse3)
+    when(userRepository.userWithFeideId(any)(any[DBSession])).thenReturn(Success(None))
 
     val result = service.getFolders(includeSubfolders = false, includeResources = true, Some("token"))
     result.get.length should be(2)
@@ -585,6 +589,7 @@ class ReadServiceTest extends UnitSuite with UnitTestEnvironment {
 
     when(folderRepository.getFolderAndChildrenSubfoldersWithResources(eqTo(folderUUID), eqTo(FolderStatus.SHARED))(any))
       .thenReturn(Success(Some(folderWithId)))
+    when(userRepository.userWithFeideId(any)(any[DBSession])).thenReturn(Success(None))
 
     service.getSharedFolder(folderUUID) should be(Success(apiFolder))
   }
@@ -612,14 +617,17 @@ class ReadServiceTest extends UnitSuite with UnitTestEnvironment {
       lastUpdated = clock.now(),
       organization = "oslo",
       email = "example@email.com",
-      arenaEnabled = false
+      arenaEnabled = false,
+      displayName = "Feide",
+      shareName = false
     )
     val apiUserData = api.MyNDLAUser(
       id = 42,
       favoriteSubjects = Seq("r", "e"),
       role = "student",
       organization = "oslo",
-      arenaEnabled = false
+      arenaEnabled = false,
+      shareName = false
     )
     val feideUserInfo = FeideExtendedUserInfo(
       displayName = "David",
@@ -657,14 +665,17 @@ class ReadServiceTest extends UnitSuite with UnitTestEnvironment {
       lastUpdated = clock.now().plusDays(1),
       organization = "oslo",
       email = "example@email.com",
-      arenaEnabled = false
+      arenaEnabled = false,
+      displayName = "Feide",
+      shareName = false
     )
     val apiUserData = api.MyNDLAUser(
       id = 42,
       favoriteSubjects = Seq("r", "e"),
       role = "student",
       organization = "oslo",
-      arenaEnabled = false
+      arenaEnabled = false,
+      shareName = false
     )
 
     when(readService.getMyNDLAEnabledOrgs).thenReturn(Success(List.empty))
@@ -691,7 +702,9 @@ class ReadServiceTest extends UnitSuite with UnitTestEnvironment {
       lastUpdated = clock.now().minusDays(1),
       organization = "oslo",
       email = "example@email.com",
-      arenaEnabled = false
+      arenaEnabled = false,
+      displayName = "Feide",
+      shareName = false
     )
     val updatedFeideUser = FeideExtendedUserInfo(
       displayName = "name",
@@ -703,7 +716,8 @@ class ReadServiceTest extends UnitSuite with UnitTestEnvironment {
       favoriteSubjects = Seq("r", "e"),
       role = "student",
       organization = "oslo",
-      arenaEnabled = false
+      arenaEnabled = false,
+      shareName = false
     )
 
     when(readService.getMyNDLAEnabledOrgs).thenReturn(Success(List.empty))

--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/UpdateServiceTest.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/UpdateServiceTest.scala
@@ -2187,7 +2187,7 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
       shareName = false
     )
     val updatedUserData =
-      api.UpdatedMyNDLAUser(favoriteSubjects = Some(Seq("r", "e")), arenaEnabled = None, shareName = None)
+      api.UpdatedMyNDLAUser(favoriteSubjects = Some(Seq("r", "e")), arenaEnabled = None, shareName = Some(true))
     val userAfterMerge = domain.MyNDLAUser(
       id = 42,
       feideId = feideId,
@@ -2198,7 +2198,7 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
       email = "example@email.com",
       arenaEnabled = false,
       displayName = "Feide",
-      shareName = false
+      shareName = true
     )
     val expected = api.MyNDLAUser(
       id = 42,
@@ -2206,7 +2206,7 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
       role = "student",
       organization = "oslo",
       arenaEnabled = false,
-      shareName = false
+      shareName = true
     )
 
     when(feideApiClient.getFeideID(any)).thenReturn(Success(feideId))


### PR DESCRIPTION
Legger til mulighet for å dele navn på eiger av mappe. Dette medfører at vi begynner å lagre displayname fra feidebruker på brukerobjektet i basen. Navnet lagres kun dersom brukeren faktisk velger å dele navnet sitt.

NDLANO/Issues#3814