### PR TITLE
Expand allowed html

### DIFF
--- a/article-api/src/main/scala/no/ndla/articleapi/ArticleApiProperties.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/ArticleApiProperties.scala
@@ -103,9 +103,9 @@ class ArticleApiProperties extends BaseProps {
     ResourceType.H5P.toString   -> H5PAddress
   )
 
-  def AllowHtmlInTitle: Boolean = booleanPropOrFalse("ALLOW_HTML_IN_TITLE")
+  def InlineHtmlTags: Set[String] = if (booleanPropOrFalse("ALLOW_HTML_IN_TITLE")) Set("code", "em", "span", "strong", "sub", "sup") else Set.empty
 
-  def H5PAddress: String = propOrElse(
+  private def H5PAddress: String = propOrElse(
     "NDLA_H5P_ADDRESS",
     Map(
       "test"    -> "https://h5p-test.ndla.no",

--- a/article-api/src/main/scala/no/ndla/articleapi/ArticleApiProperties.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/ArticleApiProperties.scala
@@ -103,7 +103,8 @@ class ArticleApiProperties extends BaseProps {
     ResourceType.H5P.toString   -> H5PAddress
   )
 
-  def InlineHtmlTags: Set[String] = if (booleanPropOrFalse("ALLOW_HTML_IN_TITLE")) Set("code", "em", "span", "strong", "sub", "sup") else Set.empty
+  def InlineHtmlTags: Set[String] =
+    if (booleanPropOrFalse("ALLOW_HTML_IN_TITLE")) Set("code", "em", "span", "strong", "sub", "sup") else Set.empty
 
   private def H5PAddress: String = propOrElse(
     "NDLA_H5P_ADDRESS",

--- a/article-api/src/main/scala/no/ndla/articleapi/ArticleApiProperties.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/ArticleApiProperties.scala
@@ -105,6 +105,8 @@ class ArticleApiProperties extends BaseProps {
 
   def InlineHtmlTags: Set[String] =
     if (booleanPropOrFalse("ALLOW_HTML_IN_TITLE")) Set("code", "em", "span", "strong", "sub", "sup") else Set.empty
+  def IntroductionHtmlTags: Set[String] =
+    if (booleanPropOrFalse("ALLOW_HTML_IN_TITLE")) InlineHtmlTags ++ Set("br", "p") else Set.empty
 
   private def H5PAddress: String = propOrElse(
     "NDLA_H5P_ADDRESS",

--- a/article-api/src/main/scala/no/ndla/articleapi/model/api/ArticleIntroduction.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/model/api/ArticleIntroduction.scala
@@ -13,6 +13,7 @@ import sttp.tapir.Schema.annotations.description
 @description("Description of the article introduction")
 case class ArticleIntroduction(
     @description("The introduction content") introduction: String,
+    @description("The html-version introduction content") htmlIntroduction: String,
     @description(
       "The ISO 639-1 language code describing which article translation this introduction belongs to"
     ) language: String

--- a/article-api/src/main/scala/no/ndla/articleapi/model/api/ArticleTitle.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/model/api/ArticleTitle.scala
@@ -13,5 +13,6 @@ import sttp.tapir.Schema.annotations.description
 @description("Description of a title")
 case class ArticleTitle(
     @description("The freetext title of the article") title: String,
+    @description("The freetext html-version title of the article") htmlTitle: String,
     @description("ISO 639-1 code that represents the language used in title") language: String
 )

--- a/article-api/src/main/scala/no/ndla/articleapi/validation/ContentValidator.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/validation/ContentValidator.scala
@@ -28,7 +28,8 @@ trait ContentValidator {
   val contentValidator: ContentValidator
 
   class ContentValidator() {
-    private val allowedTags = props.InlineHtmlTags
+    private val allowedTags             = props.InlineHtmlTags
+    private val allowedIntroductionTags = if (allowedTags.isEmpty) allowedTags else allowedTags ++ Set("br", "p")
 
     def softValidateArticle(article: Article, isImported: Boolean): Try[Article] = {
       val metaValidation =
@@ -120,7 +121,7 @@ trait ContentValidator {
 
     private def validateIntroduction(content: Introduction): Seq[ValidationMessage] = {
       val field = s"introduction.${content.language}"
-      TextValidator.validate(field, content.introduction, allowedTags).toList ++
+      TextValidator.validate(field, content.introduction, allowedIntroductionTags).toList ++
         validateLanguage("introduction.language", content.language)
     }
 

--- a/article-api/src/main/scala/no/ndla/articleapi/validation/ContentValidator.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/validation/ContentValidator.scala
@@ -28,8 +28,8 @@ trait ContentValidator {
   val contentValidator: ContentValidator
 
   class ContentValidator() {
-    private val allowedTags             = props.InlineHtmlTags
-    private val allowedIntroductionTags = if (allowedTags.isEmpty) allowedTags else allowedTags ++ Set("br", "p")
+    private val inlineHtmlTags       = props.InlineHtmlTags
+    private val introductionHtmlTags = props.IntroductionHtmlTags
 
     def softValidateArticle(article: Article, isImported: Boolean): Try[Article] = {
       val metaValidation =
@@ -121,7 +121,7 @@ trait ContentValidator {
 
     private def validateIntroduction(content: Introduction): Seq[ValidationMessage] = {
       val field = s"introduction.${content.language}"
-      TextValidator.validate(field, content.introduction, allowedIntroductionTags).toList ++
+      TextValidator.validate(field, content.introduction, introductionHtmlTags).toList ++
         validateLanguage("introduction.language", content.language)
     }
 
@@ -141,7 +141,7 @@ trait ContentValidator {
     private def validateTitle(titles: Seq[LanguageField[String]]): Seq[ValidationMessage] = {
       titles.flatMap(title => {
         val field = s"title.$language"
-        TextValidator.validate(field, title.value, allowedTags).toList ++
+        TextValidator.validate(field, title.value, inlineHtmlTags).toList ++
           validateLanguage("title.language", title.language) ++
           validateLength("title", title.value, 256)
       }) ++ validateNonEmpty("title", titles)

--- a/article-api/src/main/scala/no/ndla/articleapi/validation/ContentValidator.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/validation/ContentValidator.scala
@@ -28,7 +28,7 @@ trait ContentValidator {
   val contentValidator: ContentValidator
 
   class ContentValidator() {
-    private val allowedTags = if (props.AllowHtmlInTitle) Set("span") else Set.empty[String]
+    private val allowedTags = props.InlineHtmlTags
 
     def softValidateArticle(article: Article, isImported: Boolean): Try[Article] = {
       val metaValidation =

--- a/article-api/src/test/scala/no/ndla/articleapi/TestData.scala
+++ b/article-api/src/test/scala/no/ndla/articleapi/TestData.scala
@@ -53,7 +53,7 @@ trait TestData {
       id = 1,
       oldNdlaUrl = None,
       revision = 1,
-      title = api.ArticleTitle("title", "nb"),
+      title = api.ArticleTitle("title", "title", "nb"),
       content = api.ArticleContentV2("this is content", "nb"),
       copyright = model.api.Copyright(
         model.api.License("licence", None, None),
@@ -89,7 +89,7 @@ trait TestData {
       articleId,
       Some(s"//red.ndla.no/node/$externalId"),
       2,
-      api.ArticleTitle("title", "nb"),
+      api.ArticleTitle("title", "title", "nb"),
       api.ArticleContentV2("content", "nb"),
       model.api.Copyright(
         model.api.License(
@@ -246,7 +246,7 @@ trait TestData {
       1,
       None,
       1,
-      api.ArticleTitle("test", "en"),
+      api.ArticleTitle("test", "test", "en"),
       api.ArticleContentV2(
         """<ul><li><h1>Det er ikke lov å gjøre dette.</h1> Tekst utenfor.</li><li>Dette er helt ok</li></ul>
         |<ul><li><h2>Det er ikke lov å gjøre dette.</h2></li><li>Dette er helt ok</li></ul>

--- a/article-api/src/test/scala/no/ndla/articleapi/TestEnvironment.scala
+++ b/article-api/src/test/scala/no/ndla/articleapi/TestEnvironment.scala
@@ -61,7 +61,7 @@ trait TestEnvironment
     with TestData
     with DBMigrator {
   val props: ArticleApiProperties = new ArticleApiProperties {
-    override def AllowHtmlInTitle: Boolean = true
+    override def InlineHtmlTags: Set[String] = Set("code", "em", "span", "strong", "sub", "sup")
   }
   val TestData: TestData = new TestData
   val migrator           = mock[DBMigrator]

--- a/article-api/src/test/scala/no/ndla/articleapi/TestEnvironment.scala
+++ b/article-api/src/test/scala/no/ndla/articleapi/TestEnvironment.scala
@@ -61,7 +61,8 @@ trait TestEnvironment
     with TestData
     with DBMigrator {
   val props: ArticleApiProperties = new ArticleApiProperties {
-    override def InlineHtmlTags: Set[String] = Set("code", "em", "span", "strong", "sub", "sup")
+    override def InlineHtmlTags: Set[String]       = Set("code", "em", "span", "strong", "sub", "sup")
+    override def IntroductionHtmlTags: Set[String] = InlineHtmlTags ++ Set("br", "p")
   }
   val TestData: TestData = new TestData
   val migrator           = mock[DBMigrator]

--- a/article-api/src/test/scala/no/ndla/articleapi/service/ConverterServiceTest.scala
+++ b/article-api/src/test/scala/no/ndla/articleapi/service/ConverterServiceTest.scala
@@ -14,7 +14,7 @@ import no.ndla.articleapi.{TestEnvironment, UnitSuite}
 import no.ndla.common.model
 import no.ndla.common.model.{NDLADate, RelatedContentLink, api => commonApi}
 import no.ndla.common.model.api.{License, UpdateWith}
-import no.ndla.common.model.domain.{Author, Availability, Description, RequiredLibrary, Tag, Title}
+import no.ndla.common.model.domain.{Author, Availability, Description, Introduction, RequiredLibrary, Tag, Title}
 import no.ndla.common.model.domain.article.Copyright
 
 import scala.util.Success
@@ -40,6 +40,20 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
         Some("Creative Commons Attribution 4.0 International"),
         Some("https://creativecommons.org/licenses/by/4.0/")
       )
+    )
+  }
+
+  test("toApiArticleTitle returns both title and htmlTitle") {
+    val title = Title("Title with <span data-language=\"uk\">ukrainian</span> word", "en")
+    service.toApiArticleTitle(title) should equal(
+      api.ArticleTitle("Title with ukrainian word", "Title with <span data-language=\"uk\">ukrainian</span> word", "en")
+    )
+  }
+
+  test("toApiArticleIntroduction returns both introduction and htmlIntroduction") {
+    val introduction = Introduction("Introduction with <em>emphasis</em>", "en")
+    service.toApiArticleIntroduction(introduction) should equal(
+      api.ArticleIntroduction("Introduction with emphasis", "Introduction with <em>emphasis</em>", "en")
     )
   }
 

--- a/article-api/src/test/scala/no/ndla/articleapi/validation/ContentValidatorTest.scala
+++ b/article-api/src/test/scala/no/ndla/articleapi/validation/ContentValidatorTest.scala
@@ -28,7 +28,7 @@ import scala.util.Failure
 class ContentValidatorTest extends UnitSuite with TestEnvironment {
   override val contentValidator = new ContentValidator
   val validDocument             = """<section><h1>heisann</h1><h2>heia</h2></section>"""
-  val validIntroduction         = """<p>heisann <span lang="en">heia</span></p>"""
+  val validIntroduction         = """<p>heisann <span lang="en">heia</span></p><p>hopp</p>"""
   val invalidDocument           = """<section><invalid></invalid></section>"""
 
   test("validateArticle does not throw an exception on a valid document") {

--- a/article-api/src/test/scala/no/ndla/articleapi/validation/ContentValidatorTest.scala
+++ b/article-api/src/test/scala/no/ndla/articleapi/validation/ContentValidatorTest.scala
@@ -28,7 +28,7 @@ import scala.util.Failure
 class ContentValidatorTest extends UnitSuite with TestEnvironment {
   override val contentValidator = new ContentValidator
   val validDocument             = """<section><h1>heisann</h1><h2>heia</h2></section>"""
-  val validIntroduction         = """heisann <span lang="en">heia</span>"""
+  val validIntroduction         = """<p>heisann <span lang="en">heia</span></p>"""
   val invalidDocument           = """<section><invalid></invalid></section>"""
 
   test("validateArticle does not throw an exception on a valid document") {

--- a/draft-api/src/main/scala/no/ndla/draftapi/DraftApiProperties.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/DraftApiProperties.scala
@@ -58,7 +58,7 @@ class DraftApiProperties extends BaseProps with StrictLogging {
     "image-api"   -> s"http://$ImageApiHost/intern"
   )
 
-  def AllowHtmlInTitle: Boolean = booleanPropOrFalse("ALLOW_HTML_IN_TITLE")
+  def InlineHtmlTags: Set[String] = if (booleanPropOrFalse("ALLOW_HTML_IN_TITLE")) Set("code", "em", "span", "strong", "sub", "sup") else Set.empty
 
   def BrightcoveAccountId: String        = prop("NDLA_BRIGHTCOVE_ACCOUNT_ID")
   private def BrightcovePlayerId: String = prop("NDLA_BRIGHTCOVE_PLAYER_ID")

--- a/draft-api/src/main/scala/no/ndla/draftapi/DraftApiProperties.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/DraftApiProperties.scala
@@ -60,6 +60,8 @@ class DraftApiProperties extends BaseProps with StrictLogging {
 
   def InlineHtmlTags: Set[String] =
     if (booleanPropOrFalse("ALLOW_HTML_IN_TITLE")) Set("code", "em", "span", "strong", "sub", "sup") else Set.empty
+  def IntroductionHtmlTags: Set[String] =
+    if (booleanPropOrFalse("ALLOW_HTML_IN_TITLE")) InlineHtmlTags ++ Set("br", "p") else Set.empty
 
   def BrightcoveAccountId: String        = prop("NDLA_BRIGHTCOVE_ACCOUNT_ID")
   private def BrightcovePlayerId: String = prop("NDLA_BRIGHTCOVE_PLAYER_ID")

--- a/draft-api/src/main/scala/no/ndla/draftapi/DraftApiProperties.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/DraftApiProperties.scala
@@ -58,7 +58,8 @@ class DraftApiProperties extends BaseProps with StrictLogging {
     "image-api"   -> s"http://$ImageApiHost/intern"
   )
 
-  def InlineHtmlTags: Set[String] = if (booleanPropOrFalse("ALLOW_HTML_IN_TITLE")) Set("code", "em", "span", "strong", "sub", "sup") else Set.empty
+  def InlineHtmlTags: Set[String] =
+    if (booleanPropOrFalse("ALLOW_HTML_IN_TITLE")) Set("code", "em", "span", "strong", "sub", "sup") else Set.empty
 
   def BrightcoveAccountId: String        = prop("NDLA_BRIGHTCOVE_ACCOUNT_ID")
   private def BrightcovePlayerId: String = prop("NDLA_BRIGHTCOVE_PLAYER_ID")

--- a/draft-api/src/main/scala/no/ndla/draftapi/validation/ContentValidator.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/validation/ContentValidator.scala
@@ -34,8 +34,8 @@ trait ContentValidator {
 
   class ContentValidator() {
     import props.{BrightcoveVideoScriptUrl, H5PResizerScriptUrl, NRKVideoScriptUrl}
-    private val allowedTags             = props.InlineHtmlTags
-    private val allowedIntroductionTags = if (allowedTags.isEmpty) allowedTags else allowedTags ++ Set("br", "p")
+    private val inlineHtmlTags       = props.InlineHtmlTags
+    private val introductionHtmlTags = props.IntroductionHtmlTags
 
     def validateDate(fieldName: String, dateString: String): Seq[ValidationMessage] = {
       NDLADate.fromString(dateString) match {
@@ -172,7 +172,7 @@ trait ContentValidator {
     }
 
     private def validateIntroduction(content: Introduction): List[ValidationMessage] = {
-      TextValidator.validate("introduction", content.introduction, allowedIntroductionTags).toList ++
+      TextValidator.validate("introduction", content.introduction, introductionHtmlTags).toList ++
         validateLanguage("language", content.language)
     }
 
@@ -194,7 +194,7 @@ trait ContentValidator {
     }
 
     private def validateTitle(title: String, language: String): Seq[ValidationMessage] = {
-      TextValidator.validate(s"title.$language", title, allowedTags).toList ++
+      TextValidator.validate(s"title.$language", title, inlineHtmlTags).toList ++
         validateLanguage("language", language) ++
         validateLength(s"title.$language", title, 256) ++
         validateMinimumLength(s"title.$language", title, 1)

--- a/draft-api/src/main/scala/no/ndla/draftapi/validation/ContentValidator.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/validation/ContentValidator.scala
@@ -34,7 +34,8 @@ trait ContentValidator {
 
   class ContentValidator() {
     import props.{BrightcoveVideoScriptUrl, H5PResizerScriptUrl, NRKVideoScriptUrl}
-    private val allowedTags = props.InlineHtmlTags
+    private val allowedTags             = props.InlineHtmlTags
+    private val allowedIntroductionTags = if (allowedTags.isEmpty) allowedTags else allowedTags ++ Set("br", "p")
 
     def validateDate(fieldName: String, dateString: String): Seq[ValidationMessage] = {
       NDLADate.fromString(dateString) match {
@@ -171,7 +172,7 @@ trait ContentValidator {
     }
 
     private def validateIntroduction(content: Introduction): List[ValidationMessage] = {
-      TextValidator.validate("introduction", content.introduction, allowedTags).toList ++
+      TextValidator.validate("introduction", content.introduction, allowedIntroductionTags).toList ++
         validateLanguage("language", content.language)
     }
 

--- a/draft-api/src/main/scala/no/ndla/draftapi/validation/ContentValidator.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/validation/ContentValidator.scala
@@ -34,7 +34,7 @@ trait ContentValidator {
 
   class ContentValidator() {
     import props.{BrightcoveVideoScriptUrl, H5PResizerScriptUrl, NRKVideoScriptUrl}
-    private val allowedTags = if (props.AllowHtmlInTitle) Set("span") else Set.empty[String]
+    private val allowedTags = props.InlineHtmlTags
 
     def validateDate(fieldName: String, dateString: String): Seq[ValidationMessage] = {
       NDLADate.fromString(dateString) match {

--- a/draft-api/src/test/scala/no/ndla/draftapi/TestEnvironment.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/TestEnvironment.scala
@@ -72,8 +72,10 @@ trait TestEnvironment
     with DBMigrator
     with Props
     with DraftApiInfo {
-  val props: DraftApiProperties = new DraftApiProperties
-  val migrator: DBMigrator      = mock[DBMigrator]
+  val props: DraftApiProperties = new DraftApiProperties {
+    override def InlineHtmlTags: Set[String] = Set("code", "em", "span", "strong", "sub", "sup")
+  }
+  val migrator: DBMigrator = mock[DBMigrator]
 
   val articleSearchService   = mock[ArticleSearchService]
   val articleIndexService    = mock[ArticleIndexService]

--- a/draft-api/src/test/scala/no/ndla/draftapi/TestEnvironment.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/TestEnvironment.scala
@@ -73,7 +73,8 @@ trait TestEnvironment
     with Props
     with DraftApiInfo {
   val props: DraftApiProperties = new DraftApiProperties {
-    override def InlineHtmlTags: Set[String] = Set("code", "em", "span", "strong", "sub", "sup")
+    override def InlineHtmlTags: Set[String]       = Set("code", "em", "span", "strong", "sub", "sup")
+    override def IntroductionHtmlTags: Set[String] = InlineHtmlTags ++ Set("br", "p")
   }
   val migrator: DBMigrator = mock[DBMigrator]
 

--- a/draft-api/src/test/scala/no/ndla/draftapi/validation/ContentValidatorTest.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/validation/ContentValidatorTest.scala
@@ -43,9 +43,9 @@ class ContentValidatorTest extends UnitSuite with TestEnvironment {
   test("validateArticle should throw an error if introduction contains HTML tags") {
     val article = articleToValidate.copy(
       content = Seq(ArticleContent(validDocument, "nb")),
-      introduction = Seq(Introduction(validDocument, "nb"))
+      introduction = Seq(Introduction("<p>introduction</p>", "nb"))
     )
-    contentValidator.validateArticle(article).isFailure should be(true)
+    contentValidator.validateArticle(article).isFailure should be(false)
   }
 
   test("validateArticle should not throw an error if introduction contains plain text") {

--- a/validation/src/main/resources/embed-tag-rules.json
+++ b/validation/src/main/resources/embed-tag-rules.json
@@ -257,7 +257,15 @@
         {
           "name": "data-caption",
           "validation": {
-            "required": true
+            "required": true,
+            "allowedHtml": [
+              "code",
+              "em",
+              "span",
+              "strong",
+              "sub",
+              "sup"
+            ]
           }
         },
         {
@@ -322,7 +330,15 @@
         {
           "name": "data-caption",
           "validation": {
-            "required": true
+            "required": true,
+            "allowedHtml": [
+              "code",
+              "em",
+              "span",
+              "strong",
+              "sub",
+              "sup"
+            ]
           }
         },
         {
@@ -891,7 +907,12 @@
           "validation": {
             "required": true,
             "allowedHtml": [
-              "span"
+              "code",
+              "em",
+              "span",
+              "strong",
+              "sub",
+              "sup"
             ]
           }
         },
@@ -942,7 +963,12 @@
           "validation": {
             "required": true,
             "allowedHtml": [
-              "span"
+              "code",
+              "em",
+              "span",
+              "strong",
+              "sub",
+              "sup"
             ]
           }
         },
@@ -951,7 +977,12 @@
           "validation": {
             "required": true,
             "allowedHtml": [
-              "span"
+              "code",
+              "em",
+              "span",
+              "strong",
+              "sub",
+              "sup"
             ]
           }
         },
@@ -995,7 +1026,12 @@
           "validation": {
             "required": true,
             "allowedHtml": [
-              "span"
+              "code",
+              "em",
+              "span",
+              "strong",
+              "sub",
+              "sup"
             ]
           }
         },
@@ -1010,7 +1046,12 @@
           "validation": {
             "required": true,
             "allowedHtml": [
-              "span"
+              "code",
+              "em",
+              "span",
+              "strong",
+              "sub",
+              "sup"
             ]
           }
         },
@@ -1080,7 +1121,12 @@
           "validation": {
             "required": true,
             "allowedHtml": [
-              "span"
+              "code",
+              "em",
+              "span",
+              "strong",
+              "sub",
+              "sup"
             ]
           }
         },

--- a/validation/src/main/scala/no/ndla/validation/TextValidator.scala
+++ b/validation/src/main/scala/no/ndla/validation/TextValidator.scala
@@ -17,7 +17,6 @@ import scala.jdk.CollectionConverters.IteratorHasAsScala
 object TextValidator {
   private val IllegalContentInBasicText = "The content contains illegal tags and/or attributes. Allowed HTML tags are:"
   private val IllegalContentInPlainText = "The content contains illegal html-characters. No HTML is allowed"
-  private val FieldEmpty                = "Required field is empty"
 
   /** Validates text Will validate legal html tags if html is allowed.
     *

--- a/validation/src/main/scala/no/ndla/validation/TextValidator.scala
+++ b/validation/src/main/scala/no/ndla/validation/TextValidator.scala
@@ -82,7 +82,7 @@ object TextValidator {
       .foreach(tag => whiteList.addAttributes(tag, HtmlTagRules.legalAttributesForTag(tag).toSeq: _*))
 
     if (text.isEmpty) {
-      ValidationMessage(fieldPath, FieldEmpty) :: Nil
+      Seq.empty
     } else {
       val whiteListValidationMessage =
         ValidationMessage(fieldPath, s"$IllegalContentInBasicText ${allowedTags.mkString(",")}")

--- a/validation/src/test/scala/no/ndla/validation/EmbedTagRulesTest.scala
+++ b/validation/src/test/scala/no/ndla/validation/EmbedTagRulesTest.scala
@@ -329,14 +329,14 @@ class EmbedTagRulesTest extends UnitSuite {
     )
   }
 
-  test("Html in data-caption is forbidden for image") {
+  test("Html in data-alt is forbidden for image") {
     val embedString =
       s"""<$EmbedTagName
          | data-resource="image"
          | data-resource_id="1"
          | data-size=""
          | data-align=""
-         | data-alt=""
+         | data-alt="Bilde på <span lang='en'>engelsk</span>"
          | data-caption="Bilde på <span lang='en'>engelsk</span>"
          |/>""".stripMargin
 
@@ -345,7 +345,7 @@ class EmbedTagRulesTest extends UnitSuite {
       Seq(
         ValidationMessage(
           "test",
-          s"HTML tag '$EmbedTagName' contains attributes with HTML: data-caption"
+          s"HTML tag '$EmbedTagName' contains attributes with HTML: data-alt"
         )
       )
     )


### PR DESCRIPTION
Legger til støtte for inlinetekster i tittel og ingress. Legger på html-versjoner av tittel og introduction i api-artikkel.