### PR TITLE
Order dumps by id

### DIFF
--- a/article-api/src/main/scala/no/ndla/articleapi/repository/ArticleRepository.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/repository/ArticleRepository.scala
@@ -243,11 +243,13 @@ trait ArticleRepository {
            from (select
                    ${ar.result.*},
                    ${ar.revision} as revision,
+                   ${ar.id} as row_id,
                    ar.document as doc,
                    max(revision) over (partition by article_id) as max_revision
                  from ${Article.as(ar)}) _
            where revision = max_revision
            and doc is not null
+           order by row_id
            offset $offset
            limit $pageSize
       """

--- a/audio-api/src/main/scala/no/ndla/audioapi/repository/AudioRepository.scala
+++ b/audio-api/src/main/scala/no/ndla/audioapi/repository/AudioRepository.scala
@@ -203,6 +203,7 @@ trait AudioRepository {
            select ${au.result.*}
            from ${AudioMetaInformation.as(au)}
            where document is not null
+           order by id
            offset $offset
            limit $pageSize
       """

--- a/concept-api/src/main/scala/no/ndla/conceptapi/repository/DraftConceptRepository.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/repository/DraftConceptRepository.scala
@@ -287,6 +287,7 @@ trait DraftConceptRepository {
            select ${co.result.*}, ${co.revision} as revision
            from ${Concept.as(co)}
            where document is not null
+           order by ${co.id}
            offset $offset
            limit $pageSize
       """

--- a/concept-api/src/main/scala/no/ndla/conceptapi/repository/PublishedConceptRepository.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/repository/PublishedConceptRepository.scala
@@ -139,6 +139,7 @@ trait PublishedConceptRepository {
            select ${co.result.*}
            from ${PublishedConcept.as(co)}
            where document is not null
+           order by ${co.id}
            offset $offset
            limit $pageSize
       """

--- a/draft-api/src/main/scala/no/ndla/draftapi/repository/DraftRepository.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/repository/DraftRepository.scala
@@ -378,11 +378,13 @@ trait DraftRepository {
            select *
            from (select
                    ${ar.result.*},
+                   ${ar.id} as row_id,
                    ${ar.revision} as revision,
                    max(revision) over (partition by article_id) as max_revision
                  from ${DBArticle.as(ar)}
                  where document is not NULL) _
            where revision = max_revision
+           order by row_id
            offset $offset
            limit $pageSize
       """

--- a/image-api/src/main/scala/no/ndla/imageapi/repository/ImageRepository.scala
+++ b/image-api/src/main/scala/no/ndla/imageapi/repository/ImageRepository.scala
@@ -214,6 +214,7 @@ trait ImageRepository {
            select ${im.result.*}
            from ${ImageMetaInformation.as(im)}
            where metadata is not null
+           order by ${im.id}
            offset $offset
            limit $pageSize
       """

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/repository/LearningPathRepositoryComponent.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/repository/LearningPathRepositoryComponent.scala
@@ -374,11 +374,12 @@ trait LearningPathRepositoryComponent extends StrictLogging {
       val (lp, ls) = (DBLearningPath.syntax("lp"), DBLearningStep.syntax("ls"))
       val lps      = SubQuery.syntax("lps").include(lp)
       sql"""
-            select ${lps.resultAll}, ${ls.resultAll} from (select ${lp.resultAll}
+            select ${lps.resultAll}, ${ls.resultAll} from (select ${lp.resultAll}, ${lp.id} as row_id
                                                            from ${DBLearningPath.as(lp)}
                                                            limit $pageSize
                                                            offset $offset) lps
             left join ${DBLearningStep.as(ls)} on ${lps(lp).id} = ${ls.learningPathId}
+            order by row_id
       """
         .one(DBLearningPath.fromResultSet(lps(lp).resultName))
         .toMany(DBLearningStep.opt(ls.resultName))
@@ -394,12 +395,13 @@ trait LearningPathRepositoryComponent extends StrictLogging {
       val (lp, ls) = (DBLearningPath.syntax("lp"), DBLearningStep.syntax("ls"))
       val lps      = SubQuery.syntax("lps").include(lp)
       sql"""
-            select ${lps.resultAll}, ${ls.resultAll} from (select ${lp.resultAll}
+            select ${lps.resultAll}, ${ls.resultAll} from (select ${lp.resultAll}, ${lp.id} as row_id
                                                            from ${DBLearningPath.as(lp)}
                                                            where document#>>'{status}' = ${LearningPathStatus.PUBLISHED.toString}
                                                            limit $pageSize
                                                            offset $offset) lps
             left join ${DBLearningStep.as(ls)} on ${lps(lp).id} = ${ls.learningPathId}
+            order by row_id
       """
         .one(DBLearningPath.fromResultSet(lps(lp).resultName))
         .toMany(DBLearningStep.opt(ls.resultName))


### PR DESCRIPTION
Vet ikke om dette påvirket andre ting enn bilder siden jeg ikke eeegentlig har opplevd problemet før.
Men var en bug som gjorde at et bilde kunne dukke opp på flere sider i en dump så jeg la til sortering på alle dump endepunktene.

Kan testes ved å se at `/intern/dump/<type>` endepunktene fungerer som forventet.