### PR TITLE
search-api: Fix input body params

### DIFF
--- a/search-api/src/main/scala/no/ndla/searchapi/controller/SearchController.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/controller/SearchController.scala
@@ -559,7 +559,7 @@ trait SearchController {
       .summary("Find draft learning resources")
       .description("Shows all draft learning resources. You can search too.")
       .in("editorial")
-      .in(jsonBody[Option[DraftSearchParams]])
+      .in(jsonBody[Option[DraftSearchParams]].schema(DraftSearchParams.schema.asOption))
       .errorOut(errorOutputsFor(400, 401, 403))
       .out(jsonBody[MultiSearchResult])
       .out(EndpointOutput.derived[DynamicHeaders])

--- a/search-api/src/main/scala/no/ndla/searchapi/controller/parameters/DraftSearchParams.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/controller/parameters/DraftSearchParams.scala
@@ -10,7 +10,8 @@ package no.ndla.searchapi.controller.parameters
 import io.circe.generic.extras.semiauto.{deriveConfiguredDecoder, deriveConfiguredEncoder}
 import io.circe.{Decoder, Encoder}
 import no.ndla.common.model.NDLADate
-import sttp.tapir.EndpointIO.annotations._
+import sttp.tapir.Schema
+import sttp.tapir.Schema.annotations.description
 
   // format: off
   case class DraftSearchParams(
@@ -129,4 +130,6 @@ object DraftSearchParams {
   import no.ndla.network.tapir.NoNullJsonPrinter._
   implicit val encoder: Encoder[DraftSearchParams] = deriveConfiguredEncoder
   implicit val decoder: Decoder[DraftSearchParams] = deriveConfiguredDecoder
+
+  implicit val schema: Schema[DraftSearchParams] = Schema.derived
 }


### PR DESCRIPTION
Fikser beskrivelser på doc på input-parameteret på post endepunktet.
Skjønner ikke helt hvorfor vi trenger dette, men det funker i alle fall :shrug: 