### PR TITLE
Sorting by worklist parameters

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -137,7 +137,7 @@ lazy val language       = Module.setup(project in file("./language/"), languagel
 lazy val mapping        = Module.setup(project in file("./mapping/"), mappinglib)
 lazy val validation     = Module.setup(project in file("./validation/"), validationlib, deps = Seq(common))
 lazy val search =
-  Module.setup(project in file("./search/"), searchlib, deps = Seq(testWith(scalatestsuite), language, common))
+  Module.setup(project in file("./search/"), searchlib, deps = Seq(testWith(scalatestsuite), language, common, mapping))
 lazy val myndla =
   Module.setup(project in file("./myndla/"), myndlalib, deps = Seq(common, network, testWith(scalatestsuite)))
 

--- a/concept-api/src/main/scala/no/ndla/conceptapi/ComponentRegistry.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/ComponentRegistry.scala
@@ -10,7 +10,7 @@ package no.ndla.conceptapi
 import com.typesafe.scalalogging.StrictLogging
 import com.zaxxer.hikari.HikariDataSource
 import no.ndla.conceptapi.controller._
-import no.ndla.conceptapi.integration.{ArticleApiClient, DataSource}
+import no.ndla.conceptapi.integration.{ArticleApiClient, DataSource, TaxonomyApiClient}
 import no.ndla.conceptapi.model.api.ErrorHelpers
 import no.ndla.conceptapi.model.domain.DBConcept
 import no.ndla.conceptapi.model.search.{DraftSearchSettingsHelper, SearchSettingsHelper}
@@ -61,7 +61,8 @@ class ComponentRegistry(properties: ConceptApiProperties)
     with NdlaSwaggerSupport
     with DBConcept
     with SearchSettingsHelper
-    with DraftSearchSettingsHelper {
+    with DraftSearchSettingsHelper
+    with TaxonomyApiClient {
   override val props: ConceptApiProperties = properties
   override val migrator                    = new DBMigrator
 
@@ -81,6 +82,8 @@ class ComponentRegistry(properties: ConceptApiProperties)
   lazy val draftConceptIndexService      = new DraftConceptIndexService
   lazy val publishedConceptIndexService  = new PublishedConceptIndexService
   lazy val publishedConceptSearchService = new PublishedConceptSearchService
+
+  lazy val taxonomyApiClient: TaxonomyApiClient = new TaxonomyApiClient
 
   var e4sClient: NdlaE4sClient = Elastic4sClientFactory.getClient(props.SearchServer)
 

--- a/concept-api/src/main/scala/no/ndla/conceptapi/controller/InternController.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/controller/InternController.scala
@@ -67,7 +67,7 @@ trait InternController {
       }
     }: Unit
 
-    def deleteIndexes[T <: IndexService[_]](indexService: T) = {
+    def deleteIndexes[T <: IndexService](indexService: T) = {
       def pluralIndex(n: Int) = if (n == 1) "1 index" else s"$n indexes"
       indexService.findAllIndexes match {
         case Failure(ex) =>

--- a/concept-api/src/main/scala/no/ndla/conceptapi/integration/TaxonomyApiClient.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/integration/TaxonomyApiClient.scala
@@ -1,0 +1,51 @@
+/*
+ * Part of NDLA concept-api
+ * Copyright (C) 2024 NDLA
+ *
+ * See LICENSE
+ */
+
+package no.ndla.conceptapi.integration
+
+import no.ndla.conceptapi.Props
+import no.ndla.conceptapi.integration.model.{TaxonomyData, TaxonomySubject}
+import no.ndla.network.NdlaClient
+import no.ndla.network.TaxonomyData.{TAXONOMY_VERSION_HEADER, defaultVersion}
+import no.ndla.search.model.SearchableLanguageFormats
+import org.json4s.Formats
+import sttp.client3.quick._
+
+import scala.concurrent.duration.DurationInt
+import scala.util.Try
+
+trait TaxonomyApiClient {
+  this: NdlaClient with Props =>
+  val taxonomyApiClient: TaxonomyApiClient
+
+  class TaxonomyApiClient {
+    import props.TaxonomyUrl
+    implicit val formats: Formats   = SearchableLanguageFormats.JSonFormatsWithMillis
+    private val TaxonomyApiEndpoint = s"$TaxonomyUrl/v1"
+    private val timeoutSeconds      = 600.seconds
+
+    def getSubjects: Try[TaxonomyData] = {
+      get[List[TaxonomySubject]](
+        s"$TaxonomyApiEndpoint/nodes/",
+        headers = Map(TAXONOMY_VERSION_HEADER -> defaultVersion),
+        Seq("nodeType" -> "SUBJECT")
+      ).map(TaxonomyData.from)
+    }
+
+    private def get[A](url: String, headers: Map[String, String], params: Seq[(String, String)])(implicit
+        mf: Manifest[A],
+        formats: Formats
+    ): Try[A] = {
+      ndlaClient.fetchWithForwardedAuth[A](
+        quickRequest.get(uri"$url?$params").headers(headers).readTimeout(timeoutSeconds),
+        None
+      )
+    }
+
+  }
+
+}

--- a/concept-api/src/main/scala/no/ndla/conceptapi/integration/model/TaxonomySubject.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/integration/model/TaxonomySubject.scala
@@ -1,0 +1,35 @@
+/*
+ * Part of NDLA concept-api
+ * Copyright (C) 2024 NDLA
+ *
+ * See LICENSE
+ */
+
+package no.ndla.conceptapi.integration.model
+
+import no.ndla.search.model.LanguageValue
+
+case class TaxonomyTranslation(
+    name: String,
+    language: String
+) {
+  def toLanguageValue: LanguageValue[String] = LanguageValue(language, name)
+}
+
+case class TaxonomySubject(
+    id: String,
+    name: String,
+    translations: List[TaxonomyTranslation]
+)
+
+case class TaxonomyData(
+    subjectsById: Map[String, TaxonomySubject]
+)
+
+object TaxonomyData {
+  def from(subjects: List[TaxonomySubject]): TaxonomyData = {
+    TaxonomyData(subjects.map(s => s.id -> s).toMap)
+  }
+
+  def empty: TaxonomyData = TaxonomyData(Map.empty)
+}

--- a/concept-api/src/main/scala/no/ndla/conceptapi/model/api/ConceptSummary.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/model/api/ConceptSummary.scala
@@ -34,6 +34,8 @@ case class ConceptSummary(
     @(ApiModelProperty @field)(description = "URL for the source of the concept") source: Option[String],
     @(ApiModelProperty @field)(description = "Object with data representing the editor responsible for this concept") responsible: Option[ConceptResponsible],
     @(ApiModelProperty @field)(description = "Type of concept. 'concept', or 'gloss'") conceptType: String,
-    @(ApiModelProperty @field)(description = "Information about the gloss") glossData: Option[GlossData]
+    @(ApiModelProperty @field)(description = "Information about the gloss") glossData: Option[GlossData],
+    @(ApiModelProperty @field)(description = "A name of the concepts subject(s)") subjectName: Option[String],
+    @(ApiModelProperty @field)(description = "A translated name of the concept type") conceptTypeName: String
 )
 // format: on

--- a/concept-api/src/main/scala/no/ndla/conceptapi/model/domain/Sort.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/model/domain/Sort.scala
@@ -29,6 +29,10 @@ object Sort extends Enum[Sort] {
   case object ByResponsibleLastUpdatedAsc  extends Sort("responsibleLastUpdated")
   case object ByStatusAsc                  extends Sort("status")
   case object ByStatusDesc                 extends Sort("-status")
+  case object BySubjectAsc                 extends Sort("subject")
+  case object BySubjectDesc                extends Sort("-subject")
+  case object ByConceptTypeAsc             extends Sort("conceptType")
+  case object ByConceptTypeDesc            extends Sort("-conceptType")
 
   def valueOf(s: String): Option[Sort] = Sort.values.find(_.entryName == s)
 

--- a/concept-api/src/main/scala/no/ndla/conceptapi/model/search/SearchableConcept.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/model/search/SearchableConcept.scala
@@ -35,5 +35,9 @@ case class SearchableConcept(
     source: Option[String],
     responsible: Option[Responsible],
     gloss: Option[String],
-    domainObject: domain.Concept
+    domainObject: domain.Concept,
+    sortableSubject: SearchableLanguageValues,
+    sortableConceptType: SearchableLanguageValues,
+    defaultSortableSubject: Option[String],
+    defaultSortableConceptType: Option[String]
 )

--- a/concept-api/src/main/scala/no/ndla/conceptapi/service/search/DraftConceptIndexService.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/service/search/DraftConceptIndexService.scala
@@ -7,100 +7,19 @@
 
 package no.ndla.conceptapi.service.search
 
-import com.sksamuel.elastic4s.ElasticDsl.{nestedField, _}
-import com.sksamuel.elastic4s.fields.{ElasticField, ObjectField}
-import com.sksamuel.elastic4s.requests.indexes.IndexRequest
-import com.sksamuel.elastic4s.requests.mappings.MappingDefinition
-import com.sksamuel.elastic4s.requests.mappings.dynamictemplate.DynamicTemplateRequest
 import com.typesafe.scalalogging.StrictLogging
 import no.ndla.conceptapi.Props
-import no.ndla.conceptapi.model.api.ConceptMissingIdException
 import no.ndla.conceptapi.model.domain.{Concept, DBConcept}
 import no.ndla.conceptapi.repository.{DraftConceptRepository, Repository}
-import no.ndla.search.model.SearchableLanguageFormats
-import org.json4s.Formats
-import org.json4s.native.Serialization.write
-
-import scala.util.{Failure, Success, Try}
 
 trait DraftConceptIndexService {
   this: IndexService with DraftConceptRepository with SearchConverterService with Props with DBConcept =>
   val draftConceptIndexService: DraftConceptIndexService
 
-  class DraftConceptIndexService extends StrictLogging with IndexService[Concept] {
-    implicit val formats: Formats                = SearchableLanguageFormats.JSonFormats ++ Concept.serializers
+  class DraftConceptIndexService extends StrictLogging with IndexService {
     override val documentType: String            = props.ConceptSearchDocument
     override val searchIndex: String             = props.DraftConceptSearchIndex
     override val repository: Repository[Concept] = draftConceptRepository
-
-    override def createIndexRequest(concept: Concept, indexName: String): Try[IndexRequest] = {
-      concept.id match {
-        case Some(id) =>
-          val source = write(searchConverterService.asSearchableConcept(concept))
-          Success(
-            indexInto(indexName).doc(source).id(id.toString)
-          )
-
-        case _ => Failure(ConceptMissingIdException("Attempted to create index request for concept without an id."))
-      }
-    }
-
-    def getMapping: MappingDefinition = {
-      val fields: Seq[ElasticField] = List(
-        intField("id"),
-        keywordField("conceptType"),
-        keywordField("defaultTitle").normalizer("lower"),
-        keywordField("subjectIds"),
-        nestedField("metaImage").fields(
-          keywordField("imageId"),
-          keywordField("altText"),
-          keywordField("language")
-        ),
-        dateField("lastUpdated"),
-        dateField("created"),
-        longField("articleIds"),
-        keywordField("status.current"),
-        keywordField("status.other"),
-        keywordField("updatedBy"),
-        keywordField("license"),
-        keywordField("source"),
-        keywordField("origin"),
-        nestedField("copyright").fields(
-          nestedField("creators").fields(
-            keywordField("type"),
-            keywordField("name")
-          ),
-          nestedField("processors").fields(
-            keywordField("type"),
-            keywordField("name")
-          ),
-          nestedField("rightsholders").fields(
-            keywordField("type"),
-            keywordField("name")
-          )
-        ),
-        nestedField("embedResourcesAndIds").fields(
-          keywordField("resource"),
-          keywordField("id"),
-          keywordField("language")
-        ),
-        ObjectField(
-          "responsible",
-          properties = Seq(
-            keywordField("responsibleId"),
-            dateField("lastUpdated")
-          )
-        ),
-        textField("gloss"),
-        ObjectField("domainObject", enabled = Some(false))
-      )
-      val dynamics: Seq[DynamicTemplateRequest] = generateLanguageSupportedDynamicTemplates("title", keepRaw = true) ++
-        generateLanguageSupportedDynamicTemplates("content") ++
-        generateLanguageSupportedDynamicTemplates("tags", keepRaw = true)
-
-      properties(fields).dynamicTemplates(dynamics)
-    }
-
   }
 
 }

--- a/concept-api/src/main/scala/no/ndla/conceptapi/service/search/IndexService.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/service/search/IndexService.scala
@@ -51,7 +51,7 @@ trait IndexService {
         normalizers = List(lowerNormalizer)
       )
 
-    def createIndexRequest(
+    private def createIndexRequest(
         concept: Concept,
         indexName: String,
         taxonomyData: TaxonomyData

--- a/concept-api/src/main/scala/no/ndla/conceptapi/service/search/PublishedConceptIndexService.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/service/search/PublishedConceptIndexService.scala
@@ -7,88 +7,19 @@
 
 package no.ndla.conceptapi.service.search
 
-import com.sksamuel.elastic4s.ElasticDsl._
-import com.sksamuel.elastic4s.fields.ObjectField
-import com.sksamuel.elastic4s.requests.indexes.IndexRequest
-import com.sksamuel.elastic4s.requests.mappings.MappingDefinition
 import com.typesafe.scalalogging.StrictLogging
 import no.ndla.conceptapi.Props
-import no.ndla.conceptapi.model.api.ConceptMissingIdException
 import no.ndla.conceptapi.model.domain.{Concept, DBConcept}
 import no.ndla.conceptapi.repository.{PublishedConceptRepository, Repository}
-import no.ndla.search.model.SearchableLanguageFormats
-import org.json4s.Formats
-import org.json4s.native.Serialization.write
-
-import scala.util.{Failure, Success, Try}
 
 trait PublishedConceptIndexService {
   this: IndexService with PublishedConceptRepository with SearchConverterService with Props with DBConcept =>
   val publishedConceptIndexService: PublishedConceptIndexService
 
-  class PublishedConceptIndexService extends StrictLogging with IndexService[Concept] {
-    implicit val formats: Formats                = SearchableLanguageFormats.JSonFormats ++ Concept.serializers
+  class PublishedConceptIndexService extends StrictLogging with IndexService {
     override val documentType: String            = props.ConceptSearchDocument
     override val searchIndex: String             = props.PublishedConceptSearchIndex
     override val repository: Repository[Concept] = publishedConceptRepository
-
-    override def createIndexRequest(concept: Concept, indexName: String): Try[IndexRequest] = {
-      concept.id match {
-        case Some(id) =>
-          val source = write(searchConverterService.asSearchableConcept(concept))
-          Success(
-            indexInto(indexName).doc(source).id(id.toString)
-          )
-
-        case _ => Failure(ConceptMissingIdException("Attempted to create index request for concept without an id."))
-      }
-    }
-
-    def getMapping: MappingDefinition = {
-      val fields = List(
-        intField("id"),
-        keywordField("conceptType"),
-        keywordField("defaultTitle").normalizer("lower"),
-        keywordField("subjectIds"),
-        nestedField("metaImage").fields(
-          keywordField("imageId"),
-          keywordField("altText"),
-          keywordField("language")
-        ),
-        dateField("lastUpdated"),
-        dateField("created"),
-        longField("articleIds"),
-        keywordField("license"),
-        keywordField("source"),
-        keywordField("origin"),
-        nestedField("copyright").fields(
-          nestedField("creators").fields(
-            keywordField("type"),
-            keywordField("name")
-          ),
-          nestedField("processors").fields(
-            keywordField("type"),
-            keywordField("name")
-          ),
-          nestedField("rightsholders").fields(
-            keywordField("type"),
-            keywordField("name")
-          )
-        ),
-        nestedField("embedResourcesAndIds").fields(
-          keywordField("resource"),
-          keywordField("id"),
-          keywordField("language")
-        ),
-        textField("gloss"),
-        ObjectField("domainObject", enabled = Some(false))
-      )
-      val dynamics = generateLanguageSupportedDynamicTemplates("title", keepRaw = true) ++
-        generateLanguageSupportedDynamicTemplates("content") ++
-        generateLanguageSupportedDynamicTemplates("tags", keepRaw = true)
-      properties(fields).dynamicTemplates(dynamics)
-    }
-
   }
 
 }

--- a/concept-api/src/main/scala/no/ndla/conceptapi/service/search/SearchConverterService.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/service/search/SearchConverterService.scala
@@ -12,15 +12,15 @@ import com.typesafe.scalalogging.StrictLogging
 import no.ndla.common.model.domain.draft.DraftCopyright
 import no.ndla.common.model.domain.{Tag, Title}
 import no.ndla.common.model.{api => commonApi}
+import no.ndla.conceptapi.integration.model.TaxonomyData
 import no.ndla.conceptapi.model.api.{ConceptResponsible, ConceptSearchResult, SubjectTags}
-import no.ndla.conceptapi.model.domain.{Concept, DBConcept, SearchResult}
+import no.ndla.conceptapi.model.domain.{Concept, ConceptType, DBConcept, SearchResult}
 import no.ndla.conceptapi.model.search._
 import no.ndla.conceptapi.model.{api, domain}
 import no.ndla.conceptapi.service.ConverterService
 import no.ndla.language.Language.{UnknownLanguage, findByLanguageOrBestEffort, getSupportedLanguages}
 import no.ndla.mapping.ISO639
 import no.ndla.search.SearchConverter.getEmbedValues
-import no.ndla.search.SearchLanguage
 import no.ndla.search.model.domain.EmbedValues
 import no.ndla.search.model.{LanguageValue, SearchableLanguageFormats, SearchableLanguageList, SearchableLanguageValues}
 import org.json4s._
@@ -53,24 +53,51 @@ trait SearchConverterService {
       })
     }
 
-    def asSearchableConcept(c: Concept): SearchableConcept = {
-      val defaultTitle = c.title
-        .sortBy(title => {
-          val languagePriority = SearchLanguage.languageAnalyzers.map(la => la.languageTag.toString()).reverse
-          languagePriority.indexOf(title.language)
-        })
-        .lastOption
+    def asSearchableConcept(c: Concept, taxonomyData: TaxonomyData): SearchableConcept = {
+      val title   = SearchableLanguageValues(c.title.map(title => LanguageValue(title.language, title.title)))
+      val content = SearchableLanguageValues(c.content.map(content => LanguageValue(content.language, content.content)))
+      val tags    = SearchableLanguageList(c.tags.map(tag => LanguageValue(tag.language, tag.tags)))
+      val visualElement = SearchableLanguageValues(
+        c.visualElement.map(element => LanguageValue(element.language, element.visualElement))
+      )
+
       val embedResourcesAndIds = getEmbedResourcesAndIdsToIndex(c.visualElement, c.metaImage)
       val copyright            = asSearchableCopyright(c.copyright);
+
+      val allConnectedSubjects = c.subjectIds.flatMap(subjectId => {
+        taxonomyData.subjectsById
+          .get(subjectId)
+          .map(x => {
+            val translations = x.translations.map(_.toLanguageValue)
+            SearchableLanguageValues(translations)
+          })
+      })
+
+      val sortableSubject = SearchableLanguageValues.combine(allConnectedSubjects.toSeq)
+
+      val sortableConceptType = c.conceptType match {
+        case ConceptType.CONCEPT =>
+          SearchableLanguageValues.from(
+            "nb" -> "Forklaring",
+            "nn" -> "Forklaring",
+            "en" -> "Concept"
+          )
+        case _ =>
+          SearchableLanguageValues.from(
+            "nb" -> "Glose",
+            "nn" -> "Glose",
+            "en" -> "Gloss"
+          )
+      }
 
       SearchableConcept(
         id = c.id.get,
         conceptType = c.conceptType.toString,
-        title = SearchableLanguageValues(c.title.map(title => LanguageValue(title.language, title.title))),
-        content = SearchableLanguageValues(c.content.map(content => LanguageValue(content.language, content.content))),
-        defaultTitle = defaultTitle.map(_.title),
+        title = title,
+        content = content,
+        defaultTitle = title.defaultValue,
         metaImage = c.metaImage,
-        tags = SearchableLanguageList(c.tags.map(tag => LanguageValue(tag.language, tag.tags))),
+        tags = tags,
         subjectIds = c.subjectIds.toSeq,
         lastUpdated = c.updated,
         status = Status(c.status.current.toString, c.status.other.map(_.toString).toSeq),
@@ -78,15 +105,17 @@ trait SearchConverterService {
         license = c.copyright.flatMap(_.license),
         copyright = copyright,
         embedResourcesAndIds = embedResourcesAndIds,
-        visualElement = SearchableLanguageValues(
-          c.visualElement.map(element => LanguageValue(element.language, element.visualElement))
-        ),
+        visualElement = visualElement,
         articleIds = c.articleIds,
         created = c.created,
         source = c.copyright.flatMap(_.origin),
         responsible = c.responsible,
         gloss = c.glossData.map(_.gloss),
-        domainObject = c
+        domainObject = c,
+        sortableSubject = sortableSubject,
+        sortableConceptType = sortableConceptType,
+        defaultSortableSubject = sortableSubject.defaultValue,
+        defaultSortableConceptType = sortableConceptType.defaultValue
       )
     }
 
@@ -130,6 +159,10 @@ trait SearchConverterService {
 
       val responsible = searchableConcept.responsible.map(r => ConceptResponsible(r.responsibleId, r.lastUpdated))
       val glossData   = converterService.toApiGlossData(searchableConcept.domainObject.glossData)
+      val subjectName = searchableConcept.sortableSubject.getLanguageOrDefault(language)
+      val conceptTypeName = searchableConcept.sortableConceptType
+        .getLanguageOrDefault(language)
+        .getOrElse(searchableConcept.conceptType)
 
       api.ConceptSummary(
         id = searchableConcept.id,
@@ -150,7 +183,9 @@ trait SearchConverterService {
         source = searchableConcept.source,
         responsible = responsible,
         conceptType = searchableConcept.conceptType,
-        glossData = glossData
+        glossData = glossData,
+        subjectName = subjectName,
+        conceptTypeName = conceptTypeName
       )
     }
 

--- a/concept-api/src/main/scala/no/ndla/conceptapi/service/search/SearchConverterService.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/service/search/SearchConverterService.scala
@@ -67,8 +67,8 @@ trait SearchConverterService {
       val allConnectedSubjects = c.subjectIds.flatMap(subjectId => {
         taxonomyData.subjectsById
           .get(subjectId)
-          .map(x => {
-            val translations = x.translations.map(_.toLanguageValue)
+          .map(subject => {
+            val translations = subject.translations.map(_.toLanguageValue)
             SearchableLanguageValues(translations)
           })
       })

--- a/concept-api/src/test/scala/no/ndla/conceptapi/TestEnvironment.scala
+++ b/concept-api/src/test/scala/no/ndla/conceptapi/TestEnvironment.scala
@@ -11,7 +11,7 @@ import com.typesafe.scalalogging.StrictLogging
 import com.zaxxer.hikari.HikariDataSource
 import no.ndla.common.Clock
 import no.ndla.conceptapi.controller.{DraftConceptController, NdlaController, PublishedConceptController}
-import no.ndla.conceptapi.integration.{ArticleApiClient, DataSource}
+import no.ndla.conceptapi.integration.{ArticleApiClient, DataSource, TaxonomyApiClient}
 import no.ndla.conceptapi.model.api.ErrorHelpers
 import no.ndla.conceptapi.model.domain.DBConcept
 import no.ndla.conceptapi.model.search.{DraftSearchSettingsHelper, SearchSettingsHelper}
@@ -39,6 +39,7 @@ trait TestEnvironment
     with DraftConceptIndexService
     with DraftConceptSearchService
     with IndexService
+    with TaxonomyApiClient
     with BaseIndexService
     with Elastic4sClient
     with SearchService
@@ -74,6 +75,8 @@ trait TestEnvironment
   val draftConceptSearchService     = mock[DraftConceptSearchService]
   val publishedConceptIndexService  = mock[PublishedConceptIndexService]
   val publishedConceptSearchService = mock[PublishedConceptSearchService]
+
+  val taxonomyApiClient = mock[TaxonomyApiClient]
 
   var e4sClient        = mock[NdlaE4sClient]
   val mockitoSugar     = mock[MockitoSugar]

--- a/concept-api/src/test/scala/no/ndla/conceptapi/service/search/DraftConceptSearchServiceTest.scala
+++ b/concept-api/src/test/scala/no/ndla/conceptapi/service/search/DraftConceptSearchServiceTest.scala
@@ -20,6 +20,7 @@ import org.scalatest.Outcome
 
 import scala.util.Success
 import no.ndla.common.model.NDLADate
+import no.ndla.conceptapi.integration.model.TaxonomyData
 
 import java.util.UUID
 
@@ -232,6 +233,7 @@ class DraftConceptSearchServiceTest extends IntegrationSuite(EnableElasticsearch
 
   override def beforeAll(): Unit = {
     super.beforeAll()
+    when(taxonomyApiClient.getSubjects).thenReturn(Success(TaxonomyData.empty))
     if (elasticSearchContainer.isSuccess) {
       draftConceptIndexService.createIndexAndAlias().get
 

--- a/concept-api/src/test/scala/no/ndla/conceptapi/service/search/PublishedConceptSearchServiceTest.scala
+++ b/concept-api/src/test/scala/no/ndla/conceptapi/service/search/PublishedConceptSearchServiceTest.scala
@@ -21,6 +21,7 @@ import org.scalatest.Outcome
 import java.time.LocalDateTime
 import scala.util.Success
 import no.ndla.common.model.NDLADate
+import no.ndla.conceptapi.integration.model.TaxonomyData
 
 class PublishedConceptSearchServiceTest
     extends IntegrationSuite(EnableElasticsearchContainer = true)
@@ -207,6 +208,7 @@ class PublishedConceptSearchServiceTest
   )
 
   override def beforeAll(): Unit = if (elasticSearchContainer.isSuccess) {
+    when(taxonomyApiClient.getSubjects).thenReturn(Success(TaxonomyData.empty))
     publishedConceptIndexService.createIndexWithName(props.DraftConceptSearchIndex)
 
     publishedConceptIndexService.indexDocument(concept1)

--- a/search-api/src/main/scala/no/ndla/searchapi/model/api/MultiSearchSummary.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/model/api/MultiSearchSummary.scala
@@ -41,6 +41,9 @@ case class MultiSearchSummary(
     @(ApiModelProperty @field)(description = "Responsible field") responsible: Option[DraftResponsible],
     @(ApiModelProperty @field)(description = "Information about comments attached to the article") comments: Option[Seq[Comment]],
     @(ApiModelProperty @field)(description = "If the article should be prioritized" ) prioritized: Option[Boolean],
-    @(ApiModelProperty @field)(description = "If the article should be prioritized. Possible values are prioritized, on-hold, unspecified") priority: Option[String]
+    @(ApiModelProperty @field)(description = "If the article should be prioritized. Possible values are prioritized, on-hold, unspecified") priority: Option[String],
+    @(ApiModelProperty @field)(description = "A combined resource type name if a standard article, otherwise the article type name") resourceTypeName: Option[String],
+    @(ApiModelProperty @field)(description = "Name of the parent topic if exists") parentTopicName: Option[String],
+    @(ApiModelProperty @field)(description = "Name of the primary context root if exists") primaryRootName: Option[String]
 )
 // format: on

--- a/search-api/src/main/scala/no/ndla/searchapi/model/domain/Sort.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/model/domain/Sort.scala
@@ -37,6 +37,14 @@ object Sort extends Enum[Sort] {
   case object ByPrioritizedDesc            extends Sort("-prioritized")
   case object ByPrioritizedAsc             extends Sort("prioritized")
 
-  def valueOf(s: String): Option[Sort] = Sort.values.find(_.entryName == s)
+  case object ByParentTopicNameDesc extends Sort("-parentTopicName")
+  case object ByParentTopicNameAsc  extends Sort("parentTopicName")
 
+  case object ByPrimaryRootDesc extends Sort("-primaryRoot")
+  case object ByPrimaryRootAsc  extends Sort("primaryRoot")
+
+  case object ByResourceTypeDesc extends Sort("-resourceType")
+  case object ByResourceTypeAsc  extends Sort("resourceType")
+
+  def valueOf(s: String): Option[Sort] = Sort.values.find(_.entryName == s)
 }

--- a/search-api/src/main/scala/no/ndla/searchapi/model/domain/Sort.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/model/domain/Sort.scala
@@ -36,15 +36,12 @@ object Sort extends Enum[Sort] {
   case object ByStatusDesc                 extends Sort("-status")
   case object ByPrioritizedDesc            extends Sort("-prioritized")
   case object ByPrioritizedAsc             extends Sort("prioritized")
-
-  case object ByParentTopicNameDesc extends Sort("-parentTopicName")
-  case object ByParentTopicNameAsc  extends Sort("parentTopicName")
-
-  case object ByPrimaryRootDesc extends Sort("-primaryRoot")
-  case object ByPrimaryRootAsc  extends Sort("primaryRoot")
-
-  case object ByResourceTypeDesc extends Sort("-resourceType")
-  case object ByResourceTypeAsc  extends Sort("resourceType")
+  case object ByParentTopicNameDesc        extends Sort("-parentTopicName")
+  case object ByParentTopicNameAsc         extends Sort("parentTopicName")
+  case object ByPrimaryRootDesc            extends Sort("-primaryRoot")
+  case object ByPrimaryRootAsc             extends Sort("primaryRoot")
+  case object ByResourceTypeDesc           extends Sort("-resourceType")
+  case object ByResourceTypeAsc            extends Sort("resourceType")
 
   def valueOf(s: String): Option[Sort] = Sort.values.find(_.entryName == s)
 }

--- a/search-api/src/main/scala/no/ndla/searchapi/model/search/SearchableDraft.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/model/search/SearchableDraft.scala
@@ -40,5 +40,11 @@ case class SearchableDraft(
     nextRevision: Option[RevisionMeta],
     responsible: Option[Responsible],
     domainObject: Draft,
-    priority: Priority
+    priority: Priority,
+    defaultParentTopicName: Option[String],
+    parentTopicName: SearchableLanguageValues,
+    defaultRoot: Option[String],
+    primaryRoot: SearchableLanguageValues,
+    resourceTypeName: SearchableLanguageValues,
+    defaultResourceTypeName: Option[String]
 )

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/DraftIndexService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/DraftIndexService.scala
@@ -95,7 +95,10 @@ trait DraftIndexService {
         keywordField("nextRevision.status"),
         textField("nextRevision.note"),
         dateField("nextRevision.revisionDate"),
-        keywordField("priority")
+        keywordField("priority"),
+        keywordField("defaultParentTopicName"),
+        keywordField("defaultRoot"),
+        keywordField("defaultResourceTypeName")
       )
       val dynamics = generateLanguageSupportedDynamicTemplates("title", keepRaw = true) ++
         generateLanguageSupportedDynamicTemplates("metaDescription") ++
@@ -107,7 +110,10 @@ trait DraftIndexService {
         generateLanguageSupportedDynamicTemplates("relevance") ++
         generateLanguageSupportedDynamicTemplates("breadcrumbs") ++
         generateLanguageSupportedDynamicTemplates("name", keepRaw = true) ++
-        generateLanguageSupportedDynamicTemplates("contexts.root") ++
+        generateLanguageSupportedDynamicTemplates("contexts.root", keepRaw = true) ++
+        generateLanguageSupportedDynamicTemplates("parentTopicName", keepRaw = true) ++
+        generateLanguageSupportedDynamicTemplates("resourceTypeName", keepRaw = true) ++
+        generateLanguageSupportedDynamicTemplates("primaryRoot", keepRaw = true) ++
         generateLanguageSupportedDynamicTemplates("contexts.relevance") ++
         generateLanguageSupportedDynamicTemplates("contexts.resourceTypes.name")
 

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
@@ -403,16 +403,9 @@ trait SearchConverterService {
         case ArticleType.Standard =>
           taxonomyContexts.headOption
             .flatMap(ctx => {
-              val typeNames    = ctx.resourceTypes.map(t => t.name)
-              val allLanguages = typeNames.flatMap(_.map(_.language)).distinct
-              val values = allLanguages.map(language => {
-                val value = typeNames
-                  .map(typeName => typeName.getLanguageOrDefault(language).getOrElse(""))
-                  .mkString(" - ")
-                LanguageValue(language, value)
-              })
-              Option.when(values.nonEmpty) {
-                SearchableLanguageValues(values)
+              val typeNames = ctx.resourceTypes.map(t => t.name)
+              Option.when(typeNames.nonEmpty) {
+                SearchableLanguageValues.combine(typeNames)
               }
             })
             .getOrElse(

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
@@ -546,7 +546,10 @@ trait SearchConverterService {
         responsible = None,
         comments = None,
         prioritized = None,
-        priority = None
+        priority = None,
+        resourceTypeName = None,
+        parentTopicName = None,
+        primaryRootName = None
       )
     }
 
@@ -583,6 +586,10 @@ trait SearchConverterService {
           Comment(c.id.toString, c.content, c.created, c.updated, c.isOpen, c.solved)
         )
 
+      val resourceTypeName = searchableDraft.resourceTypeName.getLanguageOrDefault(language)
+      val parentTopicName  = searchableDraft.parentTopicName.getLanguageOrDefault(language)
+      val primaryRootName  = searchableDraft.primaryRoot.getLanguageOrDefault(language)
+
       MultiSearchSummary(
         id = searchableDraft.id,
         title = title,
@@ -603,7 +610,10 @@ trait SearchConverterService {
         responsible = responsible,
         comments = Some(comments),
         priority = Some(searchableDraft.priority.entryName),
-        prioritized = Some(searchableDraft.priority == Priority.Prioritized)
+        prioritized = Some(searchableDraft.priority == Priority.Prioritized),
+        resourceTypeName = resourceTypeName,
+        parentTopicName = parentTopicName,
+        primaryRootName = primaryRootName
       )
     }
 
@@ -655,7 +665,10 @@ trait SearchConverterService {
         responsible = None,
         comments = None,
         prioritized = None,
-        priority = None
+        priority = None,
+        resourceTypeName = None,
+        parentTopicName = None,
+        primaryRootName = None
       )
     }
 

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
@@ -336,9 +336,12 @@ trait SearchConverterService {
 
       val parentTopicName = SearchableLanguageValues(
         taxonomyContexts.headOption
-          .map(ctx => {
-            ctx.breadcrumbs
-              .map(lv => lv.value.lastOption.map(LanguageValue(lv.language, _)))
+          .map(context => {
+            context.breadcrumbs
+              .map(breadcrumbsLanguageValue =>
+                breadcrumbsLanguageValue.value.lastOption
+                  .map(LanguageValue(breadcrumbsLanguageValue.language, _))
+              )
               .flatten
           })
           .getOrElse(Seq.empty)
@@ -402,8 +405,8 @@ trait SearchConverterService {
       draft.articleType match {
         case ArticleType.Standard =>
           taxonomyContexts.headOption
-            .flatMap(ctx => {
-              val typeNames = ctx.resourceTypes.map(t => t.name)
+            .flatMap(context => {
+              val typeNames = context.resourceTypes.map(resourceType => resourceType.name)
               Option.when(typeNames.nonEmpty) {
                 SearchableLanguageValues.combine(typeNames)
               }

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
@@ -402,7 +402,7 @@ trait SearchConverterService {
       draft.articleType match {
         case ArticleType.Standard =>
           taxonomyContexts.headOption
-            .map(ctx => {
+            .flatMap(ctx => {
               val typeNames    = ctx.resourceTypes.map(t => t.name)
               val allLanguages = typeNames.flatMap(_.map(_.language)).distinct
               val values = allLanguages.map(language => {
@@ -411,7 +411,9 @@ trait SearchConverterService {
                   .mkString(" - ")
                 LanguageValue(language, value)
               })
-              SearchableLanguageValues(values)
+              Option.when(values.nonEmpty) {
+                SearchableLanguageValues(values)
+              }
             })
             .getOrElse(
               SearchableLanguageValues.from(

--- a/search-api/src/test/scala/no/ndla/searchapi/TestData.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/TestData.scala
@@ -17,17 +17,19 @@ import no.ndla.common.model.domain.{
   EditorNote,
   Introduction,
   Priority,
-  Status,
+  Responsible,
   Tag,
   Title,
   VisualElement,
-  draft
+  draft,
+  Status
 }
 import no.ndla.common.model.domain.article.{Article, Copyright}
-import no.ndla.common.model.domain.draft.{Draft, DraftCopyright, DraftStatus}
+import no.ndla.common.model.domain.draft.{Draft, DraftCopyright, DraftStatus, RevisionMeta, RevisionStatus}
 import no.ndla.common.model.domain.learningpath.LearningpathCopyright
 import no.ndla.common.model.{NDLADate, domain => common}
 import no.ndla.language.Language.DefaultLanguage
+import no.ndla.search.model.domain.EmbedValues
 import no.ndla.search.model.{LanguageValue, SearchableLanguageList, SearchableLanguageValues}
 import no.ndla.searchapi.model.domain._
 import no.ndla.searchapi.model.domain.learningpath.{LearningPath, LearningPathStatus, LearningPathVerificationStatus}
@@ -38,6 +40,7 @@ import no.ndla.searchapi.model.taxonomy._
 import org.apache.commons.lang3.RandomStringUtils
 
 import java.net.URI
+import java.util.UUID
 
 object TestData {
 
@@ -1647,5 +1650,98 @@ object TestData {
 
   val searchableTaxonomyContexts: List[SearchableTaxonomyContext] = List(
     singleSearchableTaxonomyContext
+  )
+
+  val searchableTitles = SearchableLanguageValues.from(
+    "nb" -> "Christian Tut",
+    "en" -> "Christian Honk"
+  )
+
+  val searchableContents = SearchableLanguageValues.from(
+    "nn" -> "Eg kjøyrar rundt i min fine bil",
+    "nb" -> "Jeg kjører rundt i tutut",
+    "en" -> "I'm in my mums car wroomwroom"
+  )
+
+  val searchableVisualElements = SearchableLanguageValues.from(
+    "nn" -> "image",
+    "nb" -> "image"
+  )
+
+  val searchableIntroductions    = SearchableLanguageValues.from("en" -> "Wroom wroom")
+  val searchableMetaDescriptions = SearchableLanguageValues.from("nb" -> "Mammas bil")
+  val searchableTags             = SearchableLanguageList.from("en" -> Seq("Mum", "Car", "Wroom"))
+  val searchableEmbedAttrs = SearchableLanguageList.from(
+    "nb" -> Seq("En norsk", "To norsk"),
+    "en" -> Seq("One english")
+  )
+
+  val searchableEmbedResourcesAndIds = List(
+    EmbedValues(resource = Some("test resource 1"), id = List("test id 1"), language = "nb")
+  )
+
+  val olddate = today.minusDays(5)
+
+  val searchableRevisionMeta = List(
+    RevisionMeta(
+      id = UUID.randomUUID(),
+      revisionDate = today,
+      note = "some note",
+      status = RevisionStatus.NeedsRevision
+    ),
+    RevisionMeta(
+      id = UUID.randomUUID(),
+      revisionDate = olddate,
+      note = "some other note",
+      status = RevisionStatus.NeedsRevision
+    )
+  )
+  val searchableDraft = SearchableDraft(
+    id = 100,
+    draftStatus = SearchableStatus(DraftStatus.PLANNED.toString, Seq(DraftStatus.IN_PROGRESS.toString)),
+    title = searchableTitles,
+    content = searchableContents,
+    visualElement = searchableVisualElements,
+    introduction = searchableIntroductions,
+    metaDescription = searchableMetaDescriptions,
+    tags = searchableTags,
+    lastUpdated = TestData.today,
+    license = Some("by-sa"),
+    authors = List("Jonas", "Papi"),
+    articleType = LearningResourceType.Article.toString,
+    defaultTitle = Some("Christian Tut"),
+    supportedLanguages = List("en", "nb", "nn"),
+    notes = List("Note1", "note2"),
+    contexts = searchableTaxonomyContexts,
+    users = List("ndalId54321", "ndalId12345"),
+    previousVersionsNotes = List("OldNote"),
+    grepContexts = List(),
+    traits = List.empty,
+    embedAttributes = searchableEmbedAttrs,
+    embedResourcesAndIds = searchableEmbedResourcesAndIds,
+    revisionMeta = searchableRevisionMeta,
+    nextRevision = searchableRevisionMeta.lastOption,
+    responsible = Some(Responsible("some responsible", TestData.today)),
+    domainObject = TestData.draft1.copy(
+      status = Status(DraftStatus.IN_PROGRESS, Set(DraftStatus.PUBLISHED)),
+      notes = Seq(
+        EditorNote(
+          note = "Hei",
+          user = "user",
+          timestamp = TestData.today,
+          status = Status(
+            current = DraftStatus.IN_PROGRESS,
+            other = Set(DraftStatus.PUBLISHED)
+          )
+        )
+      )
+    ),
+    priority = Priority.Unspecified,
+    parentTopicName = searchableTitles,
+    defaultParentTopicName = searchableTitles.defaultValue,
+    primaryRoot = searchableTitles,
+    defaultRoot = searchableTitles.defaultValue,
+    resourceTypeName = searchableTitles,
+    defaultResourceTypeName = searchableTitles.defaultValue
   )
 }

--- a/search-api/src/test/scala/no/ndla/searchapi/model/search/SearchableDraftTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/model/search/SearchableDraftTest.scala
@@ -123,7 +123,13 @@ class SearchableDraftTest extends UnitSuite with TestEnvironment {
           )
         )
       ),
-      priority = Priority.Unspecified
+      priority = Priority.Unspecified,
+      parentTopicName = titles,
+      defaultParentTopicName = titles.defaultValue,
+      primaryRoot = titles,
+      defaultRoot = titles.defaultValue,
+      resourceTypeName = titles,
+      defaultResourceTypeName = titles.defaultValue
     )
 
     implicit val formats: Formats = SearchableLanguageFormats.JSonFormatsWithMillis

--- a/search/src/main/scala/no/ndla/search/model/SearchableLanguageValues.scala
+++ b/search/src/main/scala/no/ndla/search/model/SearchableLanguageValues.scala
@@ -8,6 +8,7 @@
 package no.ndla.search.model
 
 import no.ndla.language.model.LanguageField
+import no.ndla.mapping.ISO639
 
 case class LanguageValue[T](language: String, value: T) extends LanguageField[T] {
   def isEmpty: Boolean = language.isEmpty
@@ -15,12 +16,31 @@ case class LanguageValue[T](language: String, value: T) extends LanguageField[T]
 
 case class SearchableLanguageValues(languageValues: Seq[LanguageValue[String]]) {
   def map[T](f: LanguageValue[String] => T): Seq[T] = languageValues.map(lv => f(lv))
+
+  def getLanguage(language: String): Option[String] =
+    languageValues.find(_.language == language).map(_.value)
+
+  def getLanguageOrDefault(language: String): Option[String] =
+    getLanguage(language).orElse(defaultValue)
+
+  def defaultValue: Option[String] =
+    languageValues
+      .sortBy(lv => ISO639.languagePriority.reverse.indexOf(lv.language))
+      .lastOption
+      .map(_.value)
 }
 
 object SearchableLanguageValues {
 
+  def empty: SearchableLanguageValues = SearchableLanguageValues(Seq.empty)
+
   def fromFields(fields: Seq[LanguageField[String]]): SearchableLanguageValues =
     SearchableLanguageValues(fields.map(f => LanguageValue(f.language, f.value)))
+
+  def from(values: (String, String)*): SearchableLanguageValues = {
+    val languageValues = values.map { case (language, value) => LanguageValue(language, value) }
+    SearchableLanguageValues(languageValues)
+  }
 }
 
 object SearchableLanguageList {
@@ -32,6 +52,11 @@ object SearchableLanguageList {
     SearchableLanguageList(
       fields.languageValues.map(field => LanguageValue(field.language, field.value :+ languageValue))
     )
+  }
+
+  def from(values: (String, Seq[String])*): SearchableLanguageList = {
+    val languageValues = values.map { case (language, value) => LanguageValue(language, value) }
+    SearchableLanguageList(languageValues)
   }
 
 }

--- a/search/src/main/scala/no/ndla/search/model/SearchableLanguageValues.scala
+++ b/search/src/main/scala/no/ndla/search/model/SearchableLanguageValues.scala
@@ -41,6 +41,16 @@ object SearchableLanguageValues {
     val languageValues = values.map { case (language, value) => LanguageValue(language, value) }
     SearchableLanguageValues(languageValues)
   }
+
+  def combine(values: Seq[SearchableLanguageValues]): SearchableLanguageValues = {
+    val allLanguages = values.flatMap(_.map(_.language)).distinct
+    val languageValues = allLanguages.map { language =>
+      val valuesForLanguage = values.map(_.getLanguageOrDefault(language).getOrElse(""))
+      LanguageValue(language, valuesForLanguage.mkString(" - "))
+    }
+
+    SearchableLanguageValues(languageValues)
+  }
 }
 
 object SearchableLanguageList {


### PR DESCRIPTION
@katrinewi sa vi trengte å sortere på de feltene som finnes i arbeidslisten i ed.

Returnerer feltene for drafts:
    `resourceTypeName` tilsvarer `Innholdstype`
    `parentTopicName` tilsvarer `Emnetilhørlighet`
    `primaryRootName` tilsvarer `Primærfag`

Sortering med henholdsvis `resourceType`, `parentTopicName`, og `primaryRoot`.