### PR TITLE
learningpath-api: Stop fetching cover photos from image-api

### DIFF
--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/LearningpathApiProperties.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/LearningpathApiProperties.scala
@@ -38,7 +38,8 @@ class LearningpathApiProperties extends BaseProps with StrictLogging {
   def MaxPageSize         = 10000
   def IndexBulkSize       = 1000
 
-  def InternalImageApiUrl: String = s"$ImageApiHost/image-api/v2/images"
+  def InternalImageApiUrl: String    = s"$ImageApiHost/image-api/v3/images"
+  def InternalImageApiRawUrl: String = s"$ImageApiHost/image-api/raw"
 
   def RedisHost: String = propOrElse("REDIS_HOST", "redis")
   def RedisPort: Int    = propOrElse("REDIS_PORT", "6379").toInt

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/controller/LearningpathControllerV2.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/controller/LearningpathControllerV2.scala
@@ -620,7 +620,7 @@ trait LearningpathControllerV2 {
       .description("Fetch all learningpaths with specified status")
       .in("status" / learningPathStatus)
       .out(jsonBody[List[LearningPathV2]])
-      .errorOut(errorOutputsFor(400, 500))
+      .errorOut(errorOutputsFor(400, 401, 403, 500))
       .withOptionalUser
       .serverLogicPure { maybeUser =>
         { case status =>

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/ConverterService.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/ConverterService.scala
@@ -82,13 +82,10 @@ trait ConverterService {
     }
 
     def asCoverPhoto(imageId: String): Option[CoverPhoto] = {
-      imageApiClient
-        .imageMetaOnUrl(createUrlToImageApi(imageId))
-        .map(imageMeta => {
-          val imageUrl = s"$Domain${imageMeta.imageUrl.path}"
-          val metaUrl  = s"$Domain${imageMeta.metaUrl.path}"
-          api.CoverPhoto(imageUrl, metaUrl)
-        })
+      val metaUrl  = createUrlToImageApi(imageId)
+      val imageUrl = createUrlToImageApiRaw(imageId)
+
+      Some(api.CoverPhoto(imageUrl, metaUrl))
     }
 
     private def asCopyright(copyright: api.Copyright): learningpath.LearningpathCopyright = {
@@ -641,6 +638,9 @@ trait ConverterService {
 
     private def createUrlToImageApi(imageId: String): String = {
       s"http://$InternalImageApiUrl/$imageId"
+    }
+    private def createUrlToImageApiRaw(imageId: String): String = {
+      s"http://$InternalImageApiRawUrl/id/$imageId"
     }
 
     private def createEmbedUrl(embedUrlOrPath: EmbedUrlV2): EmbedUrlV2 = {

--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/ConverterServiceTest.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/ConverterServiceTest.scala
@@ -12,7 +12,6 @@ import no.ndla.common.errors.{NotFoundException, ValidationException}
 import no.ndla.common.model.domain.learningpath.{EmbedType, EmbedUrl, LearningpathCopyright}
 import no.ndla.common.model.domain.{Tag, Title}
 import no.ndla.common.model.{NDLADate, api as commonApi}
-import no.ndla.learningpathapi.integration.ImageMetaInformation
 import no.ndla.learningpathapi.model.api
 import no.ndla.learningpathapi.model.api.{CoverPhoto, NewCopyLearningPathV2, NewLearningPathV2, NewLearningStepV2}
 import no.ndla.learningpathapi.model.domain.*
@@ -411,22 +410,12 @@ class ConverterServiceTest extends UnitSuite with UnitTestEnvironment {
   }
 
   test("asCoverPhoto converts an image id to CoverPhoto") {
-    val imageMeta =
-      ImageMetaInformation(
-        "1",
-        "http://image-api.ndla-local/image-api/v2/images/1",
-        "http://image-api.ndla-local/image-api/raw/1.jpg",
-        1024,
-        "something"
-      )
     val expectedResult =
       CoverPhoto(
-        "http://api-gateway.ndla-local/image-api/raw/1.jpg",
-        "http://api-gateway.ndla-local/image-api/v2/images/1"
+        s"http://${props.ImageApiHost}/image-api/raw/id/1",
+        s"http://${props.ImageApiHost}/image-api/v3/images/1"
       )
-    when(imageApiClient.imageMetaOnUrl(any[String])).thenReturn(Some(imageMeta))
     val Some(result) = service.asCoverPhoto("1")
-
     result should equal(expectedResult)
   }
 


### PR DESCRIPTION
Siden dette ikke er nødvendig alle steder så kan vi gjøre dette hos calleren der det trengs istedet (graphql-api).
Kallet på admin-siden på stier.test.ndla.no gikk fra ~25 sekunder -> 800ms lokalt.

Graphql-api pr her: https://github.com/NDLANO/graphql-api/pull/450