### PR TITLE
common: Add semi-auto encoders and decoders to `domain.Article`

### DIFF
--- a/common/src/main/scala/no/ndla/common/model/domain/ArticleContent.scala
+++ b/common/src/main/scala/no/ndla/common/model/domain/ArticleContent.scala
@@ -7,9 +7,16 @@
 
 package no.ndla.common.model.domain
 
+import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
+import io.circe.{Decoder, Encoder}
 import no.ndla.language.model.LanguageField
 
 case class ArticleContent(content: String, language: String) extends LanguageField[String] {
   override def value: String    = content
   override def isEmpty: Boolean = content.isEmpty
+}
+
+object ArticleContent {
+  implicit def encoder: Encoder[ArticleContent] = deriveEncoder[ArticleContent]
+  implicit def decoder: Decoder[ArticleContent] = deriveDecoder[ArticleContent]
 }

--- a/common/src/main/scala/no/ndla/common/model/domain/ArticleMetaImage.scala
+++ b/common/src/main/scala/no/ndla/common/model/domain/ArticleMetaImage.scala
@@ -7,10 +7,17 @@
 
 package no.ndla.common.model.domain
 
+import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
+import io.circe.{Decoder, Encoder}
 import no.ndla.language.model.LanguageField
 
 case class ArticleMetaImage(imageId: String, altText: String, language: String)
     extends LanguageField[(String, String)] {
   override def value: (String, String) = imageId -> altText
   override def isEmpty: Boolean        = imageId.isEmpty && altText.isEmpty
+}
+
+object ArticleMetaImage {
+  implicit def encoder: Encoder[ArticleMetaImage] = deriveEncoder[ArticleMetaImage]
+  implicit def decoder: Decoder[ArticleMetaImage] = deriveDecoder[ArticleMetaImage]
 }

--- a/common/src/main/scala/no/ndla/common/model/domain/Author.scala
+++ b/common/src/main/scala/no/ndla/common/model/domain/Author.scala
@@ -7,6 +7,8 @@
 
 package no.ndla.common.model.domain
 
+import io.circe.{Decoder, Encoder}
+import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
 import no.ndla.common.model.api
 
 case class Author(`type`: String, name: String) {
@@ -14,4 +16,9 @@ case class Author(`type`: String, name: String) {
     `type` = this.`type`,
     name = this.name
   )
+}
+
+object Author {
+  implicit def encoder: Encoder[Author] = deriveEncoder[Author]
+  implicit def decoder: Decoder[Author] = deriveDecoder[Author]
 }

--- a/common/src/main/scala/no/ndla/common/model/domain/Description.scala
+++ b/common/src/main/scala/no/ndla/common/model/domain/Description.scala
@@ -7,9 +7,16 @@
 
 package no.ndla.common.model.domain
 
+import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
+import io.circe.{Decoder, Encoder}
 import no.ndla.language.model.LanguageField
 
 case class Description(content: String, language: String) extends LanguageField[String] {
   override def value: String    = content
   override def isEmpty: Boolean = content.isEmpty
+}
+
+object Description {
+  implicit def encoder: Encoder[Description] = deriveEncoder[Description]
+  implicit def decoder: Decoder[Description] = deriveDecoder[Description]
 }

--- a/common/src/main/scala/no/ndla/common/model/domain/Introduction.scala
+++ b/common/src/main/scala/no/ndla/common/model/domain/Introduction.scala
@@ -7,9 +7,16 @@
 
 package no.ndla.common.model.domain
 
+import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
+import io.circe.{Decoder, Encoder}
 import no.ndla.language.model.LanguageField
 
 case class Introduction(introduction: String, language: String) extends LanguageField[String] {
   override def value: String    = introduction
   override def isEmpty: Boolean = introduction.isEmpty
+}
+
+object Introduction {
+  implicit def encoder: Encoder[Introduction] = deriveEncoder[Introduction]
+  implicit def decoder: Decoder[Introduction] = deriveDecoder[Introduction]
 }

--- a/common/src/main/scala/no/ndla/common/model/domain/RequiredLibrary.scala
+++ b/common/src/main/scala/no/ndla/common/model/domain/RequiredLibrary.scala
@@ -7,4 +7,12 @@
 
 package no.ndla.common.model.domain
 
+import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
+import io.circe.{Decoder, Encoder}
+
 case class RequiredLibrary(mediaType: String, name: String, url: String)
+
+object RequiredLibrary {
+  implicit def encoder: Encoder[RequiredLibrary] = deriveEncoder[RequiredLibrary]
+  implicit def decoder: Decoder[RequiredLibrary] = deriveDecoder[RequiredLibrary]
+}

--- a/common/src/main/scala/no/ndla/common/model/domain/Tag.scala
+++ b/common/src/main/scala/no/ndla/common/model/domain/Tag.scala
@@ -7,9 +7,16 @@
 
 package no.ndla.common.model.domain
 
+import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
+import io.circe.{Decoder, Encoder}
 import no.ndla.language.model.LanguageField
 
 case class Tag(tags: Seq[String], language: String) extends LanguageField[Seq[String]] {
   override def value: Seq[String] = tags
   override def isEmpty: Boolean   = tags.isEmpty
+}
+
+object Tag {
+  implicit def encoder: Encoder[Tag] = deriveEncoder[Tag]
+  implicit def decoder: Decoder[Tag] = deriveDecoder[Tag]
 }

--- a/common/src/main/scala/no/ndla/common/model/domain/Title.scala
+++ b/common/src/main/scala/no/ndla/common/model/domain/Title.scala
@@ -7,9 +7,16 @@
 
 package no.ndla.common.model.domain
 
+import io.circe.{Decoder, Encoder}
+import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
 import no.ndla.language.model.LanguageField
 
 case class Title(title: String, language: String) extends LanguageField[String] {
   override def value: String    = title
   override def isEmpty: Boolean = title.isEmpty
+}
+
+object Title {
+  implicit def encoder: Encoder[Title] = deriveEncoder[Title]
+  implicit def decoder: Decoder[Title] = deriveDecoder[Title]
 }

--- a/common/src/main/scala/no/ndla/common/model/domain/VisualElement.scala
+++ b/common/src/main/scala/no/ndla/common/model/domain/VisualElement.scala
@@ -7,9 +7,16 @@
 
 package no.ndla.common.model.domain
 
+import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
+import io.circe.{Decoder, Encoder}
 import no.ndla.language.model.LanguageField
 
 case class VisualElement(resource: String, language: String) extends LanguageField[String] {
   override def value: String    = resource
   override def isEmpty: Boolean = resource.isEmpty
+}
+
+object VisualElement {
+  implicit def encoder: Encoder[VisualElement] = deriveEncoder[VisualElement]
+  implicit def decoder: Decoder[VisualElement] = deriveDecoder[VisualElement]
 }

--- a/common/src/main/scala/no/ndla/common/model/domain/article/Article.scala
+++ b/common/src/main/scala/no/ndla/common/model/domain/article/Article.scala
@@ -8,8 +8,11 @@
 
 package no.ndla.common.model.domain.article
 
-import no.ndla.common.model.NDLADate
+import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
+import io.circe.{Decoder, Encoder}
+import no.ndla.common.model.{NDLADate, RelatedContentLink}
 import no.ndla.common.model.domain._
+import no.ndla.common.implicits._
 
 case class Article(
     id: Option[Long],
@@ -35,3 +38,11 @@ case class Article(
     revisionDate: Option[NDLADate],
     slug: Option[String]
 ) extends Content
+
+object Article {
+  implicit def eitherEnc: Encoder[Either[RelatedContentLink, Long]] = eitherEncoder[RelatedContentLink, Long]
+  implicit def eitherDec: Decoder[Either[RelatedContentLink, Long]] = eitherDecoder[RelatedContentLink, Long]
+
+  implicit def encoder: Encoder[Article] = deriveEncoder[Article]
+  implicit def decoder: Decoder[Article] = deriveDecoder[Article]
+}

--- a/common/src/main/scala/no/ndla/common/model/domain/article/Copyright.scala
+++ b/common/src/main/scala/no/ndla/common/model/domain/article/Copyright.scala
@@ -8,6 +8,7 @@
 
 package no.ndla.common.model.domain.article
 
+import io.circe.{Decoder, Encoder}
 import no.ndla.common.model.NDLADate
 import no.ndla.common.model.domain.Author
 
@@ -21,3 +22,8 @@ case class Copyright(
     validTo: Option[NDLADate],
     processed: Boolean
 )
+
+object Copyright {
+  implicit def encoder: Encoder[Copyright] = io.circe.generic.semiauto.deriveEncoder[Copyright]
+  implicit def decoder: Decoder[Copyright] = io.circe.generic.semiauto.deriveDecoder[Copyright]
+}

--- a/common/src/main/scala/no/ndla/common/model/domain/package.scala
+++ b/common/src/main/scala/no/ndla/common/model/domain/package.scala
@@ -7,7 +7,15 @@
 
 package no.ndla.common.model
 
+import io.circe.{Decoder, Encoder}
+import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
+
 case class RelatedContentLink(title: String, url: String)
+
+object RelatedContentLink {
+  implicit val encoder: Encoder[RelatedContentLink] = deriveEncoder[RelatedContentLink]
+  implicit val decoder: Decoder[RelatedContentLink] = deriveDecoder[RelatedContentLink]
+}
 
 package object domain {
   type RelatedContent = Either[RelatedContentLink, Long]

--- a/validation/src/main/scala/no/ndla/validation/EmbedTagRules.scala
+++ b/validation/src/main/scala/no/ndla/validation/EmbedTagRules.scala
@@ -23,7 +23,9 @@ object EmbedTagRules {
     attributeRules(resourceType)
 
   private def embedRulesToJson: Map[ResourceType, TagRules.TagAttributeRules] = {
-    val attrs = TagRules.convertJsonStrToAttributeRules(Source.fromResource("embed-tag-rules.json").mkString)
+    val classLoader = getClass.getClassLoader
+    val attrs =
+      TagRules.convertJsonStrToAttributeRules(Source.fromResource("embed-tag-rules.json", classLoader).mkString)
 
     def strToResourceType(str: String): ResourceType =
       ResourceType

--- a/validation/src/main/scala/no/ndla/validation/HtmlTagRules.scala
+++ b/validation/src/main/scala/no/ndla/validation/HtmlTagRules.scala
@@ -20,8 +20,9 @@ object HtmlTagRules {
   private[validation] lazy val attributeRules: Map[String, TagRules.TagAttributeRules] = tagRulesToJson
 
   private def tagRulesToJson: Map[String, TagRules.TagAttributeRules] = {
+    val classLoader = getClass.getClassLoader
     val attrs = TagRules
-      .convertJsonStrToAttributeRules(Source.fromResource("html-rules.json").mkString)
+      .convertJsonStrToAttributeRules(Source.fromResource("html-rules.json", classLoader).mkString)
 
     attrs.map { case (tagType, attrRules) =>
       tagType -> attrRules

--- a/validation/src/main/scala/no/ndla/validation/ValidationRules.scala
+++ b/validation/src/main/scala/no/ndla/validation/ValidationRules.scala
@@ -8,14 +8,19 @@ import scala.io.Source
 
 object ValidationRules {
 
-  def embedTagRulesJson: Map[String, Any] = convertJsonStr(Source.fromResource("embed-tag-rules.json").mkString)
+  def embedTagRulesJson: Map[String, Any] = {
+    val classLoader = getClass.getClassLoader
+    convertJsonStr(Source.fromResource("embed-tag-rules.json", classLoader).mkString)
+  }
   def htmlRulesJson: HtmlRulesFile = {
     implicit val formats: Formats = org.json4s.DefaultFormats + Json4s.serializer(TagAttribute)
-    parse(Source.fromResource("html-rules.json").mkString).extract[HtmlRulesFile]
+    val classLoader               = getClass.getClassLoader
+    parse(Source.fromResource("html-rules.json", classLoader).mkString).extract[HtmlRulesFile]
   }
   def mathMLRulesJson: MathMLRulesFile = {
     implicit val formats: Formats = org.json4s.DefaultFormats + Json4s.serializer(TagAttribute)
-    parse(Source.fromResource("mathml-rules.json").mkString).extract[MathMLRulesFile]
+    val classLoader               = getClass.getClassLoader
+    parse(Source.fromResource("mathml-rules.json", classLoader).mkString).extract[MathMLRulesFile]
   }
 
   private def convertJsonStr(jsonStr: String): Map[String, Any] = {


### PR DESCRIPTION
Encoder/Decoder's for `Either` typen er litt rare med `circe` så vi må bruke semi-auto (Mennesker på internett mener dette er bedre uansett, men jeg syns det er litt mye boilerplate).

Dette fikser feilen med a publisering ikke fungerer dersom artikkelen har `RelatedContent`.
Kan testes ved å prøve å publisere 34626 fra test :smile: 