### PR TITLE
Avoid some unnecessary `IO` wrapping

### DIFF
--- a/concept-api/src/main/scala/no/ndla/conceptapi/service/ConverterService.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/service/ConverterService.scala
@@ -8,7 +8,6 @@
 package no.ndla.conceptapi.service
 
 import cats.implicits._
-import cats.effect.IO
 import com.typesafe.scalalogging.StrictLogging
 import io.lemonlabs.uri.{Path, Url}
 import no.ndla.common.model.domain.{Responsible, Tag, Title}
@@ -333,7 +332,7 @@ trait ConverterService {
       )
     }
 
-    def updateStatus(status: ConceptStatus, concept: domain.Concept, user: TokenUser): IO[Try[domain.Concept]] =
+    def updateStatus(status: ConceptStatus, concept: domain.Concept, user: TokenUser): Try[domain.Concept] =
       StateTransitionRules.doTransition(concept, status, user)
 
     def toDomainConcept(id: Long, concept: api.UpdatedConcept, userInfo: TokenUser): domain.Concept = {

--- a/concept-api/src/main/scala/no/ndla/conceptapi/service/WriteService.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/service/WriteService.scala
@@ -7,7 +7,6 @@
 
 package no.ndla.conceptapi.service
 
-import cats.effect.unsafe.implicits.global
 import com.typesafe.scalalogging.StrictLogging
 import no.ndla.common.Clock
 import no.ndla.conceptapi.repository.{DraftConceptRepository, PublishedConceptRepository}
@@ -113,12 +112,7 @@ trait WriteService {
         val newStatusIfNotDefined = if (oldStatus == PUBLISHED) IN_PROGRESS else oldStatus
         val newStatus             = updateStatus.flatMap(ConceptStatus.valueOf).getOrElse(newStatusIfNotDefined)
 
-        converterService
-          .updateStatus(newStatus, changed, user)
-          .attempt
-          .unsafeRunSync()
-          .toTry
-          .flatten
+        converterService.updateStatus(newStatus, changed, user)
       }
     }
 
@@ -255,12 +249,7 @@ trait WriteService {
         case None => Failure(NotFoundException(s"No article with id $id was found"))
         case Some(draft) =>
           for {
-            convertedConceptT <- converterService
-              .updateStatus(status, draft, user)
-              .attempt
-              .unsafeRunSync()
-              .toTry
-            convertedConcept <- convertedConceptT
+            convertedConcept <- converterService.updateStatus(status, draft, user)
             updatedConcept   <- updateConcept(convertedConcept)
             _                <- draftConceptIndexService.indexDocument(updatedConcept)
             apiConcept <- converterService.toApiConcept(

--- a/concept-api/src/test/scala/no/ndla/conceptapi/service/StateTransitionRulesTest.scala
+++ b/concept-api/src/test/scala/no/ndla/conceptapi/service/StateTransitionRulesTest.scala
@@ -1,6 +1,5 @@
 package no.ndla.conceptapi.service
 
-import cats.effect.unsafe.implicits.global
 import no.ndla.common.model.domain.draft.DraftCopyright
 import no.ndla.common.model.domain.{Author, Responsible, Tag, Title}
 import no.ndla.conceptapi.{TestData, TestEnvironment, UnitSuite}
@@ -54,9 +53,8 @@ class StateTransitionRulesTest extends UnitSuite with TestEnvironment {
     )
     for (t <- transitionsToTest) {
       val fromDraft = concept.copy(status = status.copy(current = t.from), responsible = Some(beforeResponsible))
-      val result = StateTransitionRules
-        .doTransition(fromDraft, ConceptStatus.PUBLISHED, TestData.userWithWriteAndPublishAccess)
-        .unsafeRunSync()
+      val result =
+        StateTransitionRules.doTransition(fromDraft, ConceptStatus.PUBLISHED, TestData.userWithWriteAndPublishAccess)
 
       if (result.get.responsible.isDefined) {
         fail(s"${t.from} -> ${t.to} did not reset responsible >:( Look at the sideeffects in `StateTransitionRules`")
@@ -109,7 +107,6 @@ class StateTransitionRulesTest extends UnitSuite with TestEnvironment {
       val fromDraft = concept.copy(status = status.copy(current = t.from), responsible = Some(beforeResponsible))
       val result = StateTransitionRules
         .doTransition(fromDraft, ConceptStatus.ARCHIVED, TestData.userWithWriteAndPublishAccess)
-        .unsafeRunSync()
 
       if (result.get.responsible.isDefined) {
         fail(s"${t.from} -> ${t.to} did not reset responsible >:( Look at the sideeffects in `StateTransitionRules`")
@@ -162,7 +159,6 @@ class StateTransitionRulesTest extends UnitSuite with TestEnvironment {
       val fromDraft = concept.copy(status = status.copy(current = t.from), responsible = Some(beforeResponsible))
       val result = StateTransitionRules
         .doTransition(fromDraft, ConceptStatus.UNPUBLISHED, TestData.userWithWriteAndPublishAccess)
-        .unsafeRunSync()
 
       if (result.get.responsible.isDefined) {
         fail(s"${t.from} -> ${t.to} did not reset responsible >:( Look at the sideeffects in `StateTransitionRules`")
@@ -215,7 +211,6 @@ class StateTransitionRulesTest extends UnitSuite with TestEnvironment {
     val fromConcept = concept.copy(status = status.copy(current = transitionToTest.from))
     val result = StateTransitionRules
       .doTransition(fromConcept, ConceptStatus.IN_PROGRESS, TestData.userWithWriteAndPublishAccess)
-      .unsafeRunSync()
 
     result.get.responsible.get.responsibleId should be(expected)
   }

--- a/draft-api/src/main/scala/no/ndla/draftapi/service/ConverterService.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/service/ConverterService.scala
@@ -7,7 +7,6 @@
 
 package no.ndla.draftapi.service
 
-import cats.effect.IO
 import cats.implicits._
 import com.typesafe.scalalogging.StrictLogging
 import no.ndla.common.configuration.Constants.EmbedTagName
@@ -348,7 +347,7 @@ trait ConverterService {
         draft: Draft,
         user: TokenUser,
         isImported: Boolean
-    ): IO[Try[Draft]] = StateTransitionRules.doTransition(draft, status, user, isImported)
+    ): Try[Draft] = StateTransitionRules.doTransition(draft, status, user, isImported)
 
     private def toApiResponsible(responsible: Responsible): api.DraftResponsible =
       api.DraftResponsible(

--- a/draft-api/src/main/scala/no/ndla/draftapi/service/WriteService.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/service/WriteService.scala
@@ -7,7 +7,6 @@
 
 package no.ndla.draftapi.service
 
-import cats.effect.unsafe.implicits.global
 import cats.implicits._
 import com.typesafe.scalalogging.StrictLogging
 import io.lemonlabs.uri.Path
@@ -216,12 +215,7 @@ trait WriteService {
         case None => Failure(api.NotFoundException(s"No article with id $id was found"))
         case Some(draft) =>
           for {
-            convertedArticle <- converterService
-              .updateStatus(status, draft, user, isImported)
-              .attempt
-              .unsafeRunSync()
-              .toTry
-              .flatten
+            convertedArticle <- converterService.updateStatus(status, draft, user, isImported)
             updatedArticle <- updateArticleAndStoreAsNewIfPublished(
               convertedArticle,
               isImported,
@@ -554,12 +548,7 @@ trait WriteService {
       val newStatusIfUndefined = if (oldStatus == PUBLISHED) IN_PROGRESS else oldStatus
       val newStatus            = newManualStatus.getOrElse(newStatusIfUndefined)
 
-      converterService
-        .updateStatus(newStatus, convertedArticle, user, isImported = false)
-        .attempt
-        .unsafeRunSync()
-        .toTry
-        .flatten
+      converterService.updateStatus(newStatus, convertedArticle, user, isImported = false)
     }
 
     def updateArticle(

--- a/draft-api/src/test/scala/no/ndla/draftapi/service/ConverterServiceTest.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/service/ConverterServiceTest.scala
@@ -7,7 +7,6 @@
 
 package no.ndla.draftapi.service
 
-import cats.effect.unsafe.implicits.global
 import no.ndla.common
 import no.ndla.common.configuration.Constants.EmbedTagName
 import no.ndla.common.errors.ValidationException
@@ -154,9 +153,7 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
 
   test("updateStatus should return an IO[Failure] if the status change is illegal") {
     val Failure(res: IllegalStatusStateTransition) =
-      service
-        .updateStatus(PUBLISHED, TestData.sampleArticleWithByNcSa, TestData.userWithWriteAccess, false)
-        .unsafeRunSync()
+      service.updateStatus(PUBLISHED, TestData.sampleArticleWithByNcSa, TestData.userWithWriteAccess, false)
     res.getMessage should equal(
       s"Cannot go to PUBLISHED when article is ${TestData.sampleArticleWithByNcSa.status.current}"
     )
@@ -584,7 +581,7 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
     val article =
       TestData.sampleDomainArticle.copy(status = status, responsible = Some(Responsible("hei", clock.now())))
     val Failure(res: IllegalStatusStateTransition) =
-      service.updateStatus(ARCHIVED, article, TestData.userWithPublishAccess, isImported = false).unsafeRunSync()
+      service.updateStatus(ARCHIVED, article, TestData.userWithPublishAccess, isImported = false)
 
     res.getMessage should equal(s"Cannot go to ARCHIVED when article contains ${status.other}")
   }

--- a/draft-api/src/test/scala/no/ndla/draftapi/service/StateTransitionRulesTest.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/service/StateTransitionRulesTest.scala
@@ -7,7 +7,6 @@
 
 package no.ndla.draftapi.service
 
-import cats.effect.unsafe.implicits.global
 import no.ndla.common.errors.{ValidationException, ValidationMessage}
 import no.ndla.common.model.domain.{Priority, Responsible, Status}
 import no.ndla.common.model.domain.draft.Draft
@@ -391,7 +390,6 @@ class StateTransitionRulesTest extends UnitSuite with TestEnvironment {
           TestData.userWithPublishAccess,
           false
         )
-        .unsafeRunSync()
     )
     verify(articleApiClient, times(transitionsToTest.size))
       .validateArticle(any[common.article.Article], any[Boolean], any)
@@ -486,7 +484,6 @@ class StateTransitionRulesTest extends UnitSuite with TestEnvironment {
       val fromDraft = draft.copy(status = status.copy(current = t.from), responsible = Some(beforeResponsible))
       val result = StateTransitionRules
         .doTransition(fromDraft, PUBLISHED, TestData.userWithAdminAccess, isImported = false)
-        .unsafeRunSync()
 
       if (result.get.responsible.isDefined) {
         fail(s"${t.from} -> ${t.to} did not reset responsible >:( Look at the sideeffects in `StateTransitionRules`")
@@ -546,7 +543,6 @@ class StateTransitionRulesTest extends UnitSuite with TestEnvironment {
       val fromDraft = draft.copy(status = status.copy(current = t.from), responsible = Some(beforeResponsible))
       val result = StateTransitionRules
         .doTransition(fromDraft, ARCHIVED, TestData.userWithAdminAccess, isImported = false)
-        .unsafeRunSync()
 
       if (result.get.responsible.isDefined) {
         fail(s"${t.from} -> ${t.to} did not reset responsible >:( Look at the sideeffects in `StateTransitionRules`")
@@ -609,7 +605,6 @@ class StateTransitionRulesTest extends UnitSuite with TestEnvironment {
       val fromDraft = draft.copy(status = status.copy(current = t.from), responsible = Some(beforeResponsible))
       val result = StateTransitionRules
         .doTransition(fromDraft, UNPUBLISHED, TestData.userWithAdminAccess, isImported = false)
-        .unsafeRunSync()
 
       if (result.get.responsible.isDefined) {
         fail(s"${t.from} -> ${t.to} did not reset responsible >:( Look at the sideeffects in `StateTransitionRules`")
@@ -671,7 +666,6 @@ class StateTransitionRulesTest extends UnitSuite with TestEnvironment {
     val fromDraft = draft.copy(status = status.copy(current = transitionToTest.from))
     val result = StateTransitionRules
       .doTransition(fromDraft, IN_PROGRESS, TestData.userWithAdminAccess, isImported = false)
-      .unsafeRunSync()
 
     result.get.responsible.get.responsibleId should be(expected)
   }

--- a/draft-api/src/test/scala/no/ndla/draftapi/service/WriteServiceTest.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/service/WriteServiceTest.scala
@@ -7,7 +7,6 @@
 
 package no.ndla.draftapi.service
 
-import cats.effect.unsafe.implicits.global
 import com.amazonaws.services.s3.model.ObjectMetadata
 import no.ndla.common.configuration.Constants.EmbedTagName
 import no.ndla.common.model
@@ -458,10 +457,6 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
     val user = TokenUser("Pelle", Set(DRAFT_API_WRITE), None)
     val updatedArticle = converterService
       .updateStatus(DraftStatus.IN_PROGRESS, articleToUpdate, user, isImported = false)
-      .attempt
-      .unsafeRunSync()
-      .toTry
-      .get
       .get
     val updatedAndInserted = updatedArticle
       .copy(


### PR DESCRIPTION
Jeg tenker vi kan droppe denne `IO`-wrappingen med mindre vi skal begynne å bruke `IO` "på-ordentlig". Sånn den er nå så gjør den bare at vi må spesial-håndtere context-variabler uten at vi faktisk får noe nytte av det.