### PR TITLE
search-api: Use `NonEmptyString` as `query`

### DIFF
--- a/network/src/main/scala/no/ndla/network/tapir/NonEmptyString.scala
+++ b/network/src/main/scala/no/ndla/network/tapir/NonEmptyString.scala
@@ -7,6 +7,7 @@
 
 package no.ndla.network.tapir
 
+import com.scalatsi.TSType
 import io.circe.{Decoder, DecodingFailure, Encoder, HCursor, Json}
 import sttp.tapir.CodecFormat.TextPlain
 import sttp.tapir.{Codec, CodecFormat, DecodeResult, Schema}
@@ -21,7 +22,8 @@ object NonEmptyString {
   def fromOptString(s: Option[String]): Option[NonEmptyString] = s.filter(_.nonEmpty).map(f => new NonEmptyString(f))
   def fromString(s: String): Option[NonEmptyString]            = Option.when(s.nonEmpty)(new NonEmptyString(s))
 
-  implicit val schema: Schema[NonEmptyString] = Schema.string
+  implicit val schema: Schema[NonEmptyString]            = Schema.string
+  implicit val schemaOpt: Schema[Option[NonEmptyString]] = Schema.string.asOption
   implicit val queryParamCodec: Codec[List[String], Option[NonEmptyString], CodecFormat.TextPlain] = {
     Codec
       .id[List[String], TextPlain](TextPlain(), Schema.string)
@@ -31,6 +33,8 @@ object NonEmptyString {
         )
       )(x => x.map(_.underlying).toList)
   }
+
+  implicit val typescriptType: TSType[NonEmptyString] = TSType.sameAs[NonEmptyString, String]
 
   implicit val circeOptionDecoder: Decoder[Option[NonEmptyString]] = (c: HCursor) =>
     c.as[Option[String]].map(maybeStr => fromOptString(maybeStr))

--- a/network/src/test/scala/no/ndla/network/tapir/NonEmptyStringTest.scala
+++ b/network/src/test/scala/no/ndla/network/tapir/NonEmptyStringTest.scala
@@ -55,6 +55,15 @@ class NonEmptyStringTest extends UnitSuite {
     result.cantbeempty.get.underlying should be("spirrevipp")
   }
 
+  test("That decoding missing field returns None for optionals") {
+    import io.circe.generic.auto._
+    case class SomeObject(cantbeempty: Option[NonEmptyString])
+
+    val jsonString           = """{}"""
+    val Right(Right(result)) = io.circe.parser.parse(jsonString).map(_.as[SomeObject])
+    result.cantbeempty should be(None)
+  }
+
   test("That encoding json simply makes a normal string :^)") {
     import io.circe.generic.auto._
     import io.circe.syntax._

--- a/search-api/src/main/scala/no/ndla/searchapi/controller/parameters/DraftSearchParams.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/controller/parameters/DraftSearchParams.scala
@@ -10,6 +10,7 @@ package no.ndla.searchapi.controller.parameters
 import io.circe.generic.extras.semiauto.{deriveConfiguredDecoder, deriveConfiguredEncoder}
 import io.circe.{Decoder, Encoder}
 import no.ndla.common.model.NDLADate
+import no.ndla.network.tapir.NonEmptyString
 import sttp.tapir.Schema
 import sttp.tapir.Schema.annotations.description
 
@@ -40,10 +41,10 @@ import sttp.tapir.Schema.annotations.description
       license: Option[String],
 
       @description("Return only results with content matching the specified query.")
-      query: Option[String],
+      query: Option[NonEmptyString],
 
       @description("Return only results with notes matching the specified note-query.")
-      noteQuery: Option[String],
+      noteQuery: Option[NonEmptyString],
 
       @description("The sorting used on results.")
       sort: Option[String],

--- a/search-api/src/main/scala/no/ndla/searchapi/model/search/settings/MultiDraftSearchSettings.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/model/search/settings/MultiDraftSearchSettings.scala
@@ -10,11 +10,12 @@ package no.ndla.searchapi.model.search.settings
 import no.ndla.common.model.NDLADate
 import no.ndla.common.model.domain.draft.DraftStatus
 import no.ndla.language.Language
+import no.ndla.network.tapir.NonEmptyString
 import no.ndla.searchapi.model.domain.{LearningResourceType, Sort}
 
 case class MultiDraftSearchSettings(
-    query: Option[String],
-    noteQuery: Option[String],
+    query: Option[NonEmptyString],
+    noteQuery: Option[NonEmptyString],
     fallback: Boolean,
     language: String,
     license: Option[String],

--- a/search-api/src/main/scala/no/ndla/searchapi/model/search/settings/SearchSettings.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/model/search/settings/SearchSettings.scala
@@ -8,10 +8,11 @@
 package no.ndla.searchapi.model.search.settings
 
 import no.ndla.common.model.domain.Availability
+import no.ndla.network.tapir.NonEmptyString
 import no.ndla.searchapi.model.domain.{LearningResourceType, Sort}
 
 case class SearchSettings(
-    query: Option[String],
+    query: Option[NonEmptyString],
     fallback: Boolean,
     language: String,
     license: Option[String],

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/MultiDraftSearchService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/MultiDraftSearchService.scala
@@ -67,14 +67,15 @@ trait MultiDraftSearchService {
             langQueryFunc("content", 1),
             langQueryFunc("tags", 1),
             langQueryFunc("embedAttributes", 1),
-            simpleStringQuery(queryString).field("authors", 1),
-            simpleStringQuery(queryString).field("grepContexts.title", 1),
-            idsQuery(queryString),
-            nestedQuery("revisionMeta", simpleStringQuery(queryString).field("revisionMeta.note")).ignoreUnmapped(true)
+            simpleStringQuery(queryString.underlying).field("authors", 1),
+            simpleStringQuery(queryString.underlying).field("grepContexts.title", 1),
+            idsQuery(queryString.underlying),
+            nestedQuery("revisionMeta", simpleStringQuery(queryString.underlying).field("revisionMeta.note"))
+              .ignoreUnmapped(true)
           ) ++
-            getRevisionHistoryLogQuery(queryString, settings.excludeRevisionHistory) ++
-            buildNestedEmbedField(List(queryString), None, settings.language, settings.fallback) ++
-            buildNestedEmbedField(List.empty, Some(queryString), settings.language, settings.fallback)
+            getRevisionHistoryLogQuery(queryString.underlying, settings.excludeRevisionHistory) ++
+            buildNestedEmbedField(List(queryString.underlying), None, settings.language, settings.fallback) ++
+            buildNestedEmbedField(List.empty, Some(queryString.underlying), settings.language, settings.fallback)
         )
 
       })
@@ -82,8 +83,8 @@ trait MultiDraftSearchService {
       val noteSearch = settings.noteQuery.map(q => {
         boolQuery()
           .should(
-            simpleStringQuery(q).field("notes", 1),
-            simpleStringQuery(q).field("previousVersionsNotes", 1)
+            simpleStringQuery(q.underlying).field("notes", 1),
+            simpleStringQuery(q.underlying).field("previousVersionsNotes", 1)
           )
       })
 
@@ -113,7 +114,7 @@ trait MultiDraftSearchService {
 
         val searchToExecute = search(searchIndex)
           .query(filteredSearch)
-          .suggestions(suggestions(settings.query, searchLanguage, settings.fallback))
+          .suggestions(suggestions(settings.query.underlying, searchLanguage, settings.fallback))
           .trackTotalHits(true)
           .from(startAt)
           .size(numResults)

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/MultiSearchService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/MultiSearchService.scala
@@ -65,12 +65,12 @@ trait MultiSearchService {
               langQueryFunc("content", 1),
               langQueryFunc("tags", 1),
               langQueryFunc("embedAttributes", 1),
-              simpleStringQuery(q).field("authors", 1),
-              simpleStringQuery(q).field("grepContexts.title", 1),
-              idsQuery(q)
+              simpleStringQuery(q.underlying).field("authors", 1),
+              simpleStringQuery(q.underlying).field("grepContexts.title", 1),
+              idsQuery(q.underlying)
             ) ++
-              buildNestedEmbedField(List(q), None, settings.language, settings.fallback) ++
-              buildNestedEmbedField(List.empty, Some(q), settings.language, settings.fallback)
+              buildNestedEmbedField(List(q.underlying), None, settings.language, settings.fallback) ++
+              buildNestedEmbedField(List.empty, Some(q.underlying), settings.language, settings.fallback)
           )
         )
       })
@@ -102,7 +102,7 @@ trait MultiSearchService {
 
         val searchToExecute = search(searchIndex)
           .query(filteredSearch)
-          .suggestions(suggestions(settings.query, searchLanguage, settings.fallback))
+          .suggestions(suggestions(settings.query.underlying, searchLanguage, settings.fallback))
           .from(startAt)
           .trackTotalHits(true)
           .size(numResults)

--- a/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceAtomicTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceAtomicTest.scala
@@ -14,6 +14,7 @@ import no.ndla.common.model.NDLADate
 import no.ndla.common.model.domain._
 import no.ndla.common.model.domain.draft.{Draft, DraftStatus, RevisionMeta, RevisionStatus}
 import no.ndla.common.model.domain.{EditorNote, Priority, Responsible}
+import no.ndla.network.tapir.NonEmptyString
 import no.ndla.scalatestsuite.IntegrationSuite
 import no.ndla.search.model.{LanguageValue, SearchableLanguageList, SearchableLanguageValues}
 import no.ndla.searchapi.TestData._
@@ -259,7 +260,7 @@ class MultiDraftSearchServiceAtomicTest
 
     val Success(search1) =
       multiDraftSearchService.matchingQuery(
-        multiDraftSearchSettings.copy(query = Some("trylleformel"))
+        multiDraftSearchSettings.copy(query = Some(NonEmptyString.fromString("trylleformel").get))
       )
 
     search1.totalCount should be(1)
@@ -397,7 +398,7 @@ class MultiDraftSearchServiceAtomicTest
     multiDraftSearchService
       .matchingQuery(
         multiDraftSearchSettings.copy(
-          query = Some("Gris"),
+          query = Some(NonEmptyString.fromString("Gris").get),
           excludeRevisionHistory = true
         )
       )
@@ -408,7 +409,7 @@ class MultiDraftSearchServiceAtomicTest
     multiDraftSearchService
       .matchingQuery(
         multiDraftSearchSettings.copy(
-          query = Some("Gris"),
+          query = Some(NonEmptyString.fromString("Gris").get),
           excludeRevisionHistory = false
         )
       )


### PR DESCRIPTION
Siden vi tryner om vi sender inn en tom streng så tenker jeg vi kan være litt tydeligere med typingen :smile: 