### PR TITLE
Removing legacy fields from context

### DIFF
--- a/search-api/src/main/scala/no/ndla/searchapi/model/api/ApiTaxonomyContext.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/model/api/ApiTaxonomyContext.scala
@@ -14,21 +14,16 @@ import sttp.tapir.Schema.annotations.description
 // format: off
 @description("Taxonomy context for the resource")
 case class ApiTaxonomyContext(
-  @description("Id of the taxonomy object. Legacy field to be removed.") id: String,
   @description("Id of the taxonomy object.") publicId: String,
-  @description("Name of the subject this context is in. Legacy field to be removed.") subject: String,
   @description("Name of the root node this context is in.") root: String,
-  @description("Id of the subject this context is in. Legacy field to be removed.") subjectId: String,
   @description("Id of the root node this context is in.") rootId: String,
   @description("The relevance for this context.") relevance: String,
   @description("The relevanceId for this context.") relevanceId: String,
   @description("Path to the resource in this context.") path: String,
   @description("Breadcrumbs of path to the resource in this context.") breadcrumbs: List[String],
-  @description("Type in this context. Legacy field to be removed.") learningResourceType: String,
   @description("Type in this context.") contextType: String,
   @description("Resource-types of this context.") resourceTypes: List[TaxonomyResourceType],
   @description("Language for this context.") language: String,
-  @description("Whether this context is the primary connection. Legacy field to be removed.") isPrimaryConnection: Boolean,
   @description("Whether this context is the primary connection") isPrimary: Boolean,
   @description("Whether this context is active") isActive: Boolean
 )

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
@@ -695,21 +695,16 @@ trait SearchConverterService {
       val relevance = findByLanguageOrBestEffort(context.relevance.languageValues, language).map(_.value).getOrElse("")
 
       ApiTaxonomyContext(
-        id = context.publicId,
         publicId = context.publicId,
-        subject = subjectName,
         root = subjectName,
-        subjectId = context.rootId,
         rootId = context.rootId,
         relevance = relevance,
         relevanceId = context.relevanceId,
         path = context.path,
         breadcrumbs = breadcrumbs,
-        learningResourceType = context.contextType,
         contextType = context.contextType,
         resourceTypes = resourceTypes,
         language = language,
-        isPrimaryConnection = context.isPrimary,
         isPrimary = context.isPrimary,
         isActive = context.isActive
       )

--- a/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceAtomicTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceAtomicTest.scala
@@ -729,11 +729,11 @@ class MultiDraftSearchServiceAtomicTest
       ctxs.head
     }
 
-    ctxFor(1).isPrimaryConnection should be(true)
-    ctxFor(2).isPrimaryConnection should be(true)
-    ctxFor(3).isPrimaryConnection should be(true)
-    ctxFor(4).isPrimaryConnection should be(true)
-    ctxsFor(5).map(_.isPrimaryConnection) should be(Seq(true, true, false)) // Sorted with primary first
+    ctxFor(1).isPrimary should be(true)
+    ctxFor(2).isPrimary should be(true)
+    ctxFor(3).isPrimary should be(true)
+    ctxFor(4).isPrimary should be(true)
+    ctxsFor(5).map(_.isPrimary) should be(Seq(true, true, false)) // Sorted with primary first
 
   }
 

--- a/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceTest.scala
@@ -218,7 +218,7 @@ class MultiDraftSearchServiceTest extends IntegrationSuite(EnableElasticsearchCo
         multiDraftSearchSettings.copy(query = Some(NonEmptyString.fromString("Pingvinen").get), sort = Sort.ByTitleAsc)
       )
 
-    results.results.map(_.contexts.head.learningResourceType) should be(Seq("learningpath", "standard"))
+    results.results.map(_.contexts.head.contextType) should be(Seq("learningpath", "standard"))
     results.results.map(_.id) should be(Seq(1, 2))
     results.totalCount should be(2)
   }
@@ -231,7 +231,7 @@ class MultiDraftSearchServiceTest extends IntegrationSuite(EnableElasticsearchCo
     val hits = results.results
     results.totalCount should be(12)
     hits.head.id should be(1)
-    hits.head.contexts.head.learningResourceType should be("standard")
+    hits.head.contexts.head.contextType should be("standard")
     hits(1).id should be(2)
   }
 
@@ -243,7 +243,7 @@ class MultiDraftSearchServiceTest extends IntegrationSuite(EnableElasticsearchCo
     val hits = results.results
     results.totalCount should be(1)
     hits.head.id should be(5)
-    hits.head.contexts.head.learningResourceType should be("standard")
+    hits.head.contexts.head.contextType should be("standard")
   }
 
   test("That search matches tags") {
@@ -255,7 +255,7 @@ class MultiDraftSearchServiceTest extends IntegrationSuite(EnableElasticsearchCo
     results.totalCount should be(2)
     hits.head.id should be(3)
     hits(1).id should be(3)
-    hits(1).contexts.head.learningResourceType should be("learningpath")
+    hits(1).contexts.head.contextType should be("learningpath")
   }
 
   test("That search does not return superman since it has license copyrighted and license is not specified") {
@@ -791,7 +791,7 @@ class MultiDraftSearchServiceTest extends IntegrationSuite(EnableElasticsearchCo
 
   test("Filtering for statuses should also filter learningPaths") {
     val expectedArticleIds = List(10, 11).map(_.toLong)
-    val expectedIds        = (expectedArticleIds).sorted
+    val expectedIds        = expectedArticleIds.sorted
 
     val Success(search1) = multiDraftSearchService.matchingQuery(
       multiDraftSearchSettings.copy(language = AllLanguages, statusFilter = List(DraftStatus.IN_PROGRESS))

--- a/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceAtomicTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceAtomicTest.scala
@@ -282,7 +282,7 @@ class MultiSearchServiceAtomicTest extends IntegrationSuite(EnableElasticsearchC
       )
       .get
 
-    result.results.head.contexts.map(_.id) should be(Seq("urn:resource:2"))
+    result.results.head.contexts.map(_.publicId) should be(Seq("urn:resource:2"))
   }
 
   test("That topic taxonomy contexts with hidden elements are ignored") {
@@ -410,7 +410,7 @@ class MultiSearchServiceAtomicTest extends IntegrationSuite(EnableElasticsearchC
       )
       .get
 
-    result.results.head.contexts.map(_.id) should be(Seq("urn:topic:3"))
+    result.results.head.contexts.map(_.publicId) should be(Seq("urn:topic:3"))
   }
   test("That aggregating rootId works as expected") {
     val article1 = TestData.article1.copy(id = Some(1))

--- a/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceTest.scala
@@ -223,7 +223,7 @@ class MultiSearchServiceTest
         searchSettings.copy(Some(NonEmptyString.fromString("Pingvinen").get), sort = Sort.ByTitleAsc)
       )
     val hits = results.results
-    hits.map(_.contexts.head.learningResourceType) should be(Seq("learningpath", "standard"))
+    hits.map(_.contexts.head.contextType) should be(Seq("learningpath", "standard"))
     hits.map(_.id) should be(Seq(1, 2))
   }
 
@@ -235,7 +235,7 @@ class MultiSearchServiceTest
     results.totalCount should be(2)
     hits.head.id should be(3)
     hits(1).id should be(3)
-    hits(1).contexts.head.learningResourceType should be("learningpath")
+    hits(1).contexts.head.contextType should be("learningpath")
   }
 
   test("That search does not return superman since it has license copyrighted and license is not specified") {
@@ -433,7 +433,7 @@ class MultiSearchServiceTest
     search.totalCount should be(7)
     search.results.head.contexts.length should be(2)
     search.results.head.contexts
-      .map(_.subjectId) should be(List("urn:subject:1", "urn:subject:2")) // urn:subject:3 is not visible
+      .map(_.rootId) should be(List("urn:subject:1", "urn:subject:2")) // urn:subject:3 is not visible
     search.results.map(_.id) should be(Seq(1, 5, 5, 6, 7, 11, 12))
   }
 
@@ -531,7 +531,7 @@ class MultiSearchServiceTest
 
     search.totalCount should be(5)
     search.results.map(_.id) should be(Seq(1, 2, 3, 4, 5))
-    search.results.filter(_.contexts.nonEmpty).map(_.contexts.head.learningResourceType) should be(
+    search.results.filter(_.contexts.nonEmpty).map(_.contexts.head.contextType) should be(
       Seq.fill(5) { LearningResourceType.LearningPath.toString }
     )
   }


### PR DESCRIPTION
Vi slutta å hente disse i fjor i ndla-frontend, og no er dei også borte fra graphql-api.