### PR TITLE
Url in campaignblock should not be required

### DIFF
--- a/validation/src/main/resources/embed-tag-rules.json
+++ b/validation/src/main/resources/embed-tag-rules.json
@@ -980,14 +980,14 @@
         {
           "name": "data-url",
           "validation": {
-            "required": true,
+            "required": false,
             "dataType": "URL"
           }
         },
         {
           "name": "data-url-text",
           "validation": {
-            "required": true
+            "required": false
           }
         },
         {


### PR DESCRIPTION
For å kunne lagre kampanjeblokk uten lenke