### PR TITLE
Fix type generation of `ResourceType`

### DIFF
--- a/.github/workflows/typescript-generate.yml
+++ b/.github/workflows/typescript-generate.yml
@@ -43,6 +43,8 @@ jobs:
           --password-stdin
       - name: Generate typescript types
         run: sbt generateTypescript
+      - name: Verify typescript types
+        run: cd typescript/ && yarn install && yarn tsc
       - name: Commit typescript changes
         continue-on-error: true
         run: |

--- a/.github/workflows/typescript-generate.yml
+++ b/.github/workflows/typescript-generate.yml
@@ -2,6 +2,9 @@ name: 'Generate typescript types'
 on:
   workflow_dispatch:
     inputs: { }
+  push:
+    branches:
+      - master
 env:
   AWS_ACCESS_KEY_ID: ${{ secrets.CI_AWS_CLIENT_ID }}
   AWS_DEFAULT_REGION: eu-west-1

--- a/myndla/src/main/scala/no/ndla/myndla/model/domain/Resource.scala
+++ b/myndla/src/main/scala/no/ndla/myndla/model/domain/Resource.scala
@@ -8,6 +8,8 @@
 package no.ndla.myndla.model.domain
 
 import cats.implicits._
+import com.scalatsi.TypescriptType.{TSLiteralString, TSUnion}
+import com.scalatsi.{TSNamedType, TSType}
 import enumeratum._
 import no.ndla.common.implicits.OptionImplicit
 import no.ndla.common.model.NDLADate
@@ -45,6 +47,9 @@ sealed abstract class ResourceType(override val entryName: String) extends EnumE
 
 object ResourceType extends Enum[ResourceType] with CirceEnum[ResourceType] {
   override val values: IndexedSeq[ResourceType] = findValues
+
+  implicit val enumTsType: TSNamedType[ResourceType] =
+    TSType.alias[ResourceType]("ResourceType", TSUnion(values.map(e => TSLiteralString(e.entryName))))
 
   case object Concept           extends ResourceType("concept")
   case object Image             extends ResourceType("image")

--- a/typescript/learningpath-api.ts
+++ b/typescript/learningpath-api.ts
@@ -2,14 +2,6 @@
 
 export type ArenaGroup = "ADMIN"
 
-export interface IArticle {
-  type: "Article"
-}
-
-export interface IAudio {
-  type: "Audio"
-}
-
 export interface IAuthor {
   type: string
   name: string
@@ -18,10 +10,6 @@ export interface IAuthor {
 export interface IBreadcrumb {
   id: string
   name: string
-}
-
-export interface IConcept {
-  type: "Concept"
 }
 
 export interface IConfigMeta {
@@ -79,10 +67,6 @@ export interface IFolder {
 }
 
 export type IFolderData = IFolder
-
-export interface IImage {
-  type: "Image"
-}
 
 export interface IIntroduction {
   introduction: string
@@ -182,10 +166,6 @@ export interface ILearningStepV2 {
   supportedLanguages: string[]
 }
 
-export interface ILearningpath {
-  type: "Learningpath"
-}
-
 export interface ILicense {
   license: string
   description?: string
@@ -195,10 +175,6 @@ export interface ILicense {
 export interface IMessage {
   message: string
   date: string
-}
-
-export interface IMultidisciplinary {
-  type: "Multidisciplinary"
 }
 
 export interface IMyNDLAGroup {
@@ -275,10 +251,4 @@ export interface IUpdatedResource {
   resourceId?: string
 }
 
-export interface IVideo {
-  type: "Video"
-}
-
-export type ResourceType = (ILearningpath | IVideo | IAudio | IImage | IArticle | IMultidisciplinary | IConcept)
-
-export type ResourceType = (IAudio | IVideo | ILearningpath | IConcept | IArticle | IMultidisciplinary | IImage)
+export type ResourceType = ("concept" | "image" | "audio" | "multidisciplinary" | "article" | "learningpath" | "video")

--- a/typescript/myndla-api.ts
+++ b/typescript/myndla-api.ts
@@ -10,14 +10,6 @@ export interface IArenaUser {
   groups: ArenaGroup[]
 }
 
-export interface IArticle {
-  type: "Article"
-}
-
-export interface IAudio {
-  type: "Audio"
-}
-
 export interface IBreadcrumb {
   id: string
   name: string
@@ -46,10 +38,6 @@ export interface ICategoryWithTopics {
   isFollowing: boolean
   visible: boolean
   rank: number
-}
-
-export interface IConcept {
-  type: "Concept"
 }
 
 export interface IConfigMeta {
@@ -90,18 +78,6 @@ export interface IFolder {
 }
 
 export type IFolderData = IFolder
-
-export interface IImage {
-  type: "Image"
-}
-
-export interface ILearningpath {
-  type: "Learningpath"
-}
-
-export interface IMultidisciplinary {
-  type: "Multidisciplinary"
-}
 
 export interface IMyNDLAGroup {
   id: string
@@ -283,10 +259,4 @@ export interface IUpdatedResource {
   resourceId?: string
 }
 
-export interface IVideo {
-  type: "Video"
-}
-
-export type ResourceType = (ILearningpath | IVideo | IAudio | IImage | IArticle | IMultidisciplinary | IConcept)
-
-export type ResourceType = (IMultidisciplinary | ILearningpath | IAudio | IConcept | IVideo | IArticle | IImage)
+export type ResourceType = ("concept" | "image" | "audio" | "multidisciplinary" | "article" | "learningpath" | "video")


### PR DESCRIPTION
Gjorde visst en liten brøler i [denne](https://github.com/NDLANO/backend/pull/392) som gjorde at typegenereringen gikk litt bananas: 

<img width="399" alt="image" src="https://github.com/NDLANO/backend/assets/7853824/46bc5c4b-648a-4cf1-8010-df9dc3295a53">


Fikser det, og prøver å legge til verifisering av typene før pushing av nye typer for å kanskje unngå flere sånne loops.