### PR TITLE
Make users fetch stats from myndla-api

### DIFF
--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/controller/StatsController.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/controller/StatsController.scala
@@ -11,14 +11,13 @@ import no.ndla.learningpathapi.Props
 import no.ndla.learningpathapi.model.api.Error
 import no.ndla.learningpathapi.service.ReadService
 import no.ndla.myndla.model.api.Stats
-import no.ndla.myndla.service.FolderReadService
 import no.ndla.network.scalatra.NdlaSwaggerSupport
 import org.json4s.{DefaultFormats, Formats}
 import org.scalatra.swagger.{ResponseMessage, Swagger}
-import org.scalatra.{NotFound, Ok}
+import org.scalatra.MovedPermanently
 
 trait StatsController {
-  this: ReadService with NdlaController with Props with NdlaSwaggerSupport with FolderReadService =>
+  this: ReadService with NdlaController with Props with NdlaSwaggerSupport =>
   val statsController: StatsController
 
   class StatsController(implicit val swagger: Swagger) extends NdlaController with NdlaSwaggerSupport {
@@ -29,9 +28,7 @@ trait StatsController {
     // Additional models used in error responses
     registerModel[Error]()
 
-    val response404: ResponseMessage = ResponseMessage(404, "Not found", Some("Error"))
-    val response500: ResponseMessage = ResponseMessage(500, "Unknown error", Some("Error"))
-    val response502: ResponseMessage = ResponseMessage(502, "Remote error", Some("Error"))
+    private val response301: ResponseMessage = ResponseMessage(301, "Moved permanently", Some("Error"))
 
     get(
       "/",
@@ -39,14 +36,11 @@ trait StatsController {
         apiOperation[Stats]("getStats")
           .summary("Get stats for my-ndla usage.")
           .description("Get stats for my-ndla usage.")
-          .responseMessages(response404, response500, response502)
+          .responseMessages(response301)
           .deprecated(true)
       )
     ) {
-      folderReadService.getStats match {
-        case Some(c) => Ok(c)
-        case None    => NotFound("No stats found")
-      }
+      MovedPermanently("/myndla-api/v1/stats")
     }: Unit
   }
 

--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/controller/StatsControllerTest.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/controller/StatsControllerTest.scala
@@ -8,7 +8,6 @@
 package no.ndla.learningpathapi.controller
 
 import no.ndla.learningpathapi.{TestEnvironment, UnitSuite}
-import no.ndla.myndla.model.api.Stats
 import org.json4s.DefaultFormats
 import org.scalatra.test.scalatest.ScalatraFunSuite
 
@@ -24,10 +23,10 @@ class StatsControllerTest extends UnitSuite with TestEnvironment with ScalatraFu
     resetMocks()
   }
 
-  test("That getting stats returns in fact stats") {
-    when(folderReadService.getStats).thenReturn(Some(Stats(1, 2, 3, 4, 5, 6, List.empty)))
+  test("That getting stats redirects to the correct endpoint") {
     get("/") {
-      status should be(200)
+      status should be(301)
+      response.getHeader("Location") should be("/myndla-api/v1/stats")
     }
   }
 


### PR DESCRIPTION
Testa lokalt og med curl funker det med `curl -L` for å få data fra myndla-api. Via swagger funka det uten endringer.