### PR TITLE
Generalize testing of tapir controllers

### DIFF
--- a/article-api/src/main/scala/no/ndla/articleapi/ComponentRegistry.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/ComponentRegistry.scala
@@ -104,5 +104,5 @@ class ComponentRegistry(properties: ArticleApiProperties)
     SwaggerDocControllerConfig.swaggerInfo
   )
 
-  override val services: List[Service[Eff]] = swagger.getServices()
+  override def services: List[Service[Eff]] = swagger.getServices()
 }

--- a/article-api/src/test/scala/no/ndla/articleapi/TestEnvironment.scala
+++ b/article-api/src/test/scala/no/ndla/articleapi/TestEnvironment.scala
@@ -89,5 +89,5 @@ trait TestEnvironment
 
   val clock = mock[SystemClock]
 
-  val services: List[Service[Eff]] = List.empty
+  def services: List[Service[Eff]] = List.empty
 }

--- a/article-api/src/test/scala/no/ndla/articleapi/controller/InternControllerTest.scala
+++ b/article-api/src/test/scala/no/ndla/articleapi/controller/InternControllerTest.scala
@@ -8,13 +8,12 @@
 
 package no.ndla.articleapi.controller
 
-import cats.effect.IO
-import cats.effect.unsafe.implicits.global
 import enumeratum.Json4s
-import no.ndla.articleapi.{TestEnvironment, UnitSuite}
+import no.ndla.articleapi.{Eff, TestEnvironment, UnitSuite}
 import no.ndla.common.model.NDLADate
 import no.ndla.common.model.domain.article.Article
 import no.ndla.common.model.domain.{ArticleType, Author, Availability}
+import no.ndla.tapirtesting.TapirControllerTest
 import org.json4s.ext.{EnumNameSerializer, JavaTimeSerializers}
 import org.json4s.{DefaultFormats, Formats}
 import org.mockito.invocation.InvocationOnMock
@@ -22,7 +21,7 @@ import sttp.client3.quick._
 
 import scala.util.{Failure, Success}
 
-class InternControllerTest extends UnitSuite with TestEnvironment {
+class InternControllerTest extends UnitSuite with TestEnvironment with TapirControllerTest[Eff] {
   implicit val formats: Formats =
     DefaultFormats +
       new EnumNameSerializer(Availability) ++
@@ -34,15 +33,7 @@ class InternControllerTest extends UnitSuite with TestEnvironment {
 
   val controller = new InternController
 
-  val serverPort: Int = findFreePort
   when(clock.now()).thenCallRealMethod()
-
-  override val services = List(controller)
-
-  override def beforeAll(): Unit = {
-    IO { Routes.startJdkServer(this.getClass.getName, serverPort) {} }.unsafeRunAndForget()
-    Thread.sleep(1000)
-  }
 
   test("POST /validate/article should return 400 if the article is invalid") {
     val invalidArticle = """{"revision": 1, "title": [{"language": "nb", "titlee": "lol"]}"""
@@ -61,7 +52,6 @@ class InternControllerTest extends UnitSuite with TestEnvironment {
     when(contentValidator.validateArticle(any[Article], any))
       .thenReturn(Success(TestData.sampleArticleWithByNcSa))
 
-    import io.circe.generic.auto._
     import io.circe.syntax._
     val jsonStr = TestData.sampleArticleWithByNcSa.asJson.deepDropNullValues.noSpaces
 
@@ -145,7 +135,6 @@ class InternControllerTest extends UnitSuite with TestEnvironment {
     val authHeaderWithWriteRole =
       "Bearer eyJhbGciOiJIUzI1NiJ9.eyJodHRwczovL25kbGEubm8vY2xpZW50X2lkIjoieHh4eXl5IiwiaXNzIjoiaHR0cHM6Ly9uZGxhLmV1LmF1dGgwLmNvbS8iLCJzdWIiOiJ4eHh5eXlAY2xpZW50cyIsImF1ZCI6Im5kbGFfc3lzdGVtIiwiYXpwIjoiMTIzIiwiaWF0IjoxNTEwMzA1NzczLCJleHAiOjE1MTAzOTIxNzMsInNjb3BlIjoiYXVkaW86d3JpdGUiLCJndHkiOiJjbGllbnQtY3JlZGVudGlhbHMiLCJwZXJtaXNzaW9ucyI6WyJhdWRpbzp3cml0ZSIsImFydGljbGVzOnB1Ymxpc2giLCJhcnRpY2xlczp3cml0ZSIsImNvbmNlcHQ6YWRtaW4iLCJjb25jZXB0OndyaXRlIiwiZHJhZnRzOmFkbWluIiwiZHJhZnRzOmh0bWwiLCJkcmFmdHM6cHVibGlzaCIsImRyYWZ0czp3cml0ZSIsImZyb250cGFnZTphZG1pbiIsImZyb250cGFnZTp3cml0ZSIsImltYWdlczp3cml0ZSIsImxlYXJuaW5ncGF0aDphZG1pbiIsImxlYXJuaW5ncGF0aDpwdWJsaXNoIiwibGVhcm5pbmdwYXRoOndyaXRlIl19.nm77NIe8aFACafNhC1nROU1bTspbT-hCvxlg6_8ztDk"
 
-    import io.circe.generic.auto._
     import io.circe.syntax._
     val art     = TestData.sampleArticleWithByNcSa.copy(id = Some(10L))
     val jsonStr = art.asJson.deepDropNullValues.noSpaces
@@ -164,15 +153,6 @@ class InternControllerTest extends UnitSuite with TestEnvironment {
       useImportValidation = eqTo(false),
       useSoftValidation = eqTo(false)
     )
-  }
-
-  test("That no endpoints are shadowed") {
-    import sttp.tapir.testing.EndpointVerifier
-    val errors = EndpointVerifier(controller.endpoints.map(_.endpoint))
-    if (errors.nonEmpty) {
-      val errString = errors.map(e => e.toString).mkString("\n\t- ", "\n\t- ", "")
-      fail(s"Got errors when verifying ${controller.serviceName} controller:$errString")
-    }
   }
 
 }

--- a/audio-api/src/main/scala/no/ndla/audioapi/ComponentRegistry.scala
+++ b/audio-api/src/main/scala/no/ndla/audioapi/ComponentRegistry.scala
@@ -108,5 +108,5 @@ class ComponentRegistry(properties: AudioApiProperties)
     SwaggerDocControllerConfig.swaggerInfo
   )
 
-  override val services: List[Service[Eff]] = swagger.getServices()
+  override def services: List[Service[Eff]] = swagger.getServices()
 }

--- a/audio-api/src/test/scala/no/ndla/audioapi/TestEnvironment.scala
+++ b/audio-api/src/test/scala/no/ndla/audioapi/TestEnvironment.scala
@@ -89,6 +89,6 @@ trait TestEnvironment
   val searchConverterService: SearchConverterService = mock[SearchConverterService]
 
   val clock: SystemClock           = mock[SystemClock]
-  val services: List[Service[Eff]] = List.empty
+  def services: List[Service[Eff]] = List.empty
 
 }

--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,8 @@ lazy val `article-api`: Project = Module.setup(
     validation,
     common,
     search,
-    testWith(scalatestsuite)
+    testWith(scalatestsuite),
+    testWith(tapirtesting)
   )
 )
 
@@ -27,7 +28,8 @@ lazy val `draft-api`: Project = Module.setup(
     validation,
     common,
     search,
-    testWith(scalatestsuite)
+    testWith(scalatestsuite),
+    testWith(tapirtesting)
   )
 )
 
@@ -40,7 +42,8 @@ lazy val `audio-api` = Module.setup(
     language,
     common,
     search,
-    testWith(scalatestsuite)
+    testWith(scalatestsuite),
+    testWith(tapirtesting)
   )
 )
 
@@ -54,7 +57,8 @@ lazy val `concept-api` = Module.setup(
     validation,
     common,
     search,
-    testWith(scalatestsuite)
+    testWith(scalatestsuite),
+    testWith(tapirtesting)
   )
 )
 
@@ -66,7 +70,8 @@ lazy val `frontpage-api` = Module.setup(
     mapping,
     language,
     common,
-    testWith(scalatestsuite)
+    testWith(scalatestsuite),
+    testWith(tapirtesting)
   )
 )
 
@@ -79,7 +84,8 @@ lazy val `image-api` = Module.setup(
     language,
     common,
     search,
-    testWith(scalatestsuite)
+    testWith(scalatestsuite),
+    testWith(tapirtesting)
   )
 )
 
@@ -93,14 +99,15 @@ lazy val `learningpath-api` = Module.setup(
     common,
     search,
     myndla,
-    testWith(scalatestsuite)
+    testWith(scalatestsuite),
+    testWith(tapirtesting)
   )
 )
 
 lazy val `oembed-proxy` = Module.setup(
   project in file("./oembed-proxy/"),
   oembedproxy,
-  deps = Seq(network, common, testWith(scalatestsuite))
+  deps = Seq(network, common, testWith(scalatestsuite), testWith(tapirtesting))
 )
 
 lazy val `search-api` = Module.setup(
@@ -112,7 +119,8 @@ lazy val `search-api` = Module.setup(
     language,
     common,
     search,
-    testWith(scalatestsuite)
+    testWith(scalatestsuite),
+    testWith(tapirtesting)
   )
 )
 
@@ -125,7 +133,8 @@ lazy val `myndla-api` = Module.setup(
     language,
     common,
     myndla,
-    testWith(scalatestsuite)
+    testWith(scalatestsuite),
+    testWith(tapirtesting)
   )
 )
 
@@ -146,10 +155,12 @@ lazy val constants = Module.setup(
 // Libraries
 lazy val common = Module.setup(project in file("./common/"), commonlib, deps = Seq(testWith(scalatestsuite), language))
 lazy val scalatestsuite = Module.setup(project in file("./scalatestsuite/"), scalatestsuitelib)
-lazy val network        = Module.setup(project in file("./network/"), networklib, deps = Seq(common))
-lazy val language       = Module.setup(project in file("./language/"), languagelib)
-lazy val mapping        = Module.setup(project in file("./mapping/"), mappinglib)
-lazy val validation     = Module.setup(project in file("./validation/"), validationlib, deps = Seq(common))
+lazy val tapirtesting =
+  Module.setup(project in file("./tapirtesting/"), tapirtestinglib, deps = Seq(common, network, scalatestsuite))
+lazy val network    = Module.setup(project in file("./network/"), networklib, deps = Seq(common))
+lazy val language   = Module.setup(project in file("./language/"), languagelib)
+lazy val mapping    = Module.setup(project in file("./mapping/"), mappinglib)
+lazy val validation = Module.setup(project in file("./validation/"), validationlib, deps = Seq(common))
 lazy val search =
   Module.setup(project in file("./search/"), searchlib, deps = Seq(testWith(scalatestsuite), language, common, mapping))
 lazy val myndla =

--- a/concept-api/src/main/scala/no/ndla/conceptapi/ComponentRegistry.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/ComponentRegistry.scala
@@ -115,6 +115,6 @@ class ComponentRegistry(properties: ConceptApiProperties)
     SwaggerDocControllerConfig.swaggerInfo
   )
 
-  override val services: List[Service[Eff]] = swagger.getServices()
+  override def services: List[Service[Eff]] = swagger.getServices()
 
 }

--- a/concept-api/src/test/scala/no/ndla/conceptapi/TestEnvironment.scala
+++ b/concept-api/src/test/scala/no/ndla/conceptapi/TestEnvironment.scala
@@ -97,5 +97,5 @@ trait TestEnvironment
   val ndlaClient: NdlaClient             = mock[NdlaClient]
   val articleApiClient: ArticleApiClient = mock[ArticleApiClient]
 
-  val services: List[Service[Eff]] = List.empty
+  def services: List[Service[Eff]] = List.empty
 }

--- a/concept-api/src/test/scala/no/ndla/conceptapi/controller/InternControllerTest.scala
+++ b/concept-api/src/test/scala/no/ndla/conceptapi/controller/InternControllerTest.scala
@@ -6,35 +6,16 @@
  */
 package no.ndla.conceptapi.controller
 
-import cats.effect.IO
-import cats.effect.unsafe.implicits.global
 import no.ndla.conceptapi.{Eff, TestEnvironment, UnitSuite}
-import no.ndla.network.tapir.Service
+import no.ndla.tapirtesting.TapirControllerTest
 import org.json4s.DefaultFormats
 
-class InternControllerTest extends UnitSuite with TestEnvironment {
+class InternControllerTest extends UnitSuite with TestEnvironment with TapirControllerTest[Eff] {
   implicit val formats: DefaultFormats.type = org.json4s.DefaultFormats
-  val serverPort: Int                       = findFreePort
   val controller                            = new InternController
-  override val services: List[Service[Eff]] = List(controller)
-
-  override def beforeAll(): Unit = {
-    IO { Routes.startJdkServer(this.getClass.getName, serverPort) {} }.unsafeRunAndForget()
-    Thread.sleep(1000)
-  }
 
   override def beforeEach(): Unit = {
     reset(clock)
     when(clock.now()).thenCallRealMethod()
   }
-
-  test("That no endpoints are shadowed") {
-    import sttp.tapir.testing.EndpointVerifier
-    val errors = EndpointVerifier(controller.endpoints.map(_.endpoint))
-    if (errors.nonEmpty) {
-      val errString = errors.map(e => e.toString).mkString("\n\t- ", "\n\t- ", "")
-      fail(s"Got errors when verifying ${controller.serviceName} controller:$errString")
-    }
-  }
-
 }

--- a/draft-api/src/main/scala/no/ndla/draftapi/ComponentRegistry.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/ComponentRegistry.scala
@@ -143,5 +143,5 @@ class ComponentRegistry(properties: DraftApiProperties)
     ),
     SwaggerDocControllerConfig.swaggerInfo
   )
-  override val services: List[Service[Eff]] = swagger.getServices()
+  override def services: List[Service[Eff]] = swagger.getServices()
 }

--- a/draft-api/src/test/scala/no/ndla/draftapi/TestEnvironment.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/TestEnvironment.scala
@@ -116,5 +116,5 @@ trait TestEnvironment
   val taxonomyApiClient = mock[TaxonomyApiClient]
   val h5pApiClient      = mock[H5PApiClient]
 
-  val services: List[Service[Eff]] = List.empty
+  def services: List[Service[Eff]] = List.empty
 }

--- a/draft-api/src/test/scala/no/ndla/draftapi/controller/InternControllerTest.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/controller/InternControllerTest.scala
@@ -7,28 +7,19 @@
 
 package no.ndla.draftapi.controller
 
-import cats.effect.IO
-import cats.effect.unsafe.implicits.global
 import no.ndla.draftapi._
 import no.ndla.draftapi.model.api.ContentId
 import no.ndla.draftapi.model.domain.ImportId
-import no.ndla.network.tapir.Service
+import no.ndla.tapirtesting.TapirControllerTest
 import org.json4s.Formats
 import sttp.client3.quick._
 
 import scala.util.{Failure, Success}
 
-class InternControllerTest extends UnitSuite with TestEnvironment {
+class InternControllerTest extends UnitSuite with TestEnvironment with TapirControllerTest[Eff] {
   implicit val formats: Formats = org.json4s.DefaultFormats
-  val serverPort: Int           = findFreePort
 
-  val controller                            = new InternController
-  override val services: List[Service[Eff]] = List(controller)
-
-  override def beforeAll(): Unit = {
-    IO { Routes.startJdkServer(this.getClass.getName, serverPort) {} }.unsafeRunAndForget()
-    Thread.sleep(1000)
-  }
+  val controller = new InternController
 
   override def beforeEach(): Unit = {
     reset(clock)
@@ -184,14 +175,5 @@ class InternControllerTest extends UnitSuite with TestEnvironment {
     verify(tagIndexService).deleteIndexWithName(Some("index8"))
     verify(grepCodesIndexService).deleteIndexWithName(Some("index9"))
     verify(grepCodesIndexService).deleteIndexWithName(Some("index10"))
-  }
-
-  test("That no endpoints are shadowed") {
-    import sttp.tapir.testing.EndpointVerifier
-    val errors = EndpointVerifier(controller.endpoints.map(_.endpoint))
-    if (errors.nonEmpty) {
-      val errString = errors.map(e => e.toString).mkString("\n\t- ", "\n\t- ", "")
-      fail(s"Got errors when verifying ${controller.serviceName} controller:$errString")
-    }
   }
 }

--- a/draft-api/src/test/scala/no/ndla/draftapi/db/migration/V55__MigrateMarkdownTest.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/db/migration/V55__MigrateMarkdownTest.scala
@@ -55,7 +55,7 @@ class V55__MigrateMarkdownTest extends UnitSuite with TestEnvironment {
         |Også her et linjeskift.
         |
         |""".stripMargin + "Linje med to mellomrom  \n" +
-        """som blir til en br
+          """som blir til en br
         |
         |* liste
         |* skal

--- a/frontpage-api/src/main/scala/no/ndla/frontpageapi/ComponentRegistry.scala
+++ b/frontpage-api/src/main/scala/no/ndla/frontpageapi/ComponentRegistry.scala
@@ -71,5 +71,5 @@ class ComponentRegistry(properties: FrontpageApiProperties)
     SwaggerDocControllerConfig.swaggerInfo
   )
 
-  override val services: List[Service[Eff]] = swagger.getServices()
+  override def services: List[Service[Eff]] = swagger.getServices()
 }

--- a/frontpage-api/src/main/scala/no/ndla/frontpageapi/controller/SubjectPageController.scala
+++ b/frontpage-api/src/main/scala/no/ndla/frontpageapi/controller/SubjectPageController.scala
@@ -35,82 +35,92 @@ trait SubjectPageController {
     override val prefix: EndpointInput[Unit] = "frontpage-api" / "v1" / serviceName
 
     import ErrorHelpers._
-    override val endpoints: List[ServerEndpoint[Any, Eff]] = List(
-      endpoint.get
-        .summary("Fetch all subjectpages")
-        .in(query[Int]("page").default(1).validate(Validator.min(1)))
-        .in(query[Int]("page-size").default(props.DefaultPageSize).validate(Validator.min(1)))
-        .in(query[String]("language").default(props.DefaultLanguage))
-        .in(query[Boolean]("fallback").default(false))
-        .errorOut(errorOutputsFor(400, 404))
-        .out(jsonBody[List[SubjectPageData]])
-        .serverLogicPure { case (page, pageSize, language, fallback) =>
-          readService
-            .subjectPages(page, pageSize, language, fallback)
-            .handleErrorsOrOk
-        },
-      endpoint.get
-        .summary("Get data to display on a subject page")
-        .in(path[Long]("subjectpage-id").description("The subjectpage id"))
-        .in(query[String]("language").default(props.DefaultLanguage))
-        .in(query[Boolean]("fallback").default(false))
-        .out(jsonBody[SubjectPageData])
-        .errorOut(errorOutputsFor(400, 404))
-        .serverLogicPure { case (id, language, fallback) =>
-          readService
-            .subjectPage(id, language, fallback)
-            .handleErrorsOrOk
-        },
-      endpoint.get
-        .summary("Fetch subject pages that matches ids parameter")
-        .in("ids")
-        .in(query[CommaSeparated[Long]]("ids"))
-        .in(query[String]("language").default(props.DefaultLanguage))
-        .in(query[Boolean]("fallback").default(false))
-        .in(query[Int]("page-size").default(props.DefaultPageSize))
-        .in(query[Int]("page").default(1))
-        .out(jsonBody[List[SubjectPageData]])
-        .errorOut(errorOutputsFor(400, 404))
-        .serverLogicPure { case (ids, language, fallback, pageSize, page) =>
-          val parsedPageSize = if (pageSize < 1) props.DefaultPageSize else pageSize
-          val parsedPage     = if (page < 1) 1 else page
-          readService
-            .getSubjectPageByIds(ids.values, language, fallback, parsedPageSize, parsedPage)
-            .handleErrorsOrOk
-        },
-      endpoint.post
-        .summary("Create new subject page")
-        .in(jsonBody[NewSubjectFrontPageData])
-        .out(jsonBody[SubjectPageData])
-        .errorOut(errorOutputsFor(400, 404))
-        .requirePermission(FRONTPAGE_API_WRITE)
-        .serverLogicPure { _ => newSubjectFrontPageData =>
-          {
-            writeService
-              .newSubjectPage(newSubjectFrontPageData)
-              .partialOverride { case ex: ValidationException =>
-                ErrorHelpers.unprocessableEntity(ex.getMessage)
-              }
-          }
-        },
-      endpoint.patch
-        .summary("Update subject page")
-        .in(jsonBody[UpdatedSubjectFrontPageData])
-        .in(path[Long]("subjectpage-id").description("The subjectpage id"))
-        .in(query[String]("language").default(props.DefaultLanguage))
-        .in(query[Boolean]("fallback").default(false))
-        .out(jsonBody[SubjectPageData])
-        .errorOut(errorOutputsFor(400, 404))
-        .requirePermission(FRONTPAGE_API_WRITE)
-        .serverLogicPure { _ =>
-          { case (subjectPage, id, language, fallback) =>
-            writeService
-              .updateSubjectPage(id, subjectPage, language, fallback)
-              .partialOverride { case ex: ValidationException =>
-                ErrorHelpers.unprocessableEntity(ex.getMessage)
-              }
-          }
+
+    def getAllSubjectPages: ServerEndpoint[Any, Eff] = endpoint.get
+      .summary("Fetch all subjectpages")
+      .in(query[Int]("page").default(1).validate(Validator.min(1)))
+      .in(query[Int]("page-size").default(props.DefaultPageSize).validate(Validator.min(1)))
+      .in(query[String]("language").default(props.DefaultLanguage))
+      .in(query[Boolean]("fallback").default(false))
+      .errorOut(errorOutputsFor(400, 404))
+      .out(jsonBody[List[SubjectPageData]])
+      .serverLogicPure { case (page, pageSize, language, fallback) =>
+        readService
+          .subjectPages(page, pageSize, language, fallback)
+          .handleErrorsOrOk
+      }
+
+    def getSingleSubjectPage: ServerEndpoint[Any, Eff] = endpoint.get
+      .summary("Get data to display on a subject page")
+      .in(path[Long]("subjectpage-id").description("The subjectpage id"))
+      .in(query[String]("language").default(props.DefaultLanguage))
+      .in(query[Boolean]("fallback").default(false))
+      .out(jsonBody[SubjectPageData])
+      .errorOut(errorOutputsFor(400, 404))
+      .serverLogicPure { case (id, language, fallback) =>
+        readService
+          .subjectPage(id, language, fallback)
+          .handleErrorsOrOk
+      }
+
+    def getSubjectPagesByIds: ServerEndpoint[Any, Eff] = endpoint.get
+      .summary("Fetch subject pages that matches ids parameter")
+      .in("ids")
+      .in(query[CommaSeparated[Long]]("ids"))
+      .in(query[String]("language").default(props.DefaultLanguage))
+      .in(query[Boolean]("fallback").default(false))
+      .in(query[Int]("page-size").default(props.DefaultPageSize))
+      .in(query[Int]("page").default(1))
+      .out(jsonBody[List[SubjectPageData]])
+      .errorOut(errorOutputsFor(400, 404))
+      .serverLogicPure { case (ids, language, fallback, pageSize, page) =>
+        val parsedPageSize = if (pageSize < 1) props.DefaultPageSize else pageSize
+        val parsedPage     = if (page < 1) 1 else page
+        readService
+          .getSubjectPageByIds(ids.values, language, fallback, parsedPageSize, parsedPage)
+          .handleErrorsOrOk
+      }
+
+    def createNewSubjectPage: ServerEndpoint[Any, Eff] = endpoint.post
+      .summary("Create new subject page")
+      .in(jsonBody[NewSubjectFrontPageData])
+      .out(jsonBody[SubjectPageData])
+      .errorOut(errorOutputsFor(400, 404))
+      .requirePermission(FRONTPAGE_API_WRITE)
+      .serverLogicPure { _ => newSubjectFrontPageData =>
+        {
+          writeService
+            .newSubjectPage(newSubjectFrontPageData)
+            .partialOverride { case ex: ValidationException =>
+              ErrorHelpers.unprocessableEntity(ex.getMessage)
+            }
         }
+      }
+    def updateSubjectPage: ServerEndpoint[Any, Eff] = endpoint.patch
+      .summary("Update subject page")
+      .in(jsonBody[UpdatedSubjectFrontPageData])
+      .in(path[Long]("subjectpage-id").description("The subjectpage id"))
+      .in(query[String]("language").default(props.DefaultLanguage))
+      .in(query[Boolean]("fallback").default(false))
+      .out(jsonBody[SubjectPageData])
+      .errorOut(errorOutputsFor(400, 404))
+      .requirePermission(FRONTPAGE_API_WRITE)
+      .serverLogicPure { _ =>
+        { case (subjectPage, id, language, fallback) =>
+          writeService
+            .updateSubjectPage(id, subjectPage, language, fallback)
+            .partialOverride { case ex: ValidationException =>
+              ErrorHelpers.unprocessableEntity(ex.getMessage)
+            }
+        }
+      }
+
+    override val endpoints: List[ServerEndpoint[Any, Eff]] = List(
+      getAllSubjectPages,
+      getSubjectPagesByIds,
+      getSingleSubjectPage,
+      createNewSubjectPage,
+      updateSubjectPage
     )
   }
 }

--- a/frontpage-api/src/test/scala/no/ndla/frontpageapi/FilmPageControllerTest.scala
+++ b/frontpage-api/src/test/scala/no/ndla/frontpageapi/FilmPageControllerTest.scala
@@ -7,21 +7,11 @@
 
 package no.ndla.frontpageapi
 
-import cats.effect.IO
-import cats.effect.unsafe.implicits.global
+import no.ndla.tapirtesting.TapirControllerTest
 import sttp.client3.quick._
 
-class FilmPageControllerTest extends UnitSuite with TestEnvironment {
-
-  val serverPort: Int = findFreePort
-
-  override val filmPageController = new FilmPageController()
-  override val services           = List(filmPageController)
-
-  override def beforeAll(): Unit = {
-    IO { Routes.startJdkServer(this.getClass.getName, serverPort) {} }.unsafeRunAndForget()
-    Thread.sleep(1000)
-  }
+class FilmPageControllerTest extends UnitSuite with TestEnvironment with TapirControllerTest[Eff] {
+  override val controller = new FilmPageController()
 
   test("Should return 200 when frontpage exist") {
     when(readService.filmFrontPage(None)).thenReturn(Some(TestData.apiFilmFrontPage))

--- a/frontpage-api/src/test/scala/no/ndla/frontpageapi/SubjectPageControllerTest.scala
+++ b/frontpage-api/src/test/scala/no/ndla/frontpageapi/SubjectPageControllerTest.scala
@@ -7,23 +7,13 @@
 
 package no.ndla.frontpageapi
 
-import cats.effect.IO
-import cats.effect.unsafe.implicits.global
 import io.circe.syntax.EncoderOps
 import no.ndla.common.model.NDLADate
+import no.ndla.tapirtesting.TapirControllerTest
 import sttp.client3.quick._
 
-class SubjectPageControllerTest extends UnitSuite with TestEnvironment {
-
-  val serverPort: Int = findFreePort
-
-  override val subjectPageController = new SubjectPageController()
-  override val services              = List(subjectPageController)
-
-  override def beforeAll(): Unit = {
-    IO { Routes.startJdkServer(this.getClass.getName, serverPort) {} }.unsafeRunAndForget()
-    Thread.sleep(1000)
-  }
+class SubjectPageControllerTest extends UnitSuite with TestEnvironment with TapirControllerTest[Eff] {
+  override val controller = new SubjectPageController()
 
   test("Should return 400 with cool custom message if bad request") {
     when(clock.now()).thenReturn(NDLADate.now())

--- a/frontpage-api/src/test/scala/no/ndla/frontpageapi/TestEnvironment.scala
+++ b/frontpage-api/src/test/scala/no/ndla/frontpageapi/TestEnvironment.scala
@@ -54,5 +54,5 @@ trait TestEnvironment
   override val readService             = mock[ReadService]
   override val writeService            = mock[WriteService]
 
-  val services: List[Service[Eff]] = List.empty
+  def services: List[Service[Eff]] = List.empty
 }

--- a/image-api/src/main/scala/no/ndla/imageapi/ComponentRegistry.scala
+++ b/image-api/src/main/scala/no/ndla/imageapi/ComponentRegistry.scala
@@ -122,5 +122,5 @@ class ComponentRegistry(properties: ImageApiProperties)
     SwaggerDocControllerConfig.swaggerInfo
   )
 
-  override val services: List[Service[Eff]] = swagger.getServices()
+  override def services: List[Service[Eff]] = swagger.getServices()
 }

--- a/image-api/src/test/scala/no/ndla/imageapi/TestEnvironment.scala
+++ b/image-api/src/test/scala/no/ndla/imageapi/TestEnvironment.scala
@@ -104,5 +104,5 @@ trait TestEnvironment
   val clock  = mock[SystemClock]
   val random = mock[Random]
 
-  val services: List[Service[Eff]] = List.empty
+  def services: List[Service[Eff]] = List.empty
 }

--- a/image-api/src/test/scala/no/ndla/imageapi/controller/ImageControllerV3Test.scala
+++ b/image-api/src/test/scala/no/ndla/imageapi/controller/ImageControllerV3Test.scala
@@ -8,11 +8,10 @@
 
 package no.ndla.imageapi.controller
 
-import cats.effect.IO
-import cats.effect.unsafe.implicits.global
-import no.ndla.imageapi.{TestEnvironment, UnitSuite}
+import no.ndla.imageapi.{Eff, TestEnvironment, UnitSuite}
+import no.ndla.tapirtesting.TapirControllerTest
 
-class ImageControllerV3Test extends UnitSuite with TestEnvironment {
+class ImageControllerV3Test extends UnitSuite with TestEnvironment with TapirControllerTest[Eff] {
   val authHeaderWithWriteRole =
     "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImtpZCI6Ik9FSTFNVVU0T0RrNU56TTVNekkyTXpaRE9EazFOMFl3UXpkRE1EUXlPRFZDUXpRM1FUSTBNQSJ9.eyJodHRwczovL25kbGEubm8vbmRsYV9pZCI6Inh4eHl5eSIsImlzcyI6Imh0dHBzOi8vbmRsYS5ldS5hdXRoMC5jb20vIiwic3ViIjoieHh4eXl5QGNsaWVudHMiLCJhdWQiOiJuZGxhX3N5c3RlbSIsImlhdCI6MTUxMDMwNTc3MywiZXhwIjoxNTEwMzkyMTczLCJwZXJtaXNzaW9ucyI6WyJpbWFnZXM6d3JpdGUiXSwiZ3R5IjoiY2xpZW50LWNyZWRlbnRpYWxzIn0.1_j9R9KML2LTqeAE4bpRByJcR6m6Tv3pTOozpYCnTC8"
 
@@ -22,28 +21,11 @@ class ImageControllerV3Test extends UnitSuite with TestEnvironment {
   val authHeaderWithWrongRole =
     "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImtpZCI6Ik9FSTFNVVU0T0RrNU56TTVNekkyTXpaRE9EazFOMFl3UXpkRE1EUXlPRFZDUXpRM1FUSTBNQSJ9.eyJodHRwczovL25kbGEubm8vbmRsYV9pZCI6Inh4eHl5eSIsImlzcyI6Imh0dHBzOi8vbmRsYS5ldS5hdXRoMC5jb20vIiwic3ViIjoieHh4eXl5QGNsaWVudHMiLCJhdWQiOiJuZGxhX3N5c3RlbSIsImlhdCI6MTUxMDMwNTc3MywiZXhwIjoxNTEwMzkyMTczLCJwZXJtaXNzaW9ucyI6WyJzb21lOm90aGVyIl0sImd0eSI6ImNsaWVudC1jcmVkZW50aWFscyJ9.u8o7-FXyVzWurle2tP1pngad8KRja6VjFdmy71T4m0k"
 
-  val serverPort: Int           = findFreePort
   override val converterService = new ConverterService
   val controller                = new ImageControllerV2
-  override val services         = List(controller)
-
-  override def beforeAll(): Unit = {
-    IO { Routes.startJdkServer("ImageControllerV3Test", serverPort) {} }.unsafeRunAndForget()
-    Thread.sleep(1000)
-  }
 
   override def beforeEach(): Unit = {
     reset(clock)
     when(clock.now()).thenCallRealMethod()
   }
-
-  test("That no endpoints are shadowed") {
-    import sttp.tapir.testing.EndpointVerifier
-    val errors = EndpointVerifier(controller.endpoints.map(_.endpoint))
-    if (errors.nonEmpty) {
-      val errString = errors.map(e => e.toString).mkString("\n\t- ", "\n\t- ", "")
-      fail(s"Got errors when verifying ${controller.serviceName} controller:$errString")
-    }
-  }
-
 }

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/ComponentRegistry.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/ComponentRegistry.scala
@@ -123,6 +123,6 @@ class ComponentRegistry(properties: LearningpathApiProperties)
     SwaggerDocControllerConfig.swaggerInfo
   )
 
-  override val services: List[Service[Eff]] = swagger.getServices()
+  override def services: List[Service[Eff]] = swagger.getServices()
 
 }

--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/TestEnvironment.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/TestEnvironment.scala
@@ -89,7 +89,7 @@ trait TestEnvironment
   val redisClient: RedisClient                                         = mock[RedisClient]
   val myndlaApiClient: MyNDLAApiClient                                 = mock[MyNDLAApiClient]
 
-  val services: List[Service[Eff]] = List.empty
+  def services: List[Service[Eff]] = List.empty
 
   def resetMocks(): Unit = {
     reset(

--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/controller/InternControllerTest.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/controller/InternControllerTest.scala
@@ -7,27 +7,18 @@
 
 package no.ndla.learningpathapi.controller
 
-import cats.effect.IO
-import cats.effect.unsafe.implicits.global
 import no.ndla.learningpathapi.{Eff, TestEnvironment, UnitSuite}
-import no.ndla.network.tapir.Service
+import no.ndla.tapirtesting.TapirControllerTest
 import org.json4s.Formats
 import scalikejdbc.DBSession
 import sttp.client3.quick._
 
 import scala.util.{Failure, Success}
 
-class InternControllerTest extends UnitSuite with TestEnvironment {
+class InternControllerTest extends UnitSuite with TestEnvironment with TapirControllerTest[Eff] {
 
-  implicit val jsonFormats: Formats         = org.json4s.DefaultFormats
-  val serverPort: Int                       = findFreePort
-  val controller                            = new InternController
-  override val services: List[Service[Eff]] = List(controller)
-
-  override def beforeAll(): Unit = {
-    IO { Routes.startJdkServer("InternControllerTest", serverPort) {} }.unsafeRunAndForget()
-    Thread.sleep(1000)
-  }
+  implicit val jsonFormats: Formats = org.json4s.DefaultFormats
+  val controller                    = new InternController
 
   test("that id with value 404 gives OK") {
     resetMocks()
@@ -96,14 +87,5 @@ class InternControllerTest extends UnitSuite with TestEnvironment {
     verify(searchIndexService).deleteIndexWithName(Some("index1"))
     verify(searchIndexService).deleteIndexWithName(Some("index2"))
     verify(searchIndexService).deleteIndexWithName(Some("index3"))
-  }
-
-  test("That no endpoints are shadowed") {
-    import sttp.tapir.testing.EndpointVerifier
-    val errors = EndpointVerifier(controller.endpoints.map(_.endpoint))
-    if (errors.nonEmpty) {
-      val errString = errors.map(e => e.toString).mkString("\n\t- ", "\n\t- ", "")
-      fail(s"Got errors when verifying ${controller.serviceName} controller:$errString")
-    }
   }
 }

--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/controller/StatsControllerTest.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/controller/StatsControllerTest.scala
@@ -7,24 +7,17 @@
 
 package no.ndla.learningpathapi.controller
 
-import cats.effect.IO
-import cats.effect.unsafe.implicits.global
 import no.ndla.learningpathapi.{Eff, TestEnvironment, UnitSuite}
 import no.ndla.network.tapir.Service
+import no.ndla.tapirtesting.TapirControllerTest
 import org.json4s.DefaultFormats
 import sttp.client3.quick._
 
-class StatsControllerTest extends UnitSuite with TestEnvironment {
+class StatsControllerTest extends UnitSuite with TestEnvironment with TapirControllerTest[Eff] {
 
   implicit val formats: DefaultFormats.type = org.json4s.DefaultFormats
-  val serverPort: Int                       = findFreePort
   val controller                            = new StatsController
-  override val services: List[Service[Eff]] = List(controller)
-
-  override def beforeAll(): Unit = {
-    IO { Routes.startJdkServer("StatsControllerTest", serverPort) {} }.unsafeRunAndForget()
-    Thread.sleep(1000)
-  }
+  override def services: List[Service[Eff]] = List(controller)
 
   override def beforeEach(): Unit = {
     resetMocks()
@@ -38,15 +31,6 @@ class StatsControllerTest extends UnitSuite with TestEnvironment {
     )
     res.header("Location") should be(Some("/myndla-api/v1/stats"))
     res.code.code should be(301)
-  }
-
-  test("That no endpoints are shadowed") {
-    import sttp.tapir.testing.EndpointVerifier
-    val errors = EndpointVerifier(controller.endpoints.map(_.endpoint))
-    if (errors.nonEmpty) {
-      val errString = errors.map(e => e.toString).mkString("\n\t- ", "\n\t- ", "")
-      fail(s"Got errors when verifying ${controller.serviceName} controller:$errString")
-    }
   }
 
 }

--- a/myndla-api/src/main/scala/no/ndla/myndlaapi/ComponentRegistry.scala
+++ b/myndla-api/src/main/scala/no/ndla/myndlaapi/ComponentRegistry.scala
@@ -120,5 +120,5 @@ class ComponentRegistry(properties: MyNdlaApiProperties)
     ),
     SwaggerDocControllerConfig.swaggerInfo
   )
-  override val services: List[Service[Eff]] = swagger.getServices()
+  override def services: List[Service[Eff]] = swagger.getServices()
 }

--- a/myndla-api/src/test/scala/no/ndla/myndlaapi/TestEnvironment.scala
+++ b/myndla-api/src/test/scala/no/ndla/myndlaapi/TestEnvironment.scala
@@ -100,7 +100,7 @@ trait TestEnvironment
   val importService: ImportService                   = mock[ImportService]
   val nodebb: NodeBBClient                           = mock[NodeBBClient]
 
-  val services: List[Service[Eff]] = List.empty
+  def services: List[Service[Eff]] = List.empty
 
   def resetMocks(): Unit = reset(
     clock,

--- a/myndla-api/src/test/scala/no/ndla/myndlaapi/controller/ArenaControllerTest.scala
+++ b/myndla-api/src/test/scala/no/ndla/myndlaapi/controller/ArenaControllerTest.scala
@@ -7,28 +7,18 @@
 
 package no.ndla.myndlaapi.controller
 
-import cats.effect.IO
-import cats.effect.unsafe.implicits.global
 import no.ndla.common.errors.AccessDeniedException
 import no.ndla.myndla.model.domain.{ArenaGroup, MyNDLAUser, UserRole}
 import no.ndla.myndlaapi.model.arena.api.PaginatedTopics
 import no.ndla.myndlaapi.{Eff, TestData, TestEnvironment}
-import no.ndla.network.tapir.Service
 import no.ndla.scalatestsuite.UnitTestSuite
+import no.ndla.tapirtesting.TapirControllerTest
 import sttp.client3.quick._
 
 import scala.util.{Failure, Success}
 
-class ArenaControllerTest extends UnitTestSuite with TestEnvironment {
-  val serverPort: Int = findFreePort
-
-  val controller                            = new ArenaController()
-  override val services: List[Service[Eff]] = List(controller)
-
-  override def beforeAll(): Unit = {
-    IO { Routes.startJdkServer(this.getClass.getName, serverPort) {} }.unsafeRunAndForget()
-    Thread.sleep(1000)
-  }
+class ArenaControllerTest extends UnitTestSuite with TestEnvironment with TapirControllerTest[Eff] {
+  val controller = new ArenaController()
 
   override def beforeEach(): Unit = {
     resetMocks()
@@ -146,14 +136,4 @@ class ArenaControllerTest extends UnitTestSuite with TestEnvironment {
     verify(arenaReadService, times(1)).deleteCategory(any, eqTo(adminUser))(any)
     response.code.code should be(200)
   }
-
-  test("That no endpoints are shadowed") {
-    import sttp.tapir.testing.EndpointVerifier
-    val errors = EndpointVerifier(controller.endpoints.map(_.endpoint))
-    if (errors.nonEmpty) {
-      val errString = errors.map(e => e.toString).mkString("\n\t- ", "\n\t- ", "")
-      fail(s"Got errors when verifying ${controller.serviceName} controller:$errString")
-    }
-  }
-
 }

--- a/myndla-api/src/test/scala/no/ndla/myndlaapi/controller/FolderControllerTest.scala
+++ b/myndla-api/src/test/scala/no/ndla/myndlaapi/controller/FolderControllerTest.scala
@@ -10,26 +10,15 @@ package no.ndla.myndlaapi.controller
 import no.ndla.myndla.model.api.Folder
 import no.ndla.myndla.model.domain.{MyNDLAUser, UserRole}
 import no.ndla.myndlaapi.{Eff, TestData, TestEnvironment}
-import no.ndla.network.tapir.Service
 import no.ndla.scalatestsuite.UnitTestSuite
+import no.ndla.tapirtesting.TapirControllerTest
 import sttp.client3.quick._
 
 import java.util.UUID
-import java.util.concurrent.Executors
-import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Success
 
-class FolderControllerTest extends UnitTestSuite with TestEnvironment {
-  val serverPort: Int = findFreePort
-
-  val controller                            = new FolderController()
-  override val services: List[Service[Eff]] = List(controller)
-
-  override def beforeAll(): Unit = {
-    implicit val ec = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(1))
-    Future { Routes.startJdkServer(this.getClass.getName, serverPort) {} }
-    Thread.sleep(1000)
-  }
+class FolderControllerTest extends UnitTestSuite with TestEnvironment with TapirControllerTest[Eff] {
+  val controller = new FolderController()
 
   override def beforeEach(): Unit = {
     resetMocks()
@@ -97,14 +86,4 @@ class FolderControllerTest extends UnitTestSuite with TestEnvironment {
     verify(folderReadService, times(1)).getSingleFolder(eqTo(someId), any, any, any)
     response.code.code should be(200)
   }
-
-  test("That no endpoints are shadowed") {
-    import sttp.tapir.testing.EndpointVerifier
-    val errors = EndpointVerifier(controller.endpoints.map(_.endpoint))
-    if (errors.nonEmpty) {
-      val errString = errors.map(e => e.toString).mkString("\n\t- ", "\n\t- ", "")
-      fail(s"Got errors when verifying ${controller.serviceName} controller:$errString")
-    }
-  }
-
 }

--- a/myndla-api/src/test/scala/no/ndla/myndlaapi/e2e/ArenaTest.scala
+++ b/myndla-api/src/test/scala/no/ndla/myndlaapi/e2e/ArenaTest.scala
@@ -8,8 +8,6 @@
 
 package no.ndla.myndlaapi.e2e
 
-import cats.effect.IO
-import cats.effect.unsafe.implicits.global
 import io.circe.generic.auto._
 import io.circe.syntax.EncoderOps
 import no.ndla.common.model.NDLADate
@@ -26,6 +24,8 @@ import org.testcontainers.containers.PostgreSQLContainer
 import sttp.client3.Response
 import sttp.client3.quick._
 
+import java.util.concurrent.Executors
+import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration.DurationInt
 import scala.util.Success
 
@@ -83,7 +83,8 @@ class ArenaTest
   val myndlaApiArenaUrl = s"$myndlaApiBaseUrl/myndla-api/v1/arena"
 
   override def beforeAll(): Unit = {
-    IO { myndlaApi.run() }.unsafeRunAndForget()
+    implicit val ec = ExecutionContext.fromExecutorService(Executors.newSingleThreadExecutor)
+    Future { myndlaApi.run() }: Unit
     Thread.sleep(1000)
   }
 

--- a/myndla-api/src/test/scala/no/ndla/myndlaapi/e2e/CloneFolderTest.scala
+++ b/myndla-api/src/test/scala/no/ndla/myndlaapi/e2e/CloneFolderTest.scala
@@ -8,8 +8,6 @@
 
 package no.ndla.myndlaapi.e2e
 
-import cats.effect.IO
-import cats.effect.unsafe.implicits.global
 import enumeratum.Json4s
 import no.ndla.common.model.NDLADate
 import no.ndla.myndla.model.api
@@ -27,6 +25,8 @@ import org.testcontainers.containers.PostgreSQLContainer
 import sttp.client3.quick._
 
 import java.util.UUID
+import java.util.concurrent.Executors
+import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration.DurationInt
 import scala.util.{Failure, Success}
 
@@ -89,8 +89,9 @@ class CloneFolderTest
   val myndlaApiFolderUrl = s"$myndlaApiBaseUrl/myndla-api/v1/folders"
 
   override def beforeAll(): Unit = {
-    IO { myndlaApi.run() }.unsafeRunAndForget()
-    Thread.sleep(1000)
+    implicit val ec = ExecutionContext.fromExecutorService(Executors.newSingleThreadExecutor)
+    Future { myndlaApi.run() }: Unit
+    Thread.sleep(4000)
   }
 
   override def beforeEach(): Unit = {

--- a/network/src/main/scala/no/ndla/network/tapir/Routes.scala
+++ b/network/src/main/scala/no/ndla/network/tapir/Routes.scala
@@ -31,7 +31,7 @@ import java.util.concurrent.{ExecutorService, Executors}
 trait Routes[F[_]] {
   this: NdlaMiddleware with TapirErrorHelpers with HasBaseProps =>
 
-  val services: List[Service[F]]
+  def services: List[Service[F]]
 
   object Routes {
     val logger: Logger = getLogger

--- a/oembed-proxy/src/main/scala/no/ndla/oembedproxy/ComponentRegistry.scala
+++ b/oembed-proxy/src/main/scala/no/ndla/oembedproxy/ComponentRegistry.scala
@@ -49,6 +49,6 @@ class ComponentRegistry(properties: OEmbedProxyProperties)
     SwaggerDocControllerConfig.swaggerInfo
   )
 
-  override val services: List[Service[Eff]] = swagger.getServices()
+  override def services: List[Service[Eff]] = swagger.getServices()
 
 }

--- a/oembed-proxy/src/test/scala/no/ndla/oembedproxy/TestEnvironment.scala
+++ b/oembed-proxy/src/test/scala/no/ndla/oembedproxy/TestEnvironment.scala
@@ -39,7 +39,7 @@ trait TestEnvironment
   val healthController: TapirHealthController[Eff] = mock[TapirHealthController[Eff]]
   val clock: SystemClock                           = mock[SystemClock]
 
-  val services: List[Service[Eff]] = List.empty
+  def services: List[Service[Eff]] = List.empty
 
   def resetMocks(): Unit = {
     reset(oEmbedService, oEmbedProxyController, ndlaClient, providerService)

--- a/oembed-proxy/src/test/scala/no/ndla/oembedproxy/controller/HealthControllerTest.scala
+++ b/oembed-proxy/src/test/scala/no/ndla/oembedproxy/controller/HealthControllerTest.scala
@@ -8,22 +8,14 @@
 
 package no.ndla.oembedproxy.controller
 
-import cats.effect.IO
-import cats.effect.unsafe.implicits.global
 import no.ndla.oembedproxy.{Eff, TestEnvironment, UnitSuite}
+import no.ndla.tapirtesting.TapirControllerTest
 import sttp.client3.quick._
 
-class HealthControllerTest extends UnitSuite with TestEnvironment {
+class HealthControllerTest extends UnitSuite with TestEnvironment with TapirControllerTest[Eff] {
 
-  val serverPort: Int = findFreePort
-
-  lazy val controller   = new TapirHealthController[Eff]
-  override val services = List(controller)
+  lazy val controller = new TapirHealthController[Eff]
   controller.setWarmedUp()
-  override def beforeAll(): Unit = {
-    IO { Routes.startJdkServer(this.getClass.getName, serverPort) {} }.unsafeRunAndForget()
-    Thread.sleep(1000)
-  }
 
   test("That /health returns 200 ok") {
     val response = simpleHttpClient.send(quickRequest.get(uri"http://localhost:$serverPort/health"))

--- a/project/tapirtestinglib.scala
+++ b/project/tapirtestinglib.scala
@@ -1,0 +1,25 @@
+import Dependencies.versions.*
+import com.scalatsi.plugin.ScalaTsiPlugin
+import sbt.*
+import sbt.Keys.*
+
+object tapirtestinglib extends Module {
+  override val moduleName: String      = "tapirtesting"
+  override val enableReleases: Boolean = false
+  lazy val dependencies: Seq[ModuleID] = Seq(
+    "org.scalatest"               %% "scalatest"               % ScalaTestV,
+    "org.mockito"                 %% "mockito-scala"           % MockitoV,
+    "org.mockito"                 %% "mockito-scala-scalatest" % MockitoV,
+    "org.testcontainers"           % "elasticsearch"           % TestContainersV,
+    "org.testcontainers"           % "testcontainers"          % TestContainersV,
+    "org.testcontainers"           % "postgresql"              % TestContainersV,
+    "com.softwaremill.sttp.tapir" %% "tapir-testing"           % TapirV
+  ) ++ database ++ vulnerabilityOverrides ++ tapirHttp4sCirce
+
+  override lazy val settings: Seq[Def.Setting[_]] = Seq(
+    libraryDependencies ++= dependencies
+  ) ++
+    commonSettings
+
+  override lazy val disablePlugins = Seq(ScalaTsiPlugin)
+}

--- a/search-api/src/main/scala/no/ndla/searchapi/ComponentRegistry.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/ComponentRegistry.scala
@@ -99,5 +99,5 @@ class ComponentRegistry(properties: SearchApiProperties)
     SwaggerDocControllerConfig.swaggerInfo
   )
 
-  override val services: List[Service[Eff]] = swagger.getServices()
+  override def services: List[Service[Eff]] = swagger.getServices()
 }

--- a/search-api/src/test/scala/no/ndla/searchapi/TestEnvironment.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/TestEnvironment.scala
@@ -78,5 +78,5 @@ trait TestEnvironment
   val draftIndexService        = mock[DraftIndexService]
   val multiDraftSearchService  = mock[MultiDraftSearchService]
 
-  override val services: List[Service[Eff]] = List()
+  override def services: List[Service[Eff]] = List()
 }

--- a/search-api/src/test/scala/no/ndla/searchapi/controller/InternControllerTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/controller/InternControllerTest.scala
@@ -8,27 +8,10 @@
 
 package no.ndla.searchapi.controller
 
-import cats.effect.IO
-import cats.effect.unsafe.implicits.global
-import no.ndla.searchapi.{TestEnvironment, UnitSuite}
-import sttp.tapir.testing.EndpointVerifier
+import no.ndla.searchapi.{Eff, TestEnvironment, UnitSuite}
+import no.ndla.tapirtesting.TapirControllerTest
 
-class InternControllerTest extends UnitSuite with TestEnvironment {
-  val serverPort: Int                           = findFreePort
-  override val converterService                 = new ConverterService
-  val controller                                = new InternController
-  override val services: List[InternController] = List(controller)
-
-  override def beforeAll(): Unit = {
-    IO { Routes.startJdkServer("InternControllerTest", serverPort) {} }.unsafeRunAndForget()
-    Thread.sleep(1000)
-  }
-
-  test("That no endpoints are shadowed") {
-    val errors = EndpointVerifier(controller.endpoints.map(_.endpoint))
-    if (errors.nonEmpty) {
-      val errString = errors.map(e => e.toString).mkString("\n\t- ", "\n\t- ", "")
-      fail(s"Got errors when verifying ${controller.serviceName} controller:$errString")
-    }
-  }
+class InternControllerTest extends UnitSuite with TestEnvironment with TapirControllerTest[Eff] {
+  override val converterService = new ConverterService
+  val controller                = new InternController
 }

--- a/search-api/src/test/scala/no/ndla/searchapi/controller/SearchControllerTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/controller/SearchControllerTest.scala
@@ -8,32 +8,23 @@
 
 package no.ndla.searchapi.controller
 
-import cats.effect.IO
-import cats.effect.unsafe.implicits.global
 import no.ndla.common.model.NDLADate
 import no.ndla.common.model.domain.Availability
+import no.ndla.network.clients.FeideExtendedUserInfo
 import no.ndla.searchapi.model.domain
 import no.ndla.searchapi.model.domain.Sort
 import no.ndla.searchapi.model.search.settings.{MultiDraftSearchSettings, SearchSettings}
 import no.ndla.searchapi.{Eff, TestData, TestEnvironment, UnitSuite}
-import no.ndla.network.clients.FeideExtendedUserInfo
-import no.ndla.network.tapir.Service
+import no.ndla.tapirtesting.TapirControllerTest
 import org.mockito.ArgumentCaptor
+import sttp.client3.quick._
 
 import java.time.Month
 import scala.util.Success
-import sttp.client3.quick._
 
-class SearchControllerTest extends UnitSuite with TestEnvironment {
-  val serverPort: Int                       = findFreePort
-  override val converterService             = new ConverterService
-  val controller                            = new SearchController()
-  override val services: List[Service[Eff]] = List(controller)
-
-  override def beforeAll(): Unit = {
-    IO { Routes.startJdkServer("SearchControllerTest", serverPort) {} }.unsafeRunAndForget()
-    Thread.sleep(1000)
-  }
+class SearchControllerTest extends UnitSuite with TestEnvironment with TapirControllerTest[Eff] {
+  override val converterService = new ConverterService
+  val controller                = new SearchController()
 
   override def beforeEach(): Unit = {
     reset(clock, searchConverterService)

--- a/tapirtesting/src/main/scala/no/ndla/tapirtesting/TapirControllerTest.scala
+++ b/tapirtesting/src/main/scala/no/ndla/tapirtesting/TapirControllerTest.scala
@@ -7,12 +7,13 @@
 
 package no.ndla.tapirtesting
 
-import cats.effect.IO
-import cats.effect.unsafe.implicits.global
 import no.ndla.common.Clock
 import no.ndla.common.configuration.HasBaseProps
 import no.ndla.network.tapir.{NdlaMiddleware, Routes, Service, TapirErrorHelpers}
 import no.ndla.scalatestsuite.UnitTestSuite
+
+import java.util.concurrent.Executors
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutor, Future}
 
 trait TapirControllerTest[F[_]]
     extends UnitTestSuite
@@ -26,7 +27,8 @@ trait TapirControllerTest[F[_]]
   override def services: List[Service[F]] = List(controller)
 
   override def beforeAll(): Unit = {
-    IO { Routes.startJdkServer(s"TapirControllerTest:${this.getClass.getName}", serverPort) {} }.unsafeRunAndForget()
+    implicit val ec: ExecutionContextExecutor = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(1))
+    Future { Routes.startJdkServer(s"TapirControllerTest:${this.getClass.getName}", serverPort) {} }: Unit
     Thread.sleep(1000)
   }
 

--- a/tapirtesting/src/main/scala/no/ndla/tapirtesting/TapirControllerTest.scala
+++ b/tapirtesting/src/main/scala/no/ndla/tapirtesting/TapirControllerTest.scala
@@ -1,0 +1,42 @@
+/*
+ * Part of NDLA tapirtesting
+ * Copyright (C) 2024 NDLA
+ *
+ * See LICENSE
+ */
+
+package no.ndla.tapirtesting
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import no.ndla.common.Clock
+import no.ndla.common.configuration.HasBaseProps
+import no.ndla.network.tapir.{NdlaMiddleware, Routes, Service, TapirErrorHelpers}
+import no.ndla.scalatestsuite.UnitTestSuite
+
+trait TapirControllerTest[F[_]]
+    extends UnitTestSuite
+    with Routes[F]
+    with NdlaMiddleware
+    with HasBaseProps
+    with TapirErrorHelpers
+    with Clock {
+  val serverPort: Int = findFreePort
+  val controller: Service[F]
+  override def services: List[Service[F]] = List(controller)
+
+  override def beforeAll(): Unit = {
+    IO { Routes.startJdkServer(s"TapirControllerTest:${this.getClass.getName}", serverPort) {} }.unsafeRunAndForget()
+    Thread.sleep(1000)
+  }
+
+  test("That no endpoints are shadowed") {
+    import sttp.tapir.testing.EndpointVerifier
+    val errors = EndpointVerifier(controller.endpoints.map(_.endpoint))
+    if (errors.nonEmpty) {
+      val errString = errors.map(e => e.toString).mkString("\n\t- ", "\n\t- ", "")
+      fail(s"Got errors when verifying ${controller.serviceName} controller:$errString")
+    }
+  }
+
+}


### PR DESCRIPTION
Lager en helper-trait for å slippe å spinne opp serveren manuelt i hver eneste controller test. Samt automatisk inkludere en test for shadowing :smile: 