### PR TITLE
myndla-api: Add stats endpoint for resources

### DIFF
--- a/myndla-api/src/main/scala/no/ndla/myndlaapi/controller/StatsController.scala
+++ b/myndla-api/src/main/scala/no/ndla/myndlaapi/controller/StatsController.scala
@@ -8,7 +8,7 @@
 package no.ndla.myndlaapi.controller
 
 import no.ndla.common.errors.NotFoundException
-import no.ndla.myndla.model.api.Stats
+import no.ndla.myndla.model.api.{SingleResourceStats, Stats}
 import no.ndla.myndla.service.FolderReadService
 import no.ndla.myndlaapi.Eff
 import no.ndla.network.tapir.NoNullJsonPrinter.jsonBody
@@ -22,8 +22,7 @@ import sttp.tapir.generic.auto._
 trait StatsController {
   this: FolderReadService with TapirErrorHelpers =>
   class StatsController extends Service[Eff] {
-    override val serviceName: String = "stats"
-
+    override val serviceName: String                   = "stats"
     override protected val prefix: EndpointInput[Unit] = "myndla-api" / "v1" / serviceName
 
     def getStats: ServerEndpoint[Any, Eff] = endpoint.get
@@ -37,9 +36,22 @@ trait StatsController {
           case None    => returnLeftError(NotFoundException("No stats found"))
         }
       }
+    private val pathResourceType = path[String]("resourceType").description("The type of the resource to look up")
+    private val pathResourceId   = path[String]("resourceId").description("ID of the resource to look up")
+
+    def getFolderResourceFavorites: ServerEndpoint[Any, Eff] = endpoint.get
+      .summary("Get folder resource favorites")
+      .description("Get folder resource favorites")
+      .in("favorites" / pathResourceType / pathResourceId)
+      .out(jsonBody[SingleResourceStats])
+      .errorOut(errorOutputsFor(404))
+      .serverLogicPure { case (resourceType, resourceId) =>
+        folderReadService.getFavouriteStatsForResource(resourceId, resourceType).handleErrorsOrOk
+      }
 
     override val endpoints: List[ServerEndpoint[Any, Eff]] = List(
-      getStats
+      getStats,
+      getFolderResourceFavorites
     )
   }
 }

--- a/myndla/src/main/scala/no/ndla/myndla/model/api/SingleResourceStats.scala
+++ b/myndla/src/main/scala/no/ndla/myndla/model/api/SingleResourceStats.scala
@@ -1,0 +1,22 @@
+/*
+ * Part of NDLA myndla
+ * Copyright (C) 2024 NDLA
+ *
+ * See LICENSE
+ */
+
+package no.ndla.myndla.model.api
+
+import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
+import io.circe.{Decoder, Encoder}
+import sttp.tapir.Schema.annotations.description
+
+@description("Stats for single resource")
+case class SingleResourceStats(
+    @description("The number of times the resource has been favourited") favourites: Long
+)
+
+object SingleResourceStats {
+  implicit val encoder: Encoder[SingleResourceStats] = deriveEncoder
+  implicit val decoder: Decoder[SingleResourceStats] = deriveDecoder
+}

--- a/myndla/src/main/scala/no/ndla/myndla/model/domain/FolderResource.scala
+++ b/myndla/src/main/scala/no/ndla/myndla/model/domain/FolderResource.scala
@@ -21,7 +21,6 @@ case class FolderResource(folderId: UUID, resourceId: UUID, rank: Int) extends R
 object DBFolderResource extends SQLSyntaxSupport[FolderResource] {
   implicit val formats: Formats = DefaultFormats
   override val tableName        = "folder_resources"
-  // lazy override val schemaName = Some(props.MetaSchema)
 
   def fromResultSet(lp: SyntaxProvider[FolderResource])(rs: WrappedResultSet): Try[FolderResource] =
     fromResultSet(s => lp.resultName.c(s), rs)

--- a/myndla/src/main/scala/no/ndla/myndla/repository/FolderRepository.scala
+++ b/myndla/src/main/scala/no/ndla/myndla/repository/FolderRepository.scala
@@ -302,6 +302,20 @@ trait FolderRepository {
           Success(resourceId)
       }
 
+    def numberOfFavouritesForResource(resourceId: String, resourceType: String)(implicit
+        session: DBSession
+    ): Try[Long] = Try {
+      sql"""
+            select count(*) as count from ${DBFolderResource.table} fr
+            inner join ${DBResource.table} r on fr.resource_id = r.id
+            where r.document->>'resourceId' = $resourceId
+            and r.resource_type = $resourceType
+         """
+        .map(rs => rs.long("count"))
+        .single()
+        .getOrElse(0L)
+    }
+
     def deleteAllUserFolders(feideId: FeideID)(implicit session: DBSession = AutoSession): Try[Int] = {
       Try(sql"delete from ${DBFolder.table} where feide_id = $feideId".update()) match {
         case Failure(ex) => Failure(ex)

--- a/myndla/src/main/scala/no/ndla/myndla/service/FolderReadService.scala
+++ b/myndla/src/main/scala/no/ndla/myndla/service/FolderReadService.scala
@@ -12,7 +12,7 @@ import cats.implicits._
 import no.ndla.common.Clock
 import no.ndla.common.errors.NotFoundException
 import no.ndla.myndla.FavoriteFolderDefaultName
-import no.ndla.myndla.model.api.Folder
+import no.ndla.myndla.model.api.{Folder, SingleResourceStats}
 import no.ndla.myndla.model.domain.FolderStatus
 import no.ndla.myndla.model.{api, domain}
 import no.ndla.myndla.repository.{FolderRepository, UserRepository}
@@ -264,6 +264,13 @@ trait FolderReadService {
 
     def exportUserData(maybeFeideToken: Option[FeideAccessToken]): Try[api.ExportedUserData] = {
       withFeideId(maybeFeideToken)(feideId => exportUserDataAuthenticated(maybeFeideToken, feideId))
+    }
+
+    def getFavouriteStatsForResource(resourceId: String, resourceType: String): Try[SingleResourceStats] = {
+      implicit val session: DBSession = folderRepository.getSession(true)
+      folderRepository
+        .numberOfFavouritesForResource(resourceId, resourceType)
+        .map(totalCount => api.SingleResourceStats(totalCount))
     }
 
     private def exportUserDataAuthenticated(

--- a/project/myndlaapi.scala
+++ b/project/myndlaapi.scala
@@ -59,7 +59,9 @@ object myndlaapi extends Module {
       "PaginatedTopics",
       "PaginatedPosts",
       "PaginatedNewPostNotifications",
-      "Post"
+      "Post",
+      "Stats",
+      "SingleResourceStats"
     )
   )
 

--- a/typescript/myndla-api.ts
+++ b/typescript/myndla-api.ts
@@ -197,6 +197,25 @@ export interface IResource {
   rank?: number
 }
 
+export interface IResourceStats {
+  type: string
+  number: number
+}
+
+export interface ISingleResourceStats {
+  favourites: number
+}
+
+export interface IStats {
+  numberOfUsers: number
+  numberOfFolders: number
+  numberOfResources: number
+  numberOfTags: number
+  numberOfSubjects: number
+  numberOfSharedFolders: number
+  favouritedResources: IResourceStats[]
+}
+
 export interface ITopic {
   id: number
   title: string


### PR DESCRIPTION
Relates to https://github.com/NDLANO/Issues/issues/3943

Legger til et endepunkt som ser sånn ca sånn her ut:

```http

GET /myndla-api/v1/stats/favorites/resource/30543?resourceType=article
```

Som svarer med noe som ligner på dette
```json
{
  "favourites": 14
}
```