### PR TITLE
Makes swagger-doc consistent  with other tapir apis

### DIFF
--- a/myndla-api/src/main/scala/no/ndla/myndlaapi/controller/ConfigController.scala
+++ b/myndla-api/src/main/scala/no/ndla/myndlaapi/controller/ConfigController.scala
@@ -28,7 +28,9 @@ trait ConfigController {
   val configController: ConfigController
 
   class ConfigController extends Service[Eff] {
-    override protected val prefix: EndpointInput[Unit] = "myndla-api" / "v1" / "config"
+    override val serviceName: String = "config"
+
+    override protected val prefix: EndpointInput[Unit] = "myndla-api" / "v1" / serviceName
 
     import ErrorHelpers._
 

--- a/myndla-api/src/main/scala/no/ndla/myndlaapi/controller/StatsController.scala
+++ b/myndla-api/src/main/scala/no/ndla/myndlaapi/controller/StatsController.scala
@@ -22,7 +22,9 @@ import sttp.tapir.generic.auto._
 trait StatsController {
   this: FolderReadService with TapirErrorHelpers =>
   class StatsController extends Service[Eff] {
-    override protected val prefix: EndpointInput[Unit] = "myndla-api" / "v1" / "stats"
+    override val serviceName: String = "stats"
+
+    override protected val prefix: EndpointInput[Unit] = "myndla-api" / "v1" / serviceName
 
     def getStats: ServerEndpoint[Any, Eff] = endpoint.get
       .summary("Get stats")

--- a/myndla-api/src/main/scala/no/ndla/myndlaapi/controller/UserController.scala
+++ b/myndla-api/src/main/scala/no/ndla/myndlaapi/controller/UserController.scala
@@ -27,7 +27,9 @@ trait UserController {
   val userController: UserController
 
   class UserController extends Service[Eff] {
-    override protected val prefix: EndpointInput[Unit] = "myndla-api" / "v1" / "users"
+    override val serviceName: String = "users"
+
+    override protected val prefix: EndpointInput[Unit] = "myndla-api" / "v1" / serviceName
 
     import ErrorHelpers._
 


### PR DESCRIPTION
I stedet for at finavnet skal brukes.