### PR TITLE
oembed-proxy: Fix deserialization of providers.json

### DIFF
--- a/oembed-proxy/src/main/scala/no/ndla/oembedproxy/model/OEmbedEndpoint.scala
+++ b/oembed-proxy/src/main/scala/no/ndla/oembedproxy/model/OEmbedEndpoint.scala
@@ -16,7 +16,7 @@ case class OEmbedEndpoint(
     url: Option[String],
     discovery: Option[Boolean],
     formats: Option[List[String]],
-    mandatoryQueryParams: List[(String, String)] = List()
+    mandatoryQueryParams: Option[List[(String, String)]]
 ) {
 
   def supports(url: String): Boolean = {

--- a/oembed-proxy/src/main/scala/no/ndla/oembedproxy/model/OEmbedProvider.scala
+++ b/oembed-proxy/src/main/scala/no/ndla/oembedproxy/model/OEmbedProvider.scala
@@ -38,7 +38,9 @@ case class OEmbedProvider(
         val embedUrl = endpoint.url.get.replace("{format}", "json") // Some providers have {format} instead of ?format=
         val width    = maxWidth.map(("maxwidth", _)).toList
         val height   = maxHeight.map(("maxheight", _)).toList
-        val params   = List(("url", url), ("format", "json")) ++ endpoint.mandatoryQueryParams ++ width ++ height
+        val params = List(("url", url), ("format", "json")) ++ endpoint.mandatoryQueryParams.getOrElse(
+          List.empty
+        ) ++ width ++ height
         Url.parse(embedUrl).addParams(params).toString
     }
   }
@@ -50,8 +52,8 @@ case class OEmbedProvider(
 object OEmbedProvider {
   implicit val decoder: Decoder[OEmbedProvider] = Decoder.instance { cur =>
     for {
-      providerName <- cur.downField("providerName").as[String]
-      providerUrl  <- cur.downField("providerUrl").as[String]
+      providerName <- cur.downField("provider_name").as[String]
+      providerUrl  <- cur.downField("provider_url").as[String]
       endpoints    <- cur.downField("endpoints").as[List[OEmbedEndpoint]]
     } yield OEmbedProvider(providerName, providerUrl, endpoints)
 

--- a/oembed-proxy/src/main/scala/no/ndla/oembedproxy/service/ProviderService.scala
+++ b/oembed-proxy/src/main/scala/no/ndla/oembedproxy/service/ProviderService.scala
@@ -34,6 +34,7 @@ trait ProviderService {
         Some(props.NdlaApprovedUrl),
         Some(props.NdlaFrontendOembedServiceUrl),
         None,
+        None,
         None
       )
 
@@ -41,6 +42,7 @@ trait ProviderService {
       OEmbedEndpoint(
         Some(props.ListingFrontendApprovedUrls),
         Some(props.ListingFrontendOembedServiceUrl),
+        None,
         None,
         None
       )
@@ -56,6 +58,7 @@ trait ProviderService {
       Some(List("https://*.youtube.com/watch*", "https://*.youtube.com/v/*", "https://youtu.be/*")),
       Some("https://www.youtube.com/oembed"),
       None,
+      None,
       None
     )
 
@@ -70,7 +73,7 @@ trait ProviderService {
     val H5PApprovedUrls: List[String] = List(props.NdlaH5PApprovedUrl)
 
     val H5PEndpoint: OEmbedEndpoint =
-      OEmbedEndpoint(Some(H5PApprovedUrls), Some(s"${props.NdlaH5POembedProvider}/oembed"), None, None)
+      OEmbedEndpoint(Some(H5PApprovedUrls), Some(s"${props.NdlaH5POembedProvider}/oembed"), None, None, None)
 
     val H5PProvider: OEmbedProvider =
       OEmbedProvider("H5P", props.NdlaH5POembedProvider, List(H5PEndpoint))
@@ -91,13 +94,19 @@ trait ProviderService {
     )
 
     val TedEndpoint: OEmbedEndpoint =
-      OEmbedEndpoint(Some(TedApprovedUrls), Some("https://www.ted.com/services/v1/oembed.json"), None, None)
+      OEmbedEndpoint(Some(TedApprovedUrls), Some("https://www.ted.com/services/v1/oembed.json"), None, None, None)
     val TedProvider: OEmbedProvider = OEmbedProvider("Ted", "https://ted.com", List(TedEndpoint), removeQueryString)
 
     val IssuuApprovedUrls: List[String] = List("http://issuu.com/*", "https://issuu.com/*")
 
     val IssuuEndpoint: OEmbedEndpoint =
-      OEmbedEndpoint(Some(IssuuApprovedUrls), Some("https://issuu.com/oembed"), None, None, List(("iframe", "true")))
+      OEmbedEndpoint(
+        Some(IssuuApprovedUrls),
+        Some("https://issuu.com/oembed"),
+        None,
+        None,
+        Some(List(("iframe", "true")))
+      )
 
     val IssuuProvider: OEmbedProvider =
       OEmbedProvider("Issuu", "https://issuu.com", List(IssuuEndpoint), removeQueryStringAndFragment)
@@ -108,9 +117,8 @@ trait ProviderService {
     })
 
     def _loadProviders(): List[OEmbedProvider] = {
-      NdlaApiProvider :: TedProvider :: H5PProvider :: YoutubeProvider :: IssuuProvider :: loadProvidersFromRequest(
-        quickRequest.get(uri"${props.JSonProviderUrl}")
-      )
+      val requestProviders = loadProvidersFromRequest(quickRequest.get(uri"${props.JSonProviderUrl}"))
+      NdlaApiProvider :: TedProvider :: H5PProvider :: YoutubeProvider :: IssuuProvider :: requestProviders
     }
 
     def loadProvidersFromRequest(request: NdlaRequest): List[OEmbedProvider] = {

--- a/oembed-proxy/src/test/scala/no/ndla/oembedproxy/model/OEmbedEndpointTest.scala
+++ b/oembed-proxy/src/test/scala/no/ndla/oembedproxy/model/OEmbedEndpointTest.scala
@@ -12,7 +12,7 @@ import no.ndla.oembedproxy.UnitSuite
 
 class OEmbedEndpointTest extends UnitSuite {
 
-  val dummyEndpoint: OEmbedEndpoint = OEmbedEndpoint(None, None, None, None)
+  val dummyEndpoint: OEmbedEndpoint = OEmbedEndpoint(None, None, None, None, None)
 
   test("That matches returns true for a matching expression") {
     dummyEndpoint.matches("http://www.ndla.no/*/test", "http://www.ndla.no/123123/test") should be(right = true)

--- a/oembed-proxy/src/test/scala/no/ndla/oembedproxy/model/OEmbedProviderTest.scala
+++ b/oembed-proxy/src/test/scala/no/ndla/oembedproxy/model/OEmbedProviderTest.scala
@@ -16,13 +16,13 @@ class OEmbedProviderTest extends UnitSuite {
     OEmbedProvider("youtube", "https://www.youtube.com", List())
 
   val ndlaEndpoint: OEmbedEndpoint =
-    OEmbedEndpoint(Some(List("https://ndla.no/*/123")), Some("https://ndla.no/oembed"), None, None)
+    OEmbedEndpoint(Some(List("https://ndla.no/*/123")), Some("https://ndla.no/oembed"), None, None, None)
 
   val ndlaListEndpoint: OEmbedEndpoint =
-    OEmbedEndpoint(Some(List("https://liste.ndla.no/*")), Some("https://liste.ndla.no/oembed"), None, None)
+    OEmbedEndpoint(Some(List("https://liste.ndla.no/*")), Some("https://liste.ndla.no/oembed"), None, None, None)
 
   val youtubeEndpoint: OEmbedEndpoint =
-    OEmbedEndpoint(Some(List("https://www.youtube.com/*")), Some("https://www.youtube.com/oembed"), None, None)
+    OEmbedEndpoint(Some(List("https://www.youtube.com/*")), Some("https://www.youtube.com/oembed"), None, None, None)
 
   test("That hostMatches returns true for same host, regardless of protocol") {
     youtubeProvider.hostMatches("https://www.youtube.com") should be(right = true)

--- a/oembed-proxy/src/test/scala/no/ndla/oembedproxy/service/OEmbedServiceTest.scala
+++ b/oembed-proxy/src/test/scala/no/ndla/oembedproxy/service/OEmbedServiceTest.scala
@@ -23,14 +23,20 @@ class OEmbedServiceTest extends UnitSuite with TestEnvironment {
   val ndlaProvider: OEmbedProvider = OEmbedProvider(
     "ndla",
     "https://ndla.no",
-    List(OEmbedEndpoint(Some(List("https://ndla.no/*")), Some("https://ndla.no/oembed"), None, None))
+    List(OEmbedEndpoint(Some(List("https://ndla.no/*")), Some("https://ndla.no/oembed"), None, None, None))
   )
 
   val youtubeProvider: OEmbedProvider = OEmbedProvider(
     "YouTube",
     "https://www.youtube.com/",
     List(
-      OEmbedEndpoint(Some(List("https://www.youtube.com/*")), Some("https://www.youtube.com/oembed"), Some(true), None)
+      OEmbedEndpoint(
+        Some(List("https://www.youtube.com/*")),
+        Some("https://www.youtube.com/oembed"),
+        Some(true),
+        None,
+        None
+      )
     )
   )
 

--- a/oembed-proxy/src/test/scala/no/ndla/oembedproxy/service/ProviderServiceTest.scala
+++ b/oembed-proxy/src/test/scala/no/ndla/oembedproxy/service/ProviderServiceTest.scala
@@ -22,14 +22,20 @@ class ProviderServiceTest extends UnitSuite with TestEnvironment {
   val IncompleteProvider: OEmbedProvider = OEmbedProvider(
     "gfycat",
     "https://gfycat.com",
-    List(OEmbedEndpoint(Some(List("http://gfycat.com/*")), None, None, None))
+    List(OEmbedEndpoint(Some(List("http://gfycat.com/*")), None, None, None, None))
   )
 
   val CompleteProvider: OEmbedProvider = OEmbedProvider(
     "IFTTT",
     "http://www.ifttt.com",
     List(
-      OEmbedEndpoint(Some(List("http://ifttt.com/recipes/*")), Some("http://www.ifttt.com/oembed/"), Some(true), None)
+      OEmbedEndpoint(
+        Some(List("http://ifttt.com/recipes/*")),
+        Some("http://www.ifttt.com/oembed/"),
+        Some(true),
+        None,
+        None
+      )
     )
   )
 


### PR DESCRIPTION
Tidligere så lente vi oss på at `ndlaClient` brukte json4s sin magiske `camelization` av keys.