### PR TITLE
Drop converting to int to get correct crops

### DIFF
--- a/image-api/src/main/scala/no/ndla/imageapi/controller/RawController.scala
+++ b/image-api/src/main/scala/no/ndla/imageapi/controller/RawController.scala
@@ -163,7 +163,7 @@ trait RawController {
 
       (startX, startY, endX, endY) match {
         case (Some(sx), Some(sy), Some(ex), Some(ey)) =>
-          imageConverter.crop(image, PercentPoint(sx.toInt, sy.toInt), PercentPoint(ex.toInt, ey.toInt))
+          imageConverter.crop(image, PercentPoint(sx, sy), PercentPoint(ex, ey))
         case _ => Success(image)
       }
     }
@@ -181,7 +181,7 @@ trait RawController {
 
       (focalX, focalY, widthOpt, heightOpt) match {
         case (Some(fx), Some(fy), w, h) =>
-          imageConverter.dynamicCrop(image, PercentPoint(fx.toInt, fy.toInt), w.map(_.toInt), h.map(_.toInt), ratio)
+          imageConverter.dynamicCrop(image, PercentPoint(fx, fy), w.map(_.toInt), h.map(_.toInt), ratio)
         case _ => Success(image)
       }
     }

--- a/image-api/src/main/scala/no/ndla/imageapi/service/ImageConverter.scala
+++ b/image-api/src/main/scala/no/ndla/imageapi/service/ImageConverter.scala
@@ -25,7 +25,7 @@ trait ImageConverter {
   this: Props =>
   val imageConverter: ImageConverter
   case class PixelPoint(x: Int, y: Int) // A point given with pixles
-  case class PercentPoint(x: Int, y: Int) { // A point given with values from MinValue to MaxValue. MinValue,MinValue is top-left, MaxValue,MaxValue is bottom-right
+  case class PercentPoint(x: Double, y: Double) { // A point given with values from MinValue to MaxValue. MinValue,MinValue is top-left, MaxValue,MaxValue is bottom-right
     import PercentPoint._
     if (!inRange(x) || !inRange(y))
       throw new ValidationException(
@@ -42,14 +42,14 @@ trait ImageConverter {
     val MinValue: Int = 0
     val MaxValue: Int = 100
 
-    private def inRange(n: Int): Boolean      = n >= MinValue && n <= MaxValue
-    private def normalise(coord: Int): Double = coord.toDouble / MaxValue.toDouble
+    private def inRange(n: Double): Boolean      = n >= MinValue && n <= MaxValue
+    private def normalise(coord: Double): Double = coord / MaxValue.toDouble
   }
 
   /** This method adds a white background to a [[BufferedImage]], useful for removing transparent pixels for image types
     * that doesn't support transparency
     */
-  def fillTransparentPixels(image: BufferedImage): BufferedImage = {
+  private def fillTransparentPixels(image: BufferedImage): BufferedImage = {
     val width    = image.getWidth();
     val height   = image.getHeight();
     val newImage = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);

--- a/image-api/src/test/scala/no/ndla/imageapi/service/ImageConverterTest.scala
+++ b/image-api/src/test/scala/no/ndla/imageapi/service/ImageConverterTest.scala
@@ -9,7 +9,7 @@ package no.ndla.imageapi.service
 
 import no.ndla.imageapi.model.domain.ImageStream
 import no.ndla.imageapi.{TestEnvironment, UnitSuite}
-import org.scalactic.TolerantNumerics
+import org.scalactic.{Equality, TolerantNumerics}
 
 import java.awt.image.BufferedImage
 import javax.imageio.ImageIO
@@ -147,9 +147,9 @@ class ImageConverterTest extends UnitSuite with TestEnvironment {
     "minimalCropSizesToPreserveRatio calculates image sizes with (about) correct aspect ratio for lots of ratios and image sizes"
   ) {
     def testRatio(ratio: Double, width: Int, height: Int) = {
-      implicit val doubleEquality = TolerantNumerics.tolerantDoubleEquality(0.1)
-      val (newWidth, newHeight)   = service.minimalCropSizesToPreserveRatio(width, height, ratio)
-      val calculatedRatio         = newWidth.toDouble / newHeight.toDouble
+      implicit val doubleEquality: Equality[Double] = TolerantNumerics.tolerantDoubleEquality(0.1)
+      val (newWidth, newHeight)                     = service.minimalCropSizesToPreserveRatio(width, height, ratio)
+      val calculatedRatio                           = newWidth.toDouble / newHeight.toDouble
       calculatedRatio should equal(ratio)
     }
     for {
@@ -167,8 +167,8 @@ class ImageConverterTest extends UnitSuite with TestEnvironment {
     testRatio(1.5, 50, 50, 639, 426)
     testRatio(1.2, 50, 50, 511, 426)
 
-    def testRatio(ratio: Double, focalX: Int, focalY: Int, expectedWidth: Int, expectedHeight: Int): Unit = {
-      implicit val doubleEquality = TolerantNumerics.tolerantDoubleEquality(0.01)
+    def testRatio(ratio: Double, focalX: Double, focalY: Double, expectedWidth: Int, expectedHeight: Int): Unit = {
+      implicit val doubleEquality: Equality[Double] = TolerantNumerics.tolerantDoubleEquality(0.01)
       val croppedImage =
         service.dynamicCrop(TestData.ChildrensImage, PercentPoint(focalX, focalY), Some(100), Some(100), Some(ratio))
       val image           = ImageIO.read(croppedImage.get.stream)


### PR DESCRIPTION
Vi sender inn prosenter med opp til 15 desimaler, og disse konverteres til ints. Derfor mister vi nøyaktighet. Dette gjør at crop blir meir korrekt. 

Neste steg blir kanskje å innføre støtte for både prosent og pixler ved cropping.