### PR TITLE
Mark endpoints moved to myndla-api as deprecated.

### DIFF
--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/controller/ConfigController.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/controller/ConfigController.scala
@@ -73,6 +73,7 @@ trait ConfigController {
           .parameters(
             asPathParam(configKeyPathParam)
           )
+          .deprecated(true)
           .responseMessages(response400, response403, response404, response500)
           .authorizations("oauth2")
       )
@@ -91,6 +92,7 @@ trait ConfigController {
             asPathParam(configKeyPathParam),
             bodyParam[ConfigMetaValue]
           )
+          .deprecated(true)
           .responseMessages(response400, response404, response403, response500)
           .authorizations("oauth2")
       )

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/controller/FolderController.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/controller/FolderController.scala
@@ -92,6 +92,7 @@ trait FolderController {
             asQueryParam(includeSubfolders),
             asQueryParam(includeResources)
           )
+          .deprecated(true)
           .responseMessages(response400, response403, response404, response500, response502)
           .authorizations("oauth2")
       )
@@ -116,6 +117,7 @@ trait FolderController {
             asQueryParam(includeResources),
             asQueryParam(includeSubfolders)
           )
+          .deprecated(true)
           .responseMessages(response400, response403, response404, response500, response502)
           .authorizations("oauth2")
       )
@@ -137,6 +139,7 @@ trait FolderController {
             asHeaderParam(feideToken),
             bodyParam[NewFolder]
           )
+          .deprecated(true)
           .responseMessages(response400, response403, response404, response500, response502)
           .authorizations("oauth2")
       )
@@ -159,6 +162,7 @@ trait FolderController {
             asPathParam(folderId),
             bodyParam[UpdatedFolder]
           )
+          .deprecated(true)
           .responseMessages(response400, response403, response404, response500, response502)
           .authorizations("oauth2")
       )
@@ -179,6 +183,7 @@ trait FolderController {
             asHeaderParam(feideToken),
             asPathParam(folderId)
           )
+          .deprecated(true)
           .responseMessages(response204, response400, response403, response404, response500, response502)
           .authorizations("oauth2")
       )
@@ -200,6 +205,7 @@ trait FolderController {
             asHeaderParam(feideToken),
             asQueryParam(size)
           )
+          .deprecated(true)
           .responseMessages(response400, response403, response404, response500, response502)
           .authorizations("oauth2")
       )
@@ -226,6 +232,7 @@ trait FolderController {
             asPathParam(folderId),
             bodyParam[NewResource]
           )
+          .deprecated(true)
           .responseMessages(response400, response403, response404, response500, response502)
           .authorizations("oauth2")
       )
@@ -247,6 +254,7 @@ trait FolderController {
             asPathParam(resourceId),
             bodyParam[UpdatedResource]
           )
+          .deprecated(true)
           .responseMessages(response400, response403, response404, response500, response502)
           .authorizations("oauth2")
       )
@@ -268,6 +276,7 @@ trait FolderController {
             asPathParam(folderId),
             asPathParam(resourceId)
           )
+          .deprecated(true)
           .responseMessages(response204, response400, response403, response404, response500, response502)
           .authorizations("oauth2")
       )
@@ -290,6 +299,7 @@ trait FolderController {
           .parameters(
             asPathParam(folderId)
           )
+          .deprecated(true)
           .responseMessages(response400, response404, response500, response502)
           .authorizations("oauth2")
       )
@@ -308,6 +318,7 @@ trait FolderController {
             asPathParam(folderId),
             asQueryParam(folderStatus)
           )
+          .deprecated(true)
           .responseMessages(response204, response400, response404, response500, response502)
           .authorizations("oauth2")
       )
@@ -330,6 +341,7 @@ trait FolderController {
             asPathParam(sourceId),
             asQueryParam(destinationId)
           )
+          .deprecated(true)
           .responseMessages(response400, response403, response404, response500, response502)
           .authorizations("oauth2")
       )
@@ -351,6 +363,7 @@ trait FolderController {
             asHeaderParam(feideToken),
             bodyParam[FolderSortRequest]
           )
+          .deprecated(true)
       )
     ) {
       for {
@@ -372,6 +385,7 @@ trait FolderController {
             bodyParam[FolderSortRequest],
             asQueryParam(folderIdQuery)
           )
+          .deprecated(true)
       )
     ) {
       for {

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/controller/StatsController.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/controller/StatsController.scala
@@ -40,6 +40,7 @@ trait StatsController {
           .summary("Get stats for my-ndla usage.")
           .description("Get stats for my-ndla usage.")
           .responseMessages(response404, response500, response502)
+          .deprecated(true)
       )
     ) {
       folderReadService.getStats match {

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/controller/UserController.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/controller/UserController.scala
@@ -64,6 +64,7 @@ trait UserController {
           .parameters(
             asHeaderParam(feideToken)
           )
+          .deprecated(true)
           .responseMessages(response403, response500)
           .authorizations("oauth2")
       )
@@ -81,6 +82,7 @@ trait UserController {
             asHeaderParam(feideToken),
             bodyParam[UpdatedMyNDLAUser]
           )
+          .deprecated(true)
           .responseMessages(response403, response404, response500)
           .authorizations("oauth2")
       )
@@ -99,6 +101,7 @@ trait UserController {
             asQueryParam(feideId),
             bodyParam[UpdatedMyNDLAUser]
           )
+          .deprecated(true)
           .responseMessages(response403, response404, response500)
           .authorizations("oauth2")
       )
@@ -119,6 +122,7 @@ trait UserController {
           .parameters(
             asHeaderParam(feideToken)
           )
+          .deprecated(true)
           .responseMessages(response403, response500)
           .authorizations("oauth2")
       )
@@ -133,6 +137,7 @@ trait UserController {
           .summary("Export all stored user-related data as a json structure")
           .description("Export all stored user-related data as a json structure")
           .parameters(asHeaderParam(feideToken))
+          .deprecated(true)
       )
     ) {
       folderReadService.exportUserData(requestFeideToken)
@@ -148,6 +153,7 @@ trait UserController {
             asHeaderParam(feideToken),
             bodyParam[ExportedUserData]
           )
+          .deprecated(true)
       )
     ) {
       val importBody = tryExtract[ExportedUserData](request.body)


### PR DESCRIPTION
![image](https://github.com/NDLANO/backend/assets/8956884/bc2db4e2-8167-4637-92b2-b4ec39531725)
