### PR TITLE
Make `CommaSeparatedList` to work around empty default values

### DIFF
--- a/article-api/src/main/scala/no/ndla/articleapi/controller/ArticleControllerV2.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/controller/ArticleControllerV2.scala
@@ -18,6 +18,7 @@ import no.ndla.articleapi.service.{ConverterService, ReadService, WriteService}
 import no.ndla.articleapi.validation.ContentValidator
 import no.ndla.articleapi.{Eff, Props}
 import no.ndla.common.ContentURIUtil.parseArticleIdAndRevision
+import no.ndla.common.model.api.CommaSeparatedList._
 import no.ndla.language.Language.AllLanguages
 import no.ndla.network.tapir.NoNullJsonPrinter.jsonBody
 import no.ndla.network.tapir.Parameters.feideHeader
@@ -26,7 +27,6 @@ import no.ndla.network.tapir.TapirErrors.errorOutputsFor
 import sttp.tapir.EndpointIO.annotations.{header, jsonbody}
 import sttp.tapir._
 import sttp.tapir.generic.auto._
-import sttp.tapir.model.{CommaSeparated, Delimited}
 import sttp.tapir.server.ServerEndpoint
 
 import scala.util.{Failure, Success, Try}
@@ -71,16 +71,14 @@ trait ArticleControllerV2 {
     private val revision =
       query[Option[Int]]("revision")
         .description("Revision of article to fetch. If not provided the current revision is returned.")
-    private val articleTypes = query[CommaSeparated[String]]("articleTypes")
+    private val articleTypes = listQuery[String]("articleTypes")
       .description(
         "Return only articles of specific type(s). To provide multiple types, separate by comma (,)."
       )
-      .default(Delimited[",", String](List.empty[String]))
-    private val articleIds = query[CommaSeparated[Long]]("ids")
+    private val articleIds = listQuery[Long]("ids")
       .description(
         "Return only articles that have one of the provided ids. To provide multiple ids, separate by comma (,)."
       )
-      .default(Delimited[",", Long](List.empty[Long]))
     private val deprecatedNodeId = path[String]("deprecated_node_id").description("Id of deprecated NDLA node")
     private val fallback =
       query[Boolean]("fallback").description("Fallback to existing language if language is specified.").default(false)
@@ -92,11 +90,10 @@ trait ArticleControllerV2 {
          |If you are not paginating past $ElasticSearchIndexMaxResultWindow hits, you can ignore this and use '${this.pageNo.name}' and '${this.pageSize.name}' instead.
          |""".stripMargin
     )
-    private val grepCodes = query[CommaSeparated[String]]("grep-codes")
+    private val grepCodes = listQuery[String]("grep-codes")
       .description(
         "A comma separated list of codes from GREP API the resources should be filtered by."
       )
-      .default(Delimited[",", String](List.empty))
 
     private case class SummaryWithHeader(
         @jsonbody

--- a/article-api/src/main/scala/no/ndla/articleapi/controller/InternController.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/controller/InternController.scala
@@ -18,6 +18,7 @@ import no.ndla.articleapi.repository.ArticleRepository
 import no.ndla.articleapi.service._
 import no.ndla.articleapi.service.search.{ArticleIndexService, IndexService}
 import no.ndla.articleapi.validation.ContentValidator
+import no.ndla.common.model.api.CommaSeparatedList._
 import no.ndla.common.model.domain.article.Article
 import no.ndla.language.Language
 import no.ndla.network.tapir.NoNullJsonPrinter.jsonBody
@@ -27,7 +28,6 @@ import no.ndla.network.tapir.{Service, TapirErrorHelpers}
 import sttp.model.StatusCode
 import sttp.tapir._
 import sttp.tapir.generic.auto._
-import sttp.tapir.model.{CommaSeparated, Delimited}
 import sttp.tapir.server.ServerEndpoint
 
 import java.util.concurrent.{Executors, TimeUnit}
@@ -167,7 +167,7 @@ trait InternController {
 
     def updateArticle: ServerEndpoint[Any, Eff] = endpoint.post
       .in("article" / path[Long]("id"))
-      .in(query[CommaSeparated[String]]("external-id").default(Delimited[",", String](List.empty)))
+      .in(listQuery[String]("external-id"))
       .in(query[Boolean]("use-import-validation").default(false))
       .in(query[Boolean]("use-soft-validation").default(false))
       .in(jsonBody[Article])

--- a/audio-api/src/main/scala/no/ndla/audioapi/controller/AudioController.scala
+++ b/audio-api/src/main/scala/no/ndla/audioapi/controller/AudioController.scala
@@ -21,6 +21,7 @@ import no.ndla.audioapi.service.{ConverterService, ReadService, WriteService}
 import no.ndla.common.errors.FileTooBigException
 import no.ndla.language.Language
 import no.ndla.common.implicits._
+import no.ndla.common.model.api.CommaSeparatedList._
 import no.ndla.common.model.domain.UploadedFile
 import no.ndla.network.tapir.NoNullJsonPrinter._
 import no.ndla.network.tapir.{NonEmptyString, Service}
@@ -29,7 +30,6 @@ import no.ndla.network.tapir.auth.Permission.AUDIO_API_WRITE
 import sttp.model.Part
 import sttp.tapir.EndpointIO.annotations.{header, jsonbody}
 import sttp.tapir.generic.auto._
-import sttp.tapir.model.CommaSeparated
 import sttp.tapir.server.ServerEndpoint
 import sttp.tapir._
 
@@ -63,7 +63,7 @@ trait AudioController {
     private val pageSize = query[Option[Int]]("page-size").description(
       s"The number of search hits to display for each page. Defaults to $DefaultPageSize and max is $MaxPageSize."
     )
-    private val audioIds = query[CommaSeparated[Long]]("ids").description(
+    private val audioIds = listQuery[Long]("ids").description(
       "Return only audios that have one of the provided ids. To provide multiple ids, separate by comma (,)."
     )
     private val sort = query[Option[String]]("sort").description(

--- a/common/src/main/scala/no/ndla/common/model/api/CommaSeparatedList.scala
+++ b/common/src/main/scala/no/ndla/common/model/api/CommaSeparatedList.scala
@@ -1,0 +1,32 @@
+/*
+ * Part of NDLA common
+ * Copyright (C) 2024 NDLA
+ *
+ * See LICENSE
+ */
+
+package no.ndla.common.model.api
+
+import sttp.tapir.model.CommaSeparated
+import sttp.tapir.{Codec, CodecFormat, EndpointInput, query}
+
+/** A query parameter that is a comma separated list of values. Wraps the `CommaSeparated` type from `sttp.model`.
+  *
+  * This is a workaround for the fact that using `CommaSeparated` directly with a default value results in weird
+  * behavior in the generated swagger documentation.
+  *
+  * See: https://github.com/softwaremill/tapir/issues/3581
+  */
+object CommaSeparatedList {
+  type CommaSeparatedList[T] = Option[CommaSeparated[T]]
+
+  def listQuery[T](
+      name: String
+  )(implicit codec: Codec[String, T, CodecFormat.TextPlain]): EndpointInput.Query[CommaSeparatedList[T]] = {
+    query[CommaSeparatedList[T]](name).default(None)
+  }
+
+  implicit class sepOps[T](val sep: CommaSeparatedList[T]) extends AnyVal {
+    def values: List[T] = sep.map(_.values).getOrElse(List.empty)
+  }
+}

--- a/concept-api/src/main/scala/no/ndla/conceptapi/controller/ConceptControllerHelpers.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/controller/ConceptControllerHelpers.scala
@@ -7,11 +7,11 @@
 
 package no.ndla.conceptapi.controller
 
+import no.ndla.common.model.api.CommaSeparatedList._
 import no.ndla.conceptapi.Props
 import no.ndla.conceptapi.model.domain.{ConceptType, Sort}
 import no.ndla.language.Language
 import sttp.tapir._
-import sttp.tapir.model.{CommaSeparated, Delimited}
 
 trait ConceptControllerHelpers {
   this: Props =>
@@ -26,16 +26,14 @@ trait ConceptControllerHelpers {
     val queryParam =
       query[Option[String]]("query").description("Return only concepts with content matching the specified query.")
 
-    val conceptIds = query[CommaSeparated[Long]]("ids")
+    val conceptIds = listQuery[Long]("ids")
       .description(
         "Return only concepts that have one of the provided ids. To provide multiple ids, separate by comma (,)."
       )
-      .default(Delimited[",", Long](List.empty))
 
     val aggregatePaths =
-      query[CommaSeparated[String]]("aggregate-paths")
+      listQuery[String]("aggregate-paths")
         .description("List of index-paths that should be term-aggregated and returned in result.")
-        .default(Delimited[",", String](List.empty))
 
     val conceptType =
       query[Option[String]]("concept-type")
@@ -82,34 +80,28 @@ trait ConceptControllerHelpers {
        |""".stripMargin
         )
     val subjects =
-      query[CommaSeparated[String]]("subjects")
+      listQuery[String]("subjects")
         .description("A comma-separated list of subjects that should appear in the search.")
-        .default(Delimited[",", String](List.empty))
 
     val tagsToFilterBy =
-      query[CommaSeparated[String]]("tags")
+      listQuery[String]("tags")
         .description("A comma-separated list of tags to filter the search by.")
-        .default(Delimited[",", String](List.empty))
 
-    val userFilter = query[CommaSeparated[String]]("users")
+    val userFilter = listQuery[String]("users")
       .description(
         s"""List of users to filter by.
        |The value to search for is the user-id from Auth0.""".stripMargin
       )
-      .default(Delimited[",", String](List.empty))
 
-    val embedResource = query[CommaSeparated[String]]("embed-resource")
+    val embedResource = listQuery[String]("embed-resource")
       .description("Return concepts with matching embed type.")
-      .default(Delimited[",", String](List.empty))
     val embedId = query[Option[String]]("embed-id").description("Return concepts with matching embed id.")
 
     val exactTitleMatch =
       query[Boolean]("exact-match")
         .description("If provided, only return concept where query matches title exactly.")
         .default(false)
-    val responsibleIdFilter =
-      query[CommaSeparated[String]]("responsible-ids")
-        .description("List of responsible ids to filter by (OR filter)")
-        .default(Delimited[",", String](List.empty))
+    val responsibleIdFilter = listQuery[String]("responsible-ids")
+      .description("List of responsible ids to filter by (OR filter)")
   }
 }

--- a/concept-api/src/main/scala/no/ndla/conceptapi/controller/DraftConceptController.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/controller/DraftConceptController.scala
@@ -9,6 +9,7 @@ package no.ndla.conceptapi.controller
 
 import cats.implicits._
 import no.ndla.common.implicits._
+import no.ndla.common.model.api.CommaSeparatedList._
 import no.ndla.conceptapi.model.api._
 import no.ndla.conceptapi.model.domain.{ConceptStatus, Sort}
 import no.ndla.conceptapi.model.search.DraftSearchSettings
@@ -24,7 +25,6 @@ import sttp.model.headers.CacheDirective
 import sttp.model.{HeaderNames, StatusCode}
 import sttp.tapir._
 import sttp.tapir.generic.auto._
-import sttp.tapir.model.{CommaSeparated, Delimited}
 import sttp.tapir.server.ServerEndpoint
 
 import scala.util.{Failure, Success, Try}
@@ -47,13 +47,12 @@ trait DraftConceptController {
     override val prefix: EndpointInput[Unit] = "concept-api" / "v1" / serviceName
 
     private val pathStatus = path[String]("STATUS").description("Concept status")
-    private val statusFilter = query[CommaSeparated[String]]("status")
+    private val statusFilter = listQuery[String]("status")
       .description(
         s"""List of statuses to filter by.
          |A draft only needs to have one of the available statuses to appear in result (OR).
        """.stripMargin
       )
-      .default(Delimited[",", String](List.empty))
 
     override val endpoints: List[ServerEndpoint[Any, Eff]] = List(
       getStatusStateMachine,

--- a/concept-api/src/main/scala/no/ndla/conceptapi/controller/PublishedConceptController.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/controller/PublishedConceptController.scala
@@ -8,6 +8,7 @@
 package no.ndla.conceptapi.controller
 
 import cats.implicits.catsSyntaxEitherId
+import no.ndla.common.model.api.CommaSeparatedList._
 import no.ndla.common.implicits._
 import no.ndla.conceptapi.model.api._
 import no.ndla.conceptapi.model.domain.Sort

--- a/draft-api/src/main/scala/no/ndla/draftapi/controller/DraftController.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/controller/DraftController.scala
@@ -10,6 +10,7 @@ package no.ndla.draftapi.controller
 import cats.implicits._
 import io.circe.generic.auto._
 import no.ndla.common.model.NDLADate
+import no.ndla.common.model.api.CommaSeparatedList._
 import no.ndla.common.model.api.License
 import no.ndla.common.model.domain.ArticleType
 import no.ndla.common.model.domain.draft.DraftStatus
@@ -29,7 +30,6 @@ import no.ndla.network.tapir.{DynamicHeaders, Service}
 import sttp.model.StatusCode
 import sttp.tapir._
 import sttp.tapir.generic.auto._
-import sttp.tapir.model.{CommaSeparated, Delimited}
 import sttp.tapir.server.ServerEndpoint
 
 import scala.util.{Failure, Success, Try}
@@ -57,23 +57,20 @@ trait DraftController {
         .description("The ID of the article to generate a status state machine for")
     private val pathArticleId = path[Long]("article_id").description("Id of the article that is to be fetched")
     private val pathNodeId    = path[String]("node_id").description("Id of the taxonomy node to process")
-    private val articleTypes = query[CommaSeparated[String]]("articleTypes")
+    private val articleTypes = listQuery[String]("articleTypes")
       .description("Return only articles of specific type(s). To provide multiple types, separate by comma (,).")
-      .default(Delimited[",", String](List.empty))
-    private val articleIds = query[CommaSeparated[Long]]("ids")
+    private val articleIds = listQuery[Long]("ids")
       .description(
         "Return only articles that have one of the provided ids. To provide multiple ids, separate by comma (,)."
       )
-      .default(Delimited[",", Long](List.empty))
     private val filter     = query[Option[String]]("filter").description("A filter to include a specific entry")
     private val filterNot  = query[Option[String]]("filterNot").description("A filter to remove a specific entry")
     private val pathStatus = path[String]("STATUS").description("An article status")
     private val copiedTitleFlag = query[Boolean]("copied-title-postfix")
       .description("Add a string to the title marking this article as a copy, defaults to 'true'.")
       .default(true)
-    private val grepCodes = query[CommaSeparated[String]]("grep-codes")
+    private val grepCodes = listQuery[String]("grep-codes")
       .description("A comma separated list of codes from GREP API the resources should be filtered by.")
-      .default(Delimited[",", String](List.empty))
     private val articleSlug = path[String]("slug").description("Slug of the article that is to be fecthed.")
     private val pageNo = query[Int]("page")
       .description("The page number of the search hits to display.")
@@ -104,12 +101,11 @@ trait DraftController {
          |If you are not paginating past ${props.ElasticSearchIndexMaxResultWindow} hits, you can ignore this and use '${this.pageNo.name}' and '${this.pageSize.name}' instead.
          |""".stripMargin
     )
-    private val externalIds    = query[CommaSeparated[String]]("externalId").default(Delimited[",", String](List.empty))
-    private val oldCreatedDate = query[Option[String]]("oldNdlaCreatedDate")
-    private val oldUpdatedDate = query[Option[String]]("oldNdlaUpdatedDate")
-    private val externalSubjects = query[CommaSeparated[String]]("externalSubjectIds")
-      .default(Delimited[",", String](List.empty))
-    private val importId = query[Option[String]]("importId")
+    private val externalIds      = listQuery[String]("externalId")
+    private val oldCreatedDate   = query[Option[String]]("oldNdlaCreatedDate")
+    private val oldUpdatedDate   = query[Option[String]]("oldNdlaUpdatedDate")
+    private val externalSubjects = listQuery[String]("externalSubjectIds")
+    private val importId         = query[Option[String]]("importId")
 
     override val endpoints: List[ServerEndpoint[Any, Eff]] = List(
       getLicenses,

--- a/frontpage-api/src/main/scala/no/ndla/frontpageapi/controller/SubjectPageController.scala
+++ b/frontpage-api/src/main/scala/no/ndla/frontpageapi/controller/SubjectPageController.scala
@@ -8,6 +8,7 @@
 package no.ndla.frontpageapi.controller
 
 import io.circe.generic.auto._
+import no.ndla.common.model.api.CommaSeparatedList._
 import no.ndla.frontpageapi.{Eff, Props}
 import no.ndla.frontpageapi.model.api.{
   ErrorHelpers,
@@ -23,7 +24,6 @@ import no.ndla.network.tapir.TapirErrors.errorOutputsFor
 import no.ndla.network.tapir.auth.Permission.FRONTPAGE_API_WRITE
 import sttp.tapir._
 import sttp.tapir.generic.auto._
-import sttp.tapir.model.CommaSeparated
 import sttp.tapir.server.ServerEndpoint
 
 trait SubjectPageController {
@@ -66,7 +66,7 @@ trait SubjectPageController {
     def getSubjectPagesByIds: ServerEndpoint[Any, Eff] = endpoint.get
       .summary("Fetch subject pages that matches ids parameter")
       .in("ids")
-      .in(query[CommaSeparated[Long]]("ids"))
+      .in(listQuery[Long]("ids"))
       .in(query[String]("language").default(props.DefaultLanguage))
       .in(query[Boolean]("fallback").default(false))
       .in(query[Int]("page-size").default(props.DefaultPageSize))

--- a/image-api/src/main/scala/no/ndla/imageapi/controller/BaseImageController.scala
+++ b/image-api/src/main/scala/no/ndla/imageapi/controller/BaseImageController.scala
@@ -9,13 +9,13 @@
 package no.ndla.imageapi.controller
 
 import no.ndla.common.errors.FileTooBigException
+import no.ndla.common.model.api.CommaSeparatedList._
 import no.ndla.common.model.domain.UploadedFile
 import no.ndla.imageapi.Props
 import no.ndla.imageapi.model.domain.{ModelReleasedStatus, Sort}
 import no.ndla.language.Language
 import sttp.model.Part
 import sttp.tapir._
-import sttp.tapir.model.{CommaSeparated, Delimited}
 
 import java.io.File
 import scala.util.{Failure, Try}
@@ -81,18 +81,16 @@ trait BaseImageController {
          |""".stripMargin
     )
 
-    val modelReleased = query[CommaSeparated[String]]("model-released")
+    val modelReleased = listQuery[String]("model-released")
       .description(
         s"Filter whether the image(s) should be model-released or not. Multiple values can be specified in a comma separated list. Possible values include: ${ModelReleasedStatus.values
             .mkString(",")}"
       )
-      .default(Delimited[",", String](List.empty))
 
-    val imageIds = query[CommaSeparated[Long]]("ids")
+    val imageIds = listQuery[Long]("ids")
       .description(
         "Return only images that have one of the provided ids. To provide multiple ids, separate by comma (,)."
       )
-      .default(Delimited[",", Long](List.empty))
     val podcastFriendly =
       query[Option[Boolean]]("podcast-friendly")
         .description("Filter images that are podcast friendly. Width==heigth and between 1400 and 3000.")

--- a/image-api/src/main/scala/no/ndla/imageapi/controller/ImageControllerV2.scala
+++ b/image-api/src/main/scala/no/ndla/imageapi/controller/ImageControllerV2.scala
@@ -9,22 +9,23 @@
 package no.ndla.imageapi.controller
 
 import cats.implicits._
-import no.ndla.language.Language
+import no.ndla.common.model.api.CommaSeparatedList._
 import no.ndla.imageapi.controller.multipart.{MetaDataAndFileForm, UpdateMetaDataAndFileForm}
-import no.ndla.imageapi.{Eff, Props}
-import no.ndla.imageapi.model.api.{ErrorHelpers, ImageMetaInformationV2, SearchParams, SearchResult, TagsSearchResult}
+import no.ndla.imageapi.model.api._
 import no.ndla.imageapi.model.domain.{ModelReleasedStatus, SearchSettings, Sort}
 import no.ndla.imageapi.repository.ImageRepository
-import no.ndla.imageapi.service.{ConverterService, ReadService, WriteService}
 import no.ndla.imageapi.service.search.{ImageSearchService, SearchConverterService}
+import no.ndla.imageapi.service.{ConverterService, ReadService, WriteService}
+import no.ndla.imageapi.{Eff, Props}
+import no.ndla.language.Language
 import no.ndla.network.tapir.NoNullJsonPrinter._
-import no.ndla.network.tapir.{DynamicHeaders, Service}
 import no.ndla.network.tapir.TapirErrors.errorOutputsFor
 import no.ndla.network.tapir.auth.Permission.IMAGE_API_WRITE
 import no.ndla.network.tapir.auth.TokenUser
+import no.ndla.network.tapir.{DynamicHeaders, Service}
+import sttp.tapir._
 import sttp.tapir.generic.auto._
 import sttp.tapir.server.ServerEndpoint
-import sttp.tapir._
 
 import scala.util.{Failure, Success, Try}
 

--- a/image-api/src/main/scala/no/ndla/imageapi/controller/ImageControllerV3.scala
+++ b/image-api/src/main/scala/no/ndla/imageapi/controller/ImageControllerV3.scala
@@ -9,22 +9,23 @@
 package no.ndla.imageapi.controller
 
 import cats.implicits._
-import no.ndla.language.Language
+import no.ndla.common.model.api.CommaSeparatedList._
 import no.ndla.imageapi.controller.multipart.{MetaDataAndFileForm, UpdateMetaDataAndFileForm}
-import no.ndla.imageapi.{Eff, Props}
-import no.ndla.imageapi.model.api.{ErrorHelpers, ImageMetaInformationV3, SearchParams, SearchResultV3, TagsSearchResult}
+import no.ndla.imageapi.model.api._
 import no.ndla.imageapi.model.domain.{ModelReleasedStatus, SearchSettings, Sort}
 import no.ndla.imageapi.repository.ImageRepository
-import no.ndla.imageapi.service.{ConverterService, ReadService, WriteService}
 import no.ndla.imageapi.service.search.{ImageSearchService, SearchConverterService}
+import no.ndla.imageapi.service.{ConverterService, ReadService, WriteService}
+import no.ndla.imageapi.{Eff, Props}
+import no.ndla.language.Language
 import no.ndla.network.tapir.NoNullJsonPrinter._
-import no.ndla.network.tapir.{DynamicHeaders, Service}
 import no.ndla.network.tapir.TapirErrors.errorOutputsFor
 import no.ndla.network.tapir.auth.Permission.IMAGE_API_WRITE
 import no.ndla.network.tapir.auth.TokenUser
+import no.ndla.network.tapir.{DynamicHeaders, Service}
+import sttp.tapir._
 import sttp.tapir.generic.auto._
 import sttp.tapir.server.ServerEndpoint
-import sttp.tapir._
 
 import scala.util.{Failure, Success, Try}
 

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/controller/InternController.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/controller/InternController.scala
@@ -9,6 +9,7 @@
 package no.ndla.learningpathapi.controller
 
 import cats.implicits.catsSyntaxEitherId
+import no.ndla.common.model.api.CommaSeparatedList._
 import no.ndla.learningpathapi.model.api.{ErrorHelpers, LearningPathDomainDump, LearningPathSummaryV2}
 import no.ndla.learningpathapi.{Eff, Props}
 import no.ndla.learningpathapi.model.domain
@@ -21,7 +22,6 @@ import no.ndla.network.tapir.TapirErrors.errorOutputsFor
 import sttp.model.StatusCode
 import sttp.tapir._
 import sttp.tapir.generic.auto._
-import sttp.tapir.model.{CommaSeparated, Delimited}
 import sttp.tapir.server.ServerEndpoint
 
 import scala.util.{Failure, Success}
@@ -142,7 +142,7 @@ trait InternController {
 
     def containsArticle: ServerEndpoint[Any, Eff] = endpoint.get
       .in("containsArticle")
-      .in(query[CommaSeparated[String]]("paths").default(Delimited[",", String](List.empty)))
+      .in(listQuery[String]("paths"))
       .out(jsonBody[Seq[LearningPathSummaryV2]])
       .errorOut(errorOutputsFor(404))
       .serverLogicPure { paths =>

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/controller/LearningpathControllerV2.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/controller/LearningpathControllerV2.scala
@@ -9,6 +9,7 @@
 package no.ndla.learningpathapi.controller
 
 import cats.implicits.catsSyntaxEitherId
+import no.ndla.common.model.api.CommaSeparatedList._
 import no.ndla.common.model.api.{Author, License}
 import no.ndla.language.Language
 import no.ndla.language.Language.AllLanguages
@@ -30,7 +31,6 @@ import no.ndla.network.tapir.{DynamicHeaders, Service}
 import sttp.model.StatusCode
 import sttp.tapir._
 import sttp.tapir.generic.auto._
-import sttp.tapir.model.{CommaSeparated, Delimited}
 import sttp.tapir.server.ServerEndpoint
 
 import scala.util.{Failure, Success, Try}
@@ -84,11 +84,10 @@ trait LearningpathControllerV2 {
       path[Long]("learningstep_id").description("Id of the learningstep.")
     private val tag =
       query[Option[String]]("tag").description("Return only Learningpaths that are tagged with this exact tag.")
-    private val learningpathIds = query[CommaSeparated[Long]]("ids")
+    private val learningpathIds = listQuery[Long]("ids")
       .description(
         "Return only Learningpaths that have one of the provided ids. To provide multiple ids, separate by comma (,)."
       )
-      .default(Delimited[",", Long](List.empty))
     private val licenseFilter =
       query[Option[String]]("filter")
         .description("Query for filtering licenses. Only licenses containing filter-string are returned.")
@@ -110,11 +109,10 @@ trait LearningpathControllerV2 {
       )
     private val verificationStatus = query[Option[String]]("verificationStatus")
       .description("Return only learning paths that have this verification status.")
-    private val ids = query[CommaSeparated[Long]]("ids")
+    private val ids = listQuery[Long]("ids")
       .description(
         "Return only learningpaths that have one of the provided ids. To provide multiple ids, separate by comma (,)."
       )
-      .default(Delimited[",", Long](List.empty))
 
     /** Does a scroll with [[SearchService]] If no scrollId is specified execute the function @orFunction in the second
       * parameter list.

--- a/search-api/src/main/scala/no/ndla/searchapi/controller/SearchController.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/controller/SearchController.scala
@@ -10,6 +10,7 @@ package no.ndla.searchapi.controller
 
 import cats.implicits._
 import no.ndla.common.model.NDLADate
+import no.ndla.common.model.api.CommaSeparatedList._
 import no.ndla.common.model.domain.draft.DraftStatus
 import no.ndla.common.model.domain.{ArticleType, Availability}
 import no.ndla.language.Language.AllLanguages
@@ -40,7 +41,6 @@ import scala.concurrent.{Await, ExecutionContext, ExecutionContextExecutorServic
 import scala.util.{Failure, Success, Try}
 import sttp.tapir._
 import sttp.tapir.generic.auto._
-import sttp.tapir.model.{CommaSeparated, Delimited}
 import sttp.tapir.server.ServerEndpoint
 
 trait SearchController {
@@ -84,70 +84,58 @@ trait SearchController {
       .default(DefaultPageSize)
       .validate(Validator.inRange(1, MaxPageSize))
     private val resourceTypes =
-      query[CommaSeparated[String]]("resource-types")
+      listQuery[String]("resource-types")
         .description(
           "Return only learning resources of specific type(s). To provide multiple types, separate by comma (,)."
         )
-        .default(Delimited[",", String](List.empty))
     private val learningResourceIds =
-      query[CommaSeparated[Long]]("ids")
+      listQuery[Long]("ids")
         .description(
           "Return only learning resources that have one of the provided ids. To provide multiple ids, separate by comma (,)."
         )
-        .default(Delimited[",", Long](List.empty))
     private val fallback =
       query[Boolean]("fallback")
         .description("Fallback to existing language if language is specified.")
         .default(false)
     private val subjects =
-      query[CommaSeparated[String]]("subjects")
+      listQuery[String]("subjects")
         .description("A comma separated list of subjects the learning resources should be filtered by.")
-        .default(Delimited[",", String](List.empty))
     private val articleTypes =
-      query[CommaSeparated[String]]("article-types")
+      listQuery[String]("article-types")
         .description(
           s"A comma separated list of article-types the search should be filtered by. Available values is ${ArticleType.all
               .mkString(", ")}"
         )
-        .default(Delimited[",", String](List.empty))
     private val contextTypes =
-      query[CommaSeparated[String]]("context-types")
+      listQuery[String]("context-types")
         .description(
           s"A comma separated list of context-types the learning resources should be filtered by. Available values is ${LearningResourceType.values
               .mkString(", ")}"
         )
-        .default(Delimited[",", String](List.empty))
     private val groupTypes =
-      query[CommaSeparated[String]]("resource-types")
+      listQuery[String]("resource-types")
         .description("A comma separated list of resource-types the learning resources should be grouped by.")
-        .default(Delimited[",", String](List.empty))
-    private val languageFilter = query[CommaSeparated[String]]("language-filter")
-      .description(
-        "A comma separated list of ISO 639-1 language codes that the learning resource can be available in."
-      )
-      .default(Delimited[",", String](List.empty))
-    private val relevanceFilter = query[CommaSeparated[String]]("relevance")
+    private val languageFilter = listQuery[String]("language-filter")
+      .description("A comma separated list of ISO 639-1 language codes that the learning resource can be available in.")
+    private val relevanceFilter = listQuery[String]("relevance")
       .description(
         """A comma separated list of relevances the learning resources should be filtered by.
         |If subjects are specified the learning resource must have specified relevances in relation to a specified subject.
         |If levels are specified the learning resource must have specified relevances in relation to a specified level.""".stripMargin
       )
-      .default(Delimited[",", String](List.empty))
-    private val contextFilters = query[CommaSeparated[String]]("context-filters")
+    private val contextFilters = listQuery[String]("context-filters")
       .description(
         """A comma separated list of resource-types the learning resources should be filtered by.
         |Used in conjunction with the parameter resource-types to filter additional resource-types.
       """.stripMargin
       )
-      .default(Delimited[",", String](List.empty))
     private val includeMissingResourceTypeGroup = query[Boolean]("missing-group")
       .description(
         "Whether to include group without resource-types for group-search. Defaults to false."
       )
       .default(false)
-    private val grepCodes = query[CommaSeparated[String]]("grep-codes")
+    private val grepCodes = listQuery[String]("grep-codes")
       .description("A comma separated list of codes from GREP API the resources should be filtered by.")
-      .default(Delimited[",", String](List.empty))
     private val scrollId = query[Option[String]]("search-context")
       .description(
         s"""A unique string obtained from a search you want to keep scrolling in. To obtain one from a search, provide one of the following values: ${InitialScrollContextKeywords
@@ -157,15 +145,13 @@ trait SearchController {
           |If you are not paginating past $ElasticSearchIndexMaxResultWindow hits, you can ignore this and use '${this.pageNo.name}' and '${this.pageSize.name}' instead.
           |""".stripMargin
       )
-    private val aggregatePaths = query[CommaSeparated[String]]("aggregate-paths")
+    private val aggregatePaths = listQuery[String]("aggregate-paths")
       .description("List of index-paths that should be term-aggregated and returned in result.")
-      .default(Delimited[",", String](List.empty))
     private val embedResource =
-      query[CommaSeparated[String]]("embed-resource")
+      listQuery[String]("embed-resource")
         .description(
           "Return only results with embed data-resource the specified resource. Can specify multiple with a comma separated list to filter for one of the embed types."
         )
-        .default(Delimited[",", String](List.empty))
     private val embedId =
       query[Option[String]]("embed-id")
         .description("Return only results with embed data-resource_id, data-videoid or data-url with the specified id.")


### PR DESCRIPTION
Når vi bruker `sttp.tapir.model.CommaSeparated` direkte, ender vi opp med en streng som default-verdi når vi bruker `.default`.

Dette resulterer i at Swagger tror det skal være ett element med en tom streng i forespørselen.
Å pakke det inn i en `Option` lar oss ha en default-verdi `None`, og den implicit classen gjør overgangen mellom
Option[CommaSeparated[...]] og CommaSeparated[...] ganske enkel, sånn at det blir lett å gå tilbake om [denne](https://github.com/softwaremill/tapir/issues/3581) blir løst.