### PR TITLE
concept-api: Add `aggregate-paths` query-param to search

### DIFF
--- a/concept-api/src/main/scala/no/ndla/conceptapi/controller/DraftConceptController.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/controller/DraftConceptController.scala
@@ -91,7 +91,8 @@ trait DraftConceptController {
         embedResource: Option[String],
         embedId: Option[String],
         responsibleId: List[String],
-        conceptType: Option[String]
+        conceptType: Option[String],
+        aggregatePaths: List[String]
     ) = {
       val settings = DraftSearchSettings(
         withIdIn = idList,
@@ -108,7 +109,8 @@ trait DraftConceptController {
         embedResource = embedResource,
         embedId = embedId,
         responsibleIdFilter = responsibleId,
-        conceptType = conceptType
+        conceptType = conceptType,
+        aggregatePaths = aggregatePaths
       )
 
       val result = query.emptySomeToNone match {
@@ -176,7 +178,8 @@ trait DraftConceptController {
             asQueryParam(embedResource),
             asQueryParam(embedId),
             asQueryParam(responsibleIdFilter),
-            asQueryParam(conceptType)
+            asQueryParam(conceptType),
+            asQueryParam(aggregatePaths)
           )
           .authorizations("oauth2")
           .responseMessages(response500)
@@ -201,6 +204,7 @@ trait DraftConceptController {
         val embedId            = paramOrNone(this.embedId.paramName)
         val responsibleIds     = paramAsListOfString(this.responsibleIdFilter.paramName)
         val conceptType        = paramOrNone(this.conceptType.paramName)
+        val aggregatePaths     = paramAsListOfString(this.aggregatePaths.paramName)
 
         search(
           query,
@@ -218,7 +222,8 @@ trait DraftConceptController {
           embedResource,
           embedId,
           responsibleIds,
-          conceptType
+          conceptType,
+          aggregatePaths
         )
 
       }
@@ -311,6 +316,7 @@ trait DraftConceptController {
             val embedId        = searchParams.embedId
             val responsibleId  = searchParams.responsibleIds
             val conceptType    = searchParams.conceptType
+            val aggregatePaths = searchParams.aggregatePaths
 
             search(
               query,
@@ -328,7 +334,8 @@ trait DraftConceptController {
               embedResource,
               embedId,
               responsibleId,
-              conceptType
+              conceptType,
+              aggregatePaths
             )
           case Failure(ex) => errorHandler(ex)
         }

--- a/concept-api/src/main/scala/no/ndla/conceptapi/controller/NdlaController.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/controller/NdlaController.scala
@@ -87,6 +87,10 @@ trait NdlaController {
       "ids",
       "Return only concepts that have one of the provided ids. To provide multiple ids, separate by comma (,)."
     )
+    protected val aggregatePaths = Param[Option[Seq[String]]](
+      "aggregate-paths",
+      "List of index-paths that should be term-aggregated and returned in result."
+    )
     protected val conceptType = Param[Option[String]](
       "concept-type",
       s"Return only concepts of given type. Allowed values are ${ConceptType.values.mkString(",")}"

--- a/concept-api/src/main/scala/no/ndla/conceptapi/controller/PublishedConceptController.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/controller/PublishedConceptController.scala
@@ -73,7 +73,8 @@ trait PublishedConceptController {
         shouldScroll: Boolean,
         embedResource: Option[String],
         embedId: Option[String],
-        conceptType: Option[String]
+        conceptType: Option[String],
+        aggregatePaths: List[String]
     ) = {
       val settings = SearchSettings(
         withIdIn = idList,
@@ -88,7 +89,8 @@ trait PublishedConceptController {
         shouldScroll = shouldScroll,
         embedResource = embedResource,
         embedId = embedId,
-        conceptType = conceptType
+        conceptType = conceptType,
+        aggregatePaths = aggregatePaths
       )
 
       val result = query.emptySomeToNone match {
@@ -154,7 +156,8 @@ trait PublishedConceptController {
             asQueryParam(exactTitleMatch),
             asQueryParam(embedResource),
             asQueryParam(embedId),
-            asQueryParam(conceptType)
+            asQueryParam(conceptType),
+            asQueryParam(aggregatePaths)
           )
           authorizations "oauth2"
           responseMessages response500
@@ -177,6 +180,7 @@ trait PublishedConceptController {
         val embedResource   = paramOrNone(this.embedResource.paramName)
         val embedId         = paramOrNone(this.embedId.paramName)
         val conceptType     = paramOrNone(this.conceptType.paramName)
+        val aggregatePaths  = paramAsListOfString(this.aggregatePaths.paramName)
 
         search(
           query,
@@ -192,7 +196,8 @@ trait PublishedConceptController {
           shouldScroll,
           embedResource,
           embedId,
-          conceptType
+          conceptType,
+          aggregatePaths
         )
 
       }
@@ -233,6 +238,7 @@ trait PublishedConceptController {
             val embedResource   = searchParams.embedResource
             val embedId         = searchParams.embedId
             val conceptType     = searchParams.conceptType
+            val aggregatePaths  = searchParams.aggregatePaths
 
             search(
               query,
@@ -248,7 +254,8 @@ trait PublishedConceptController {
               shouldScroll,
               embedResource,
               embedId,
-              conceptType
+              conceptType,
+              aggregatePaths
             )
           case Failure(ex) => errorHandler(ex)
         }

--- a/concept-api/src/main/scala/no/ndla/conceptapi/model/api/ConceptSearchParams.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/model/api/ConceptSearchParams.scala
@@ -28,4 +28,5 @@ case class ConceptSearchParams(
   @(ApiModelProperty @field)(description = "Embed resource type that should exist in the concepts.") embedResource: Option[String],
   @(ApiModelProperty @field)(description = "Embed id attribute that should exist in the concepts.") embedId: Option[String],
   @(ApiModelProperty @field)(description = "The type of concepts to return.") conceptType: Option[String],
+  @(ApiModelProperty @field)(description = "A list of index paths to aggregate over") aggregatePaths: List[String],
 )

--- a/concept-api/src/main/scala/no/ndla/conceptapi/model/api/ConceptSearchResult.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/model/api/ConceptSearchResult.scala
@@ -7,6 +7,7 @@
 
 package no.ndla.conceptapi.model.api
 
+import no.ndla.search.api.MultiSearchTermsAggregation
 import org.scalatra.swagger.annotations.{ApiModel, ApiModelProperty}
 
 import scala.annotation.meta.field
@@ -17,5 +18,8 @@ case class ConceptSearchResult(
     @(ApiModelProperty @field)(description = "For which page results are shown from") page: Option[Int],
     @(ApiModelProperty @field)(description = "The number of results per page") pageSize: Int,
     @(ApiModelProperty @field)(description = "The chosen search language") language: String,
-    @(ApiModelProperty @field)(description = "The search results") results: Seq[ConceptSummary]
+    @(ApiModelProperty @field)(description = "The search results") results: Seq[ConceptSummary],
+    @(ApiModelProperty @field)(description = "The aggregated fields if specified in query") aggregations: Seq[
+      MultiSearchTermsAggregation
+    ]
 )

--- a/concept-api/src/main/scala/no/ndla/conceptapi/model/api/DraftConceptSearchParams.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/model/api/DraftConceptSearchParams.scala
@@ -30,4 +30,5 @@ case class DraftConceptSearchParams(
   @(ApiModelProperty @field)(description = "Embed id attribute that should exist in the concepts.") embedId: Option[String],
   @(ApiModelProperty @field)(description = "A comma-separated list of NDLA IDs to filter the search by.") responsibleIds: List[String],
   @(ApiModelProperty @field)(description = "The type of concepts to return.") conceptType: Option[String],
+  @(ApiModelProperty @field)(description = "A list of index paths to aggregate over") aggregatePaths: List[String],
 )

--- a/concept-api/src/main/scala/no/ndla/conceptapi/model/domain/SearchResult.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/model/domain/SearchResult.scala
@@ -7,11 +7,14 @@
 
 package no.ndla.conceptapi.model.domain
 
+import no.ndla.search.model.domain.TermAggregation
+
 case class SearchResult[T](
     totalCount: Long,
     page: Option[Int],
     pageSize: Int,
     language: String,
     results: Seq[T],
+    aggregations: Seq[TermAggregation],
     scrollId: Option[String]
 )

--- a/concept-api/src/main/scala/no/ndla/conceptapi/model/search/DraftSearchSettings.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/model/search/DraftSearchSettings.scala
@@ -26,7 +26,8 @@ case class DraftSearchSettings(
     embedResource: Option[String],
     embedId: Option[String],
     responsibleIdFilter: List[String],
-    conceptType: Option[String]
+    conceptType: Option[String],
+    aggregatePaths: List[String]
 )
 
 trait DraftSearchSettingsHelper {
@@ -48,7 +49,8 @@ trait DraftSearchSettingsHelper {
         embedResource = None,
         embedId = None,
         responsibleIdFilter = List.empty,
-        conceptType = None
+        conceptType = None,
+        aggregatePaths = List.empty
       )
     }
   }

--- a/concept-api/src/main/scala/no/ndla/conceptapi/model/search/SearchSettings.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/model/search/SearchSettings.scala
@@ -24,7 +24,8 @@ case class SearchSettings(
     shouldScroll: Boolean,
     embedResource: Option[String],
     embedId: Option[String],
-    conceptType: Option[String]
+    conceptType: Option[String],
+    aggregatePaths: List[String]
 )
 
 trait SearchSettingsHelper {
@@ -44,7 +45,8 @@ trait SearchSettingsHelper {
         shouldScroll = false,
         embedResource = None,
         embedId = None,
-        conceptType = None
+        conceptType = None,
+        aggregatePaths = List.empty
       )
     }
   }

--- a/concept-api/src/main/scala/no/ndla/conceptapi/service/search/SearchConverterService.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/service/search/SearchConverterService.scala
@@ -20,6 +20,7 @@ import no.ndla.conceptapi.model.{api, domain}
 import no.ndla.conceptapi.service.ConverterService
 import no.ndla.language.Language.{UnknownLanguage, findByLanguageOrBestEffort, getSupportedLanguages}
 import no.ndla.mapping.ISO639
+import no.ndla.search.AggregationBuilder.toApiMultiTermsAggregation
 import no.ndla.search.SearchConverter.getEmbedValues
 import no.ndla.search.model.domain.EmbedValues
 import no.ndla.search.model.{LanguageValue, SearchableLanguageFormats, SearchableLanguageList, SearchableLanguageValues}
@@ -238,7 +239,8 @@ trait SearchConverterService {
         searchResult.page,
         searchResult.pageSize,
         searchResult.language,
-        searchResult.results
+        searchResult.results,
+        searchResult.aggregations.map(toApiMultiTermsAggregation)
       )
 
     def toApiStatus(status: Status): api.Status = {

--- a/concept-api/src/main/scala/no/ndla/conceptapi/service/search/SearchService.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/service/search/SearchService.scala
@@ -21,6 +21,7 @@ import no.ndla.conceptapi.model.domain.{SearchResult, Sort}
 import no.ndla.language.Language
 import no.ndla.language.Language.{AllLanguages, NoLanguage}
 import no.ndla.mapping.ISO639
+import no.ndla.search.AggregationBuilder.getAggregationsFromResult
 import no.ndla.search.{Elastic4sClient, IndexNotFoundException, NdlaSearchException}
 
 import java.lang.Math.max
@@ -48,6 +49,7 @@ trait SearchService {
             pageSize = response.result.hits.hits.length,
             language = if (language == "*") AllLanguages else language,
             results = hits,
+            aggregations = getAggregationsFromResult(response.result),
             scrollId = response.result.scrollId
           )
         })

--- a/concept-api/src/test/scala/no/ndla/conceptapi/controller/DraftConceptControllerTest.scala
+++ b/concept-api/src/test/scala/no/ndla/conceptapi/controller/DraftConceptControllerTest.scala
@@ -208,7 +208,7 @@ class DraftConceptControllerTest extends UnitSuite with TestEnvironment with Sca
     reset(draftConceptSearchService)
 
     val multiResult =
-      SearchResult[ConceptSummary](0, None, 10, "nn", Seq.empty, Some("heiheihei"))
+      SearchResult[ConceptSummary](0, None, 10, "nn", Seq.empty, Seq.empty, Some("heiheihei"))
     when(draftConceptSearchService.all(any[search.DraftSearchSettings])).thenReturn(Success(multiResult))
 
     val expectedSettings =

--- a/concept-api/src/test/scala/no/ndla/conceptapi/controller/PublishedConceptControllerTest.scala
+++ b/concept-api/src/test/scala/no/ndla/conceptapi/controller/PublishedConceptControllerTest.scala
@@ -65,7 +65,7 @@ class PublishedConceptControllerTest extends UnitSuite with TestEnvironment with
     reset(publishedConceptSearchService)
 
     val multiResult =
-      SearchResult[ConceptSummary](0, None, 10, "nn", Seq.empty, Some("heiheihei"))
+      SearchResult[ConceptSummary](0, None, 10, "nn", Seq.empty, Seq.empty, Some("heiheihei"))
     when(publishedConceptSearchService.all(any[SearchSettings])).thenReturn(Success(multiResult))
 
     val expectedSettings =

--- a/concept-api/src/test/scala/no/ndla/conceptapi/service/search/DraftConceptSearchServiceTest.scala
+++ b/concept-api/src/test/scala/no/ndla/conceptapi/service/search/DraftConceptSearchServiceTest.scala
@@ -228,7 +228,8 @@ class DraftConceptSearchServiceTest extends IntegrationSuite(EnableElasticsearch
     embedResource = None,
     embedId = None,
     responsibleIdFilter = List.empty,
-    conceptType = None
+    conceptType = None,
+    aggregatePaths = List.empty
   )
 
   override def beforeAll(): Unit = {

--- a/search-api/src/main/scala/no/ndla/searchapi/model/api/GroupSearchResult.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/model/api/GroupSearchResult.scala
@@ -7,7 +7,9 @@
 
 package no.ndla.searchapi.model.api
 
+import no.ndla.search.api.MultiSearchTermsAggregation
 import org.scalatra.swagger.annotations.{ApiModel, ApiModelProperty}
+
 import scala.annotation.meta.field
 
 // format: off

--- a/search-api/src/main/scala/no/ndla/searchapi/model/api/MultiSearchResult.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/model/api/MultiSearchResult.scala
@@ -7,6 +7,7 @@
 
 package no.ndla.searchapi.model.api
 
+import no.ndla.search.api.MultiSearchTermsAggregation
 import org.scalatra.swagger.annotations.{ApiModel, ApiModelProperty}
 
 import scala.annotation.meta.field

--- a/search-api/src/main/scala/no/ndla/searchapi/model/domain/SearchResult.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/model/domain/SearchResult.scala
@@ -6,6 +6,7 @@
  */
 
 package no.ndla.searchapi.model.domain
+import no.ndla.search.model.domain.TermAggregation
 import no.ndla.searchapi.model.api.{MultiSearchSuggestion, MultiSearchSummary}
 
 case class SearchResult(

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/MultiDraftSearchService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/MultiDraftSearchService.scala
@@ -17,6 +17,7 @@ import no.ndla.common.model.domain.draft.DraftStatus
 import no.ndla.language.Language.AllLanguages
 import no.ndla.language.model.Iso639
 import no.ndla.network.model.RequestInfo
+import no.ndla.search.AggregationBuilder.{buildTermsAggregation, getAggregationsFromResult}
 import no.ndla.search.Elastic4sClient
 import no.ndla.searchapi.Props
 import no.ndla.searchapi.model.api.ErrorHelpers
@@ -108,7 +109,7 @@ trait MultiDraftSearchService {
         Failure(ResultWindowTooLargeException())
       } else {
 
-        val aggregations = buildTermsAggregation(settings.aggregatePaths)
+        val aggregations = buildTermsAggregation(settings.aggregatePaths, indexServices.map(_.getMapping))
 
         val searchToExecute = search(searchIndex)
           .query(filteredSearch)

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/MultiSearchService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/MultiSearchService.scala
@@ -15,6 +15,7 @@ import no.ndla.common.model.domain.Availability
 import no.ndla.language.Language.AllLanguages
 import no.ndla.language.model.Iso639
 import no.ndla.network.model.RequestInfo
+import no.ndla.search.AggregationBuilder.{buildTermsAggregation, getAggregationsFromResult}
 import no.ndla.search.Elastic4sClient
 import no.ndla.searchapi.Props
 import no.ndla.searchapi.model.api.ErrorHelpers
@@ -97,7 +98,7 @@ trait MultiSearchService {
         Failure(ResultWindowTooLargeException())
       } else {
 
-        val aggregations = buildTermsAggregation(settings.aggregatePaths)
+        val aggregations = buildTermsAggregation(settings.aggregatePaths, indexServices.map(_.getMapping))
 
         val searchToExecute = search(searchIndex)
           .query(filteredSearch)

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
@@ -20,6 +20,7 @@ import no.ndla.language.Language.{UnknownLanguage, findByLanguageOrBestEffort, g
 import no.ndla.language.model.Iso639
 import no.ndla.mapping.ISO639
 import no.ndla.mapping.License.getLicense
+import no.ndla.search.AggregationBuilder.toApiMultiTermsAggregation
 import no.ndla.search.SearchConverter.getEmbedValues
 import no.ndla.search.model.domain.EmbedValues
 import no.ndla.search.model.{LanguageValue, SearchableLanguageFormats, SearchableLanguageList, SearchableLanguageValues}
@@ -766,19 +767,6 @@ trait SearchConverterService {
             .toList
       }
     }
-
-    private def toApiMultiTermsAggregation(agg: domain.TermAggregation): api.MultiSearchTermsAggregation =
-      api.MultiSearchTermsAggregation(
-        field = agg.field.mkString("."),
-        sumOtherDocCount = agg.sumOtherDocCount,
-        docCountErrorUpperBound = agg.docCountErrorUpperBound,
-        values = agg.buckets.map(b =>
-          api.TermValue(
-            value = b.value,
-            count = b.count
-          )
-        )
-      )
 
     def toApiMultiSearchResult(searchResult: domain.SearchResult): MultiSearchResult =
       api.MultiSearchResult(

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/SearchService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/SearchService.scala
@@ -7,12 +7,9 @@
 
 package no.ndla.searchapi.service.search
 
-import cats.data.NonEmptySeq
 import cats.implicits._
 import com.sksamuel.elastic4s.ElasticDsl._
-import com.sksamuel.elastic4s.fields.{ElasticField, NestedField, ObjectField, TextField}
 import com.sksamuel.elastic4s.handlers.searches.suggestion.{DirectGenerator, PhraseSuggestion}
-import com.sksamuel.elastic4s.requests.searches.aggs.Aggregation
 import com.sksamuel.elastic4s.requests.searches.queries.compound.BoolQuery
 import com.sksamuel.elastic4s.requests.searches.queries.{NestedQuery, Query, SimpleStringQuery}
 import com.sksamuel.elastic4s.requests.searches.sort.{FieldSort, SortOrder}
@@ -22,6 +19,7 @@ import SortOrder.{Asc, Desc}
 import com.typesafe.scalalogging.StrictLogging
 import no.ndla.language.Language
 import no.ndla.language.model.Iso639
+import no.ndla.search.AggregationBuilder.getAggregationsFromResult
 import no.ndla.search.{Elastic4sClient, IndexNotFoundException, NdlaSearchException, SearchLanguage}
 import no.ndla.searchapi.Props
 import no.ndla.searchapi.model.api.{MultiSearchSuggestion, MultiSearchSummary, SearchSuggestion, SuggestOption}
@@ -30,7 +28,6 @@ import no.ndla.searchapi.model.domain._
 import no.ndla.searchapi.model.search.SearchType
 
 import java.lang.Math.max
-import scala.annotation.tailrec
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
 
@@ -177,129 +174,6 @@ trait SearchService {
       response.suggestions.map { case (key, value) =>
         MultiSearchSuggestion(name = key, suggestions = getSuggestion(value))
       }.toSeq
-    }
-
-    protected[search] def buildTermsAggregation(paths: Seq[String]): Seq[Aggregation] = {
-      val indexRootFields: Seq[ElasticField] = indexServices.flatMap(_.getMapping.properties)
-      val aggregationTrees        = paths.flatMap(p => buildAggregationTreeFromPath(p, indexRootFields).toSeq)
-      val initialFakeAggregations = aggregationTrees.flatMap(FakeAgg.seqAggsToSubAggs(_).toSeq)
-      val mergedFakeAggregations  = mergeAllFakeAggregations(initialFakeAggregations)
-      mergedFakeAggregations.map(_.convertToReal())
-    }
-
-    /** This method merges all the [[FakeAgg]]'s that can be merged together */
-    private def mergeAllFakeAggregations(initialFakeAggregations: Seq[FakeAgg]): Seq[FakeAgg] =
-      initialFakeAggregations.foldLeft(Seq.empty[FakeAgg])((acc, fakeAgg) => {
-        val (hasBeenMerged, merged) = acc.foldLeft((false, Seq.empty[FakeAgg]))((acc, toMerge) => {
-          val (curHasBeenMerged, aggs) = acc
-          fakeAgg.merge(toMerge) match {
-            case Some(merged) => true             -> (aggs :+ merged)
-            case None         => curHasBeenMerged -> (aggs :+ toMerge)
-          }
-        })
-        if (hasBeenMerged) merged else merged :+ fakeAgg
-      })
-
-    private def buildAggregationTreeFromPath(path: String, fieldsInIndex: Seq[ElasticField]): Option[Seq[FakeAgg]] = {
-      @tailrec
-      def _buildAggregationRecursive(
-          parts: Seq[String],
-          fullPath: String,
-          fieldsInIndex: Seq[ElasticField],
-          remainder: Seq[String],
-          parentAgg: Seq[FakeAgg]
-      ): Option[(Seq[FakeAgg], Seq[String])] = if (parts.isEmpty) { None }
-      else {
-        val matchingIndexFields: Seq[ElasticField] = fieldsInIndex.filter(_.name == parts.mkString("."))
-        NonEmptySeq.fromSeq(matchingIndexFields) match {
-          case None =>
-            val (newPath, restOfPath) = parts.splitAt(math.max(parts.size - 1, 1))
-            if (parts == newPath) { None }
-            else { _buildAggregationRecursive(newPath, fullPath, fieldsInIndex, restOfPath ++ remainder, parentAgg) }
-          case Some(fieldsFound) =>
-            val fieldTypes    = fieldsFound.map(_.`type`).distinct
-            val pathSoFar     = parts.mkString(".")
-            val fullPathSoFar = fullPath.split("\\.").reverse.dropWhile(_ != parts.last).reverse.mkString(".")
-            val newParent     = newParentAggregation(fullPath, parentAgg, fieldTypes.toList, pathSoFar, fullPathSoFar)
-
-            if (remainder.isEmpty) { Some(newParent -> Seq.empty) }
-            else { _buildAggregationRecursive(remainder, fullPath, subfieldsOf(fieldsFound), Seq.empty, newParent) }
-        }
-      }
-
-      def newParentAggregation(
-          fullPath: String,
-          parentAgg: Seq[FakeAgg],
-          fieldTypes: Seq[String],
-          pathSoFar: String,
-          fullPathSoFar: String
-      ): Seq[FakeAgg] = fieldTypes match {
-        case singleType :: Nil if singleType == "nested" =>
-          val n = FakeNestedAgg(pathSoFar, fullPathSoFar)
-          parentAgg :+ n
-        case singleType :: Nil if singleType == "keyword" =>
-          val n = FakeTermAgg(pathSoFar).field(fullPath)
-          parentAgg :+ n
-        case _ => parentAgg
-      }
-
-      def subfieldsOf(fieldsFound: NonEmptySeq[ElasticField]): Seq[ElasticField] = fieldsFound.head match {
-        case nestedField: NestedField => nestedField.properties
-        case objectField: ObjectField => objectField.properties
-        case textField: TextField     => textField.fields
-        case _                        => Seq.empty
-      }
-
-      _buildAggregationRecursive(path.split("\\.").toSeq, path, fieldsInIndex, Seq.empty, Seq.empty).map(_._1)
-    }
-
-    def getAggregationsFromResult(response: SearchResponse): Seq[TermAggregation] = {
-      getTermsAggregationResults(response.aggs.data)
-    }
-
-    private def convertBuckets(buckets: Seq[Map[String, Any]]): Seq[Bucket] = {
-      buckets
-        .flatMap(bucket => {
-          Try {
-            val key      = bucket("key").asInstanceOf[String]
-            val docCount = bucket("doc_count").asInstanceOf[Int]
-            Bucket(key, docCount)
-          }.toOption
-        })
-    }
-
-    private def handleBucketResult(resMap: Map[String, Any], field: Seq[String]): Seq[TermAggregation] = {
-      Try {
-        val sumOtherDocCount        = resMap("sum_other_doc_count").asInstanceOf[Int]
-        val docCountErrorUpperBound = resMap("doc_count_error_upper_bound").asInstanceOf[Int]
-        val buckets                 = resMap("buckets").asInstanceOf[Seq[Map[String, Any]]]
-
-        TermAggregation(
-          field,
-          sumOtherDocCount,
-          docCountErrorUpperBound,
-          buckets = convertBuckets(buckets)
-        )
-      }.toOption.toSeq
-    }
-
-    private def getTermsAggregationResults(
-        aggregationMap: Map[String, Any],
-        fields: Seq[String] = Seq.empty,
-        foundBuckets: Seq[TermAggregation] = Seq.empty
-    ): Seq[TermAggregation] = aggregationMap.toSeq.flatMap { case (key, map) =>
-      val newMap = Try(map.asInstanceOf[Map[String, Any]]).getOrElse(Map.empty[String, Any])
-
-      val hasBucketAggregationKeys =
-        newMap.contains("buckets") &&
-          newMap.contains("sum_other_doc_count") &&
-          newMap.contains("doc_count_error_upper_bound")
-
-      if (hasBucketAggregationKeys) {
-        handleBucketResult(newMap, fields :+ key)
-      } else {
-        getTermsAggregationResults(newMap, fields :+ key, foundBuckets)
-      }
     }
 
     def getSuggestion(results: Seq[SuggestionResult]): Seq[SearchSuggestion] = {

--- a/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceAtomicTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceAtomicTest.scala
@@ -10,9 +10,9 @@ package no.ndla.searchapi.service.search
 import no.ndla.common.configuration.Constants.EmbedTagName
 import no.ndla.common.model.domain.ArticleContent
 import no.ndla.scalatestsuite.IntegrationSuite
+import no.ndla.search.model.domain.{Bucket, TermAggregation}
 import no.ndla.search.model.{LanguageValue, SearchableLanguageList, SearchableLanguageValues}
 import no.ndla.searchapi.TestData.{core, generateContexts, subjectMaterial}
-import no.ndla.searchapi.model.domain.{Bucket, TermAggregation}
 import no.ndla.searchapi.model.taxonomy._
 import no.ndla.searchapi.{TestData, TestEnvironment}
 import org.scalatest.Outcome

--- a/search-api/src/test/scala/no/ndla/searchapi/service/search/SearchServiceTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/service/search/SearchServiceTest.scala
@@ -8,7 +8,6 @@
 package no.ndla.searchapi.service.search
 
 import no.ndla.searchapi.{TestEnvironment, UnitSuite}
-import com.sksamuel.elastic4s.ElasticDsl._
 import no.ndla.searchapi.model.search.SearchType
 
 class SearchServiceTest extends UnitSuite with TestEnvironment {
@@ -25,89 +24,6 @@ class SearchServiceTest extends UnitSuite with TestEnvironment {
     override val searchIndex = List(SearchIndexes(SearchType.Drafts), SearchIndexes(SearchType.LearningPaths))
     override val indexServices: List[IndexService[_]]     = List(draftIndexService, learningPathIndexService)
     override protected def scheduleIndexDocuments(): Unit = {}
-  }
-
-  test("That building single termsAggregation works as expected") {
-    val res1 = service.buildTermsAggregation(Seq("draftStatus.current"))
-    res1 should be(
-      Seq(
-        termsAgg("draftStatus.current", "draftStatus.current")
-          .size(50)
-      )
-    )
-  }
-
-  test("That building nested termsAggregation works as expected") {
-    val res1 = service.buildTermsAggregation(Seq("contexts.contextType"))
-    res1 should be(
-      Seq(
-        nestedAggregation("contexts", "contexts").subAggregations(
-          termsAgg("contextType", "contexts.contextType").size(50)
-        )
-      )
-    )
-  }
-
-  test("That building nested multiple layers termsAggregation works as expected") {
-    val res1 = service.buildTermsAggregation(Seq("contexts.resourceTypes.id"))
-    res1 should be(
-      Seq(
-        nestedAggregation("contexts", "contexts")
-          .subAggregations(
-            nestedAggregation("resourceTypes", "contexts.resourceTypes")
-              .subAggregations(
-                termsAgg("id", "contexts.resourceTypes.id").size(50)
-              )
-          )
-      )
-    )
-  }
-
-  test("That aggregating paths that requires merging works as expected") {
-    val res1 = service.buildTermsAggregation(Seq("contexts.contextType", "contexts.resourceTypes.id"))
-
-    res1 should be(
-      Seq(
-        nestedAggregation("contexts", "contexts")
-          .subAggregations(
-            nestedAggregation("resourceTypes", "contexts.resourceTypes")
-              .subAggregations(
-                termsAgg("id", "contexts.resourceTypes.id").size(50)
-              ),
-            termsAgg("contextType", "contexts.contextType").size(50)
-          )
-      )
-    )
-  }
-
-  test("That building multiple termsAggregation works as expected") {
-    val res1 = service.buildTermsAggregation(
-      Seq("draftStatus.current", "draftStatus.other", "contexts.contextType", "contexts.resourceTypes.id")
-    )
-    res1 should be(
-      Seq(
-        termsAgg("draftStatus.current", "draftStatus.current").size(50),
-        termsAgg("draftStatus.other", "draftStatus.other").size(50),
-        nestedAggregation("contexts", "contexts")
-          .subAggregations(
-            nestedAggregation("resourceTypes", "contexts.resourceTypes")
-              .subAggregations(
-                termsAgg("id", "contexts.resourceTypes.id").size(50)
-              ),
-            termsAgg("contextType", "contexts.contextType").size(50)
-          )
-      )
-    )
-  }
-
-  test("that passing in an empty list does not crash even though it shouldnt happen") {
-    val res1 = service.buildTermsAggregation(Seq.empty)
-    res1 should be(Seq.empty)
-  }
-
-  test("that passing in a path that doesn't exist doesn't run forever") {
-    val res1 = service.buildTermsAggregation(Seq("contexts.someFieldThatDoesntExist"))
-    res1 should be(Seq.empty)
   }
 
 }

--- a/search/src/main/scala/no/ndla/search/AggregationBuilder.scala
+++ b/search/src/main/scala/no/ndla/search/AggregationBuilder.scala
@@ -1,0 +1,159 @@
+/*
+ * Part of NDLA search
+ * Copyright (C) 2024 NDLA
+ *
+ * See LICENSE
+ */
+
+package no.ndla.search
+
+import cats.data.NonEmptySeq
+import cats.implicits.toFoldableOps
+import com.sksamuel.elastic4s.fields.{ElasticField, NestedField, ObjectField, TextField}
+import com.sksamuel.elastic4s.requests.mappings.MappingDefinition
+import com.sksamuel.elastic4s.requests.searches.SearchResponse
+import com.sksamuel.elastic4s.requests.searches.aggs.Aggregation
+import no.ndla.search.api.{MultiSearchTermsAggregation, TermValue}
+import no.ndla.search.model.domain.{Bucket, TermAggregation}
+
+import scala.annotation.tailrec
+import scala.util.Try
+
+object AggregationBuilder {
+  def buildTermsAggregation(paths: Seq[String], mappings: List[MappingDefinition]): Seq[Aggregation] = {
+    val indexRootFields: Seq[ElasticField] = mappings.flatMap(_.properties)
+    val aggregationTrees                   = paths.flatMap(p => buildAggregationTreeFromPath(p, indexRootFields).toSeq)
+    val initialFakeAggregations            = aggregationTrees.flatMap(FakeAgg.seqAggsToSubAggs(_).toSeq)
+    val mergedFakeAggregations             = mergeAllFakeAggregations(initialFakeAggregations)
+    mergedFakeAggregations.map(_.convertToReal())
+  }
+
+  /** This method merges all the [[FakeAgg]]'s that can be merged together */
+  private def mergeAllFakeAggregations(initialFakeAggregations: Seq[FakeAgg]): Seq[FakeAgg] =
+    initialFakeAggregations.foldLeft(Seq.empty[FakeAgg])((acc, fakeAgg) => {
+      val (hasBeenMerged, merged) = acc.foldLeft((false, Seq.empty[FakeAgg]))((acc, toMerge) => {
+        val (curHasBeenMerged, aggs) = acc
+        fakeAgg.merge(toMerge) match {
+          case Some(merged) => true             -> (aggs :+ merged)
+          case None         => curHasBeenMerged -> (aggs :+ toMerge)
+        }
+      })
+      if (hasBeenMerged) merged else merged :+ fakeAgg
+    })
+
+  private def buildAggregationTreeFromPath(path: String, fieldsInIndex: Seq[ElasticField]): Option[Seq[FakeAgg]] = {
+    @tailrec
+    def _buildAggregationRecursive(
+        parts: Seq[String],
+        fullPath: String,
+        fieldsInIndex: Seq[ElasticField],
+        remainder: Seq[String],
+        parentAgg: Seq[FakeAgg]
+    ): Option[(Seq[FakeAgg], Seq[String])] = if (parts.isEmpty) { None }
+    else {
+      val matchingIndexFields: Seq[ElasticField] = fieldsInIndex.filter(_.name == parts.mkString("."))
+      NonEmptySeq.fromSeq(matchingIndexFields) match {
+        case None =>
+          val (newPath, restOfPath) = parts.splitAt(math.max(parts.size - 1, 1))
+          if (parts == newPath) { None }
+          else { _buildAggregationRecursive(newPath, fullPath, fieldsInIndex, restOfPath ++ remainder, parentAgg) }
+        case Some(fieldsFound) =>
+          val fieldTypes    = fieldsFound.map(_.`type`).distinct
+          val pathSoFar     = parts.mkString(".")
+          val fullPathSoFar = fullPath.split("\\.").reverse.dropWhile(_ != parts.last).reverse.mkString(".")
+          val newParent     = newParentAggregation(fullPath, parentAgg, fieldTypes.toList, pathSoFar, fullPathSoFar)
+
+          if (remainder.isEmpty) { Some(newParent -> Seq.empty) }
+          else { _buildAggregationRecursive(remainder, fullPath, subfieldsOf(fieldsFound), Seq.empty, newParent) }
+      }
+    }
+
+    def newParentAggregation(
+        fullPath: String,
+        parentAgg: Seq[FakeAgg],
+        fieldTypes: Seq[String],
+        pathSoFar: String,
+        fullPathSoFar: String
+    ): Seq[FakeAgg] = fieldTypes match {
+      case singleType :: Nil if singleType == "nested" =>
+        val n = FakeNestedAgg(pathSoFar, fullPathSoFar)
+        parentAgg :+ n
+      case singleType :: Nil if singleType == "keyword" =>
+        val n = FakeTermAgg(pathSoFar).field(fullPath)
+        parentAgg :+ n
+      case _ => parentAgg
+    }
+
+    def subfieldsOf(fieldsFound: NonEmptySeq[ElasticField]): Seq[ElasticField] = fieldsFound.head match {
+      case nestedField: NestedField => nestedField.properties
+      case objectField: ObjectField => objectField.properties
+      case textField: TextField     => textField.fields
+      case _                        => Seq.empty
+    }
+
+    _buildAggregationRecursive(path.split("\\.").toSeq, path, fieldsInIndex, Seq.empty, Seq.empty).map(_._1)
+  }
+
+  def getAggregationsFromResult(response: SearchResponse): Seq[TermAggregation] = {
+    getTermsAggregationResults(response.aggs.data)
+  }
+
+  private def convertBuckets(buckets: Seq[Map[String, Any]]): Seq[Bucket] = {
+    buckets
+      .flatMap(bucket => {
+        Try {
+          val key      = bucket("key").asInstanceOf[String]
+          val docCount = bucket("doc_count").asInstanceOf[Int]
+          Bucket(key, docCount)
+        }.toOption
+      })
+  }
+
+  private def handleBucketResult(resMap: Map[String, Any], field: Seq[String]): Seq[TermAggregation] = {
+    Try {
+      val sumOtherDocCount        = resMap("sum_other_doc_count").asInstanceOf[Int]
+      val docCountErrorUpperBound = resMap("doc_count_error_upper_bound").asInstanceOf[Int]
+      val buckets                 = resMap("buckets").asInstanceOf[Seq[Map[String, Any]]]
+
+      TermAggregation(
+        field,
+        sumOtherDocCount,
+        docCountErrorUpperBound,
+        buckets = convertBuckets(buckets)
+      )
+    }.toOption.toSeq
+  }
+
+  private def getTermsAggregationResults(
+      aggregationMap: Map[String, Any],
+      fields: Seq[String] = Seq.empty,
+      foundBuckets: Seq[TermAggregation] = Seq.empty
+  ): Seq[TermAggregation] = aggregationMap.toSeq.flatMap { case (key, map) =>
+    val newMap = Try(map.asInstanceOf[Map[String, Any]]).getOrElse(Map.empty[String, Any])
+
+    val hasBucketAggregationKeys =
+      newMap.contains("buckets") &&
+        newMap.contains("sum_other_doc_count") &&
+        newMap.contains("doc_count_error_upper_bound")
+
+    if (hasBucketAggregationKeys) {
+      handleBucketResult(newMap, fields :+ key)
+    } else {
+      getTermsAggregationResults(newMap, fields :+ key, foundBuckets)
+    }
+  }
+
+  def toApiMultiTermsAggregation(agg: TermAggregation): MultiSearchTermsAggregation =
+    MultiSearchTermsAggregation(
+      field = agg.field.mkString("."),
+      sumOtherDocCount = agg.sumOtherDocCount,
+      docCountErrorUpperBound = agg.docCountErrorUpperBound,
+      values = agg.buckets.map(b =>
+        TermValue(
+          value = b.value,
+          count = b.count
+        )
+      )
+    )
+
+}

--- a/search/src/main/scala/no/ndla/search/FakeAgg.scala
+++ b/search/src/main/scala/no/ndla/search/FakeAgg.scala
@@ -1,14 +1,14 @@
 /*
- * Part of NDLA search-api.
- * Copyright (C) 2021 NDLA
+ * Part of NDLA search
+ * Copyright (C) 2024 NDLA
  *
  * See LICENSE
  */
 
-package no.ndla.searchapi.service.search
+package no.ndla.search
 
-import com.sksamuel.elastic4s.requests.searches.aggs.Aggregation
 import com.sksamuel.elastic4s.ElasticDsl._
+import com.sksamuel.elastic4s.requests.searches.aggs.Aggregation
 
 /** [[FakeAgg]] and inheriting classes are an abstraction to easier work with Elastic4s' Aggregations They are usually
   * used by calling `convertToReal()` which returns the real Elasitc4s [[Aggregation]] And then passing them to an

--- a/search/src/main/scala/no/ndla/search/api/MultiSearchTermsAggregation.scala
+++ b/search/src/main/scala/no/ndla/search/api/MultiSearchTermsAggregation.scala
@@ -1,11 +1,11 @@
 /*
- * Part of NDLA search-api
- * Copyright (C) 2021 NDLA
+ * Part of NDLA search
+ * Copyright (C) 2024 NDLA
  *
  * See LICENSE
  */
 
-package no.ndla.searchapi.model.api
+package no.ndla.search.api
 
 import org.scalatra.swagger.annotations.{ApiModel, ApiModelProperty}
 

--- a/search/src/main/scala/no/ndla/search/model/domain/TermAggregation.scala
+++ b/search/src/main/scala/no/ndla/search/model/domain/TermAggregation.scala
@@ -1,11 +1,11 @@
 /*
- * Part of NDLA search-api
- * Copyright (C) 2021 NDLA
+ * Part of NDLA search
+ * Copyright (C) 2024 NDLA
  *
  * See LICENSE
  */
 
-package no.ndla.searchapi.model.domain
+package no.ndla.search.model.domain
 
 case class Bucket(value: String, count: Int)
 case class TermAggregation(

--- a/search/src/test/scala/no/ndla/search/AggregationBuilderTest.scala
+++ b/search/src/test/scala/no/ndla/search/AggregationBuilderTest.scala
@@ -1,0 +1,170 @@
+/*
+ * Part of NDLA search
+ * Copyright (C) 2024 NDLA
+ *
+ * See LICENSE
+ */
+
+package no.ndla.search
+
+import com.sksamuel.elastic4s.ElasticApi.{nestedAggregation, termsAgg}
+import com.sksamuel.elastic4s.ElasticDsl._
+import com.sksamuel.elastic4s.fields.ObjectField
+import com.sksamuel.elastic4s.requests.mappings.MappingDefinition
+import no.ndla.scalatestsuite.UnitTestSuite
+
+class AggregationBuilderTest extends UnitTestSuite {
+
+  val testMapping: MappingDefinition = {
+    val fields = List(
+      ObjectField("domainObject", enabled = Some(false)),
+      intField("id"),
+      keywordField("draftStatus.current"),
+      keywordField("draftStatus.other"),
+      dateField("lastUpdated"),
+      keywordField("license"),
+      keywordField("defaultTitle"),
+      textField("authors"),
+      keywordField("articleType"),
+      keywordField("supportedLanguages"),
+      textField("notes"),
+      textField("previousVersionsNotes"),
+      keywordField("users"),
+      keywordField("grepContexts.code"),
+      textField("grepContexts.title"),
+      keywordField("traits"),
+      ObjectField(
+        "responsible",
+        properties = Seq(
+          keywordField("responsibleId"),
+          dateField("lastUpdated")
+        )
+      ),
+      nestedField("contexts").fields(
+        keywordField("publicId"),
+        keywordField("path"),
+        keywordField("contextType"),
+        keywordField("rootId"),
+        keywordField("parentIds"),
+        keywordField("relevanceId"),
+        booleanField("isActive"),
+        booleanField("isPrimary"),
+        nestedField("resourceTypes").fields(
+          keywordField("id")
+        )
+      ),
+      nestedField("embedResourcesAndIds").fields(
+        keywordField("resource"),
+        keywordField("id"),
+        keywordField("language")
+      ),
+      nestedField("metaImage").fields(
+        keywordField("imageId"),
+        keywordField("altText"),
+        keywordField("language")
+      ),
+      nestedField("revisionMeta").fields(
+        keywordField("id"),
+        dateField("revisionDate"),
+        keywordField("note"),
+        keywordField("status")
+      ),
+      keywordField("nextRevision.id"),
+      keywordField("nextRevision.status"),
+      textField("nextRevision.note"),
+      dateField("nextRevision.revisionDate"),
+      keywordField("priority"),
+      keywordField("defaultParentTopicName"),
+      keywordField("defaultRoot"),
+      keywordField("defaultResourceTypeName")
+    )
+    properties(fields)
+  }
+
+  test("That building single termsAggregation works as expected") {
+    val res1 = AggregationBuilder.buildTermsAggregation(Seq("draftStatus.current"), List(testMapping))
+    res1 should be(
+      Seq(
+        termsAgg("draftStatus.current", "draftStatus.current")
+          .size(50)
+      )
+    )
+  }
+
+  test("That building nested termsAggregation works as expected") {
+    val res1 = AggregationBuilder.buildTermsAggregation(Seq("contexts.contextType"), List(testMapping))
+    res1 should be(
+      Seq(
+        nestedAggregation("contexts", "contexts").subAggregations(
+          termsAgg("contextType", "contexts.contextType").size(50)
+        )
+      )
+    )
+  }
+
+  test("That building nested multiple layers termsAggregation works as expected") {
+    val res1 = AggregationBuilder.buildTermsAggregation(Seq("contexts.resourceTypes.id"), List(testMapping))
+    res1 should be(
+      Seq(
+        nestedAggregation("contexts", "contexts")
+          .subAggregations(
+            nestedAggregation("resourceTypes", "contexts.resourceTypes")
+              .subAggregations(
+                termsAgg("id", "contexts.resourceTypes.id").size(50)
+              )
+          )
+      )
+    )
+  }
+
+  test("That aggregating paths that requires merging works as expected") {
+    val res1 = AggregationBuilder.buildTermsAggregation(
+      Seq("contexts.contextType", "contexts.resourceTypes.id"),
+      List(testMapping)
+    )
+
+    res1 should be(
+      Seq(
+        nestedAggregation("contexts", "contexts")
+          .subAggregations(
+            nestedAggregation("resourceTypes", "contexts.resourceTypes")
+              .subAggregations(
+                termsAgg("id", "contexts.resourceTypes.id").size(50)
+              ),
+            termsAgg("contextType", "contexts.contextType").size(50)
+          )
+      )
+    )
+  }
+
+  test("That building multiple termsAggregation works as expected") {
+    val res1 = AggregationBuilder.buildTermsAggregation(
+      Seq("draftStatus.current", "draftStatus.other", "contexts.contextType", "contexts.resourceTypes.id"),
+      List(testMapping)
+    )
+    res1 should be(
+      Seq(
+        termsAgg("draftStatus.current", "draftStatus.current").size(50),
+        termsAgg("draftStatus.other", "draftStatus.other").size(50),
+        nestedAggregation("contexts", "contexts")
+          .subAggregations(
+            nestedAggregation("resourceTypes", "contexts.resourceTypes")
+              .subAggregations(
+                termsAgg("id", "contexts.resourceTypes.id").size(50)
+              ),
+            termsAgg("contextType", "contexts.contextType").size(50)
+          )
+      )
+    )
+  }
+
+  test("that passing in an empty list does not crash even though it shouldnt happen") {
+    val res1 = AggregationBuilder.buildTermsAggregation(Seq.empty, List(testMapping))
+    res1 should be(Seq.empty)
+  }
+
+  test("that passing in a path that doesn't exist doesn't run forever") {
+    val res1 = AggregationBuilder.buildTermsAggregation(Seq("contexts.someFieldThatDoesntExist"), List(testMapping))
+    res1 should be(Seq.empty)
+  }
+}


### PR DESCRIPTION
Katrine ville ha

Kan testes ved å se at `/concept-api/v1/concepts/?aggregate-paths=subjectIds` feks returnerer noe fornuftig :smile: 