### PR TITLE
Override toString to fix api

### DIFF
--- a/common/src/main/scala/no/ndla/common/model/domain/learningpath/EmbedUrl.scala
+++ b/common/src/main/scala/no/ndla/common/model/domain/learningpath/EmbedUrl.scala
@@ -24,7 +24,9 @@ object EmbedUrl {
   implicit val decoder: Decoder[EmbedUrl] = deriveDecoder
 }
 
-sealed abstract class EmbedType(override val entryName: String) extends EnumEntry {}
+sealed abstract class EmbedType(override val entryName: String) extends EnumEntry {
+  override def toString: String = entryName
+}
 
 object EmbedType extends Enum[EmbedType] with CirceEnum[EmbedType] {
   case object OEmbed extends EmbedType("oembed")


### PR DESCRIPTION
embedType blei sendt ut av apiet som IFrame og ikkje iframe. Dette fikser det.
Det er en mulighet for at det er andre steder tilsvarende kan ha skjedd.

Fixes NDLANO/Issues#3989