### PR TITLE
Generate RSS feed for frontpage article menu

### DIFF
--- a/article-api/src/main/scala/no/ndla/articleapi/ArticleApiProperties.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/ArticleApiProperties.scala
@@ -117,6 +117,12 @@ class ArticleApiProperties extends BaseProps {
     ).getOrElse(Environment, "https://h5p.ndla.no")
   )
 
+  def ndlaFrontendUrl = Environment match {
+    case "local" => "http://localhost:30017"
+    case "prod"  => "https://ndla.no"
+    case _       => s"https://$Environment.ndla.no"
+  }
+
   def BrightcoveAccountId: String        = prop("NDLA_BRIGHTCOVE_ACCOUNT_ID")
   private def BrightcovePlayerId: String = prop("NDLA_BRIGHTCOVE_PLAYER_ID")
 

--- a/article-api/src/main/scala/no/ndla/articleapi/ComponentRegistry.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/ComponentRegistry.scala
@@ -65,7 +65,8 @@ class ComponentRegistry(properties: ArticleApiProperties)
     with TapirHealthController
     with NdlaMiddleware
     with SwaggerControllerConfig
-    with SwaggerDocControllerConfig {
+    with SwaggerDocControllerConfig
+    with FrontpageApiClient {
   override val props: ArticleApiProperties = properties
   override val migrator                    = new DBMigrator
 
@@ -92,6 +93,7 @@ class ComponentRegistry(properties: ArticleApiProperties)
   lazy val searchApiClient     = new SearchApiClient
   lazy val feideApiClient      = new FeideApiClient
   lazy val redisClient         = new RedisClient(props.RedisHost, props.RedisPort)
+  lazy val frontpageApiClient  = new FrontpageApiClient
 
   lazy val clock = new SystemClock
 

--- a/article-api/src/main/scala/no/ndla/articleapi/integration/FrontpageApiClient.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/integration/FrontpageApiClient.scala
@@ -1,0 +1,33 @@
+/*
+ * Part of NDLA article-api
+ * Copyright (C) 2019 NDLA
+ *
+ * See LICENSE
+ */
+
+package no.ndla.articleapi.integration
+
+import com.typesafe.scalalogging.StrictLogging
+import no.ndla.articleapi.Props
+import no.ndla.articleapi.service.ConverterService
+import no.ndla.common.model.api.FrontPage
+import no.ndla.network.NdlaClient
+import sttp.client3.quick.*
+
+import scala.util.Try
+
+trait FrontpageApiClient {
+  this: NdlaClient with ConverterService with Props =>
+  val frontpageApiClient: FrontpageApiClient
+
+  class FrontpageApiClient(FrontpageApiBaseUrl: String = props.FrontpageApiUrl) extends StrictLogging {
+
+    private val frontpageApiBaseUrl = s"$FrontpageApiBaseUrl/frontpage-api/v1/frontpage"
+
+    def getFrontpage: Try[FrontPage] = {
+      val req = quickRequest.get(uri"$frontpageApiBaseUrl")
+      ndlaClient.fetch[FrontPage](req)
+    }
+  }
+
+}

--- a/article-api/src/main/scala/no/ndla/articleapi/integration/FrontpageApiClient.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/integration/FrontpageApiClient.scala
@@ -1,6 +1,6 @@
 /*
  * Part of NDLA article-api
- * Copyright (C) 2019 NDLA
+ * Copyright (C) 2024 NDLA
  *
  * See LICENSE
  */

--- a/article-api/src/main/scala/no/ndla/articleapi/model/domain/Cachable.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/model/domain/Cachable.scala
@@ -52,6 +52,10 @@ case class Cachable[T](
 }
 
 object Cachable {
+  def merge[T](cachables: List[Cachable[T]]): Cachable[List[T]] = {
+    val canBeCached = cachables.forall(_.canBeCached)
+    Cachable(cachables.map(_.value), canBeCached)
+  }
 
   def yes[T <: Try[U], U](value: T): Try[Cachable[U]] =
     value.map(v => Cachable.yes(v))

--- a/article-api/src/main/scala/no/ndla/articleapi/service/ReadService.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/service/ReadService.scala
@@ -307,31 +307,32 @@ trait ReadService {
     }
 
     def toArticleItem(article: api.ArticleV2): String = {
-      s"""
-         |<item>
-         |<title>${article.title.title}</title>
-         |<description>${article.metaDescription.metaDescription}</description>
-         |<link>${toNdlaFrontendUrl(article.slug, article.id)}</link>
-         |<pubDate>${article.published.asString}</pubDate>
-         |${article.metaImage.map(i => s"""<image>${i.url}</image>""").getOrElse("")}
-         |</item>
-         """.stripMargin
+      s"""<item>
+         |  <title>${article.title.title}</title>
+         |  <description>${article.metaDescription.metaDescription}</description>
+         |  <link>${toNdlaFrontendUrl(article.slug, article.id)}</link>
+         |  <pubDate>${article.published.asString}</pubDate>
+         |  ${article.metaImage.map(i => s"""<image>${i.url}</image>""").getOrElse("")}
+         |</item>""".stripMargin.indent(4)
     }
 
     private def toNdlaFrontendUrl(slug: Option[String], id: Long) = slug
       .map(slug => s"${props.ndlaFrontendUrl}/about/$slug")
       .getOrElse(s"${props.ndlaFrontendUrl}/article/$id")
 
+    private val allBlankLinesRegex = """(?m)^\s*$[\r\n]*""".r
     def toRSSXML(parentArticle: api.ArticleV2, articles: List[api.ArticleV2]): String = {
-      s"""<?xml version="1.0" encoding="utf-8"?>
+      val rss = s"""<?xml version="1.0" encoding="utf-8"?>
          |<rss version="2.0">
          |  <channel>
          |    <title>${parentArticle.title.title}</title>
          |    <link>${toNdlaFrontendUrl(parentArticle.slug, parentArticle.id)}</link>
          |    <description>${parentArticle.metaDescription.metaDescription}</description>
-         |    ${articles.map(toArticleItem).mkString}
+         |${articles.map(toArticleItem).mkString}
          |  </channel>
          |</rss>""".stripMargin
+
+      allBlankLinesRegex.replaceAllIn(rss, "")
     }
 
     def getArticleFrontpageRSS(slug: String): Try[Cachable[String]] = {

--- a/article-api/src/test/scala/no/ndla/articleapi/TestEnvironment.scala
+++ b/article-api/src/test/scala/no/ndla/articleapi/TestEnvironment.scala
@@ -56,7 +56,8 @@ trait TestEnvironment
     with DBArticle
     with Props
     with TestData
-    with DBMigrator {
+    with DBMigrator
+    with FrontpageApiClient {
   val props: ArticleApiProperties = new ArticleApiProperties {
     override def InlineHtmlTags: Set[String]       = Set("code", "em", "span", "strong", "sub", "sup")
     override def IntroductionHtmlTags: Set[String] = InlineHtmlTags ++ Set("br", "p")
@@ -86,6 +87,7 @@ trait TestEnvironment
   val searchApiClient: SearchApiClient               = mock[SearchApiClient]
   val feideApiClient: FeideApiClient                 = mock[FeideApiClient]
   val redisClient: RedisClient                       = mock[RedisClient]
+  val frontpageApiClient: FrontpageApiClient         = mock[FrontpageApiClient]
 
   val clock: SystemClock = mock[SystemClock]
 

--- a/article-api/src/test/scala/no/ndla/articleapi/model/CachableTest.scala
+++ b/article-api/src/test/scala/no/ndla/articleapi/model/CachableTest.scala
@@ -42,4 +42,14 @@ class CachableTest extends UnitSuite with TestEnvironment {
     val c2: Cachable[Try[Int]] = Cachable.yes(t2)
     c2 should be(Cachable(Success(2), true))
   }
+
+  test("That merging returns non-cachable if any non-cachable") {
+    val cachables1: List[Cachable[Int]] = List(Cachable.yes(1), Cachable.yes(2), Cachable.yes(3))
+    val result1                         = Cachable.merge(cachables1)
+    result1 should be(Cachable(List(1, 2, 3), true))
+
+    val cachables2: List[Cachable[Int]] = List(Cachable.yes(1), Cachable.no(2), Cachable.yes(3))
+    val result2                         = Cachable.merge(cachables2)
+    result2 should be(Cachable(List(1, 2, 3), false))
+  }
 }

--- a/common/src/main/scala/no/ndla/common/configuration/BaseProps.scala
+++ b/common/src/main/scala/no/ndla/common/configuration/BaseProps.scala
@@ -26,6 +26,7 @@ trait BaseProps {
   def MyNDLAApiHost: String       = propOrElse("MYNDLA_API_HOST", "myndla-api.ndla-local")
   def LearningpathApiHost: String = propOrElse("LEARNINGPATH_API_HOST", "learningpath-api.ndla-local")
   def SearchApiHost: String       = propOrElse("SEARCH_API_HOST", "search-api.ndla-local")
+  def FrontpageApiHost: String    = propOrElse("FRONTPAGE_API_HOST", "frontpage-api.ndla-local")
   def TaxonomyApiHost: String     = propOrElse("TAXONOMY_API_HOST", "taxonomy-api.ndla-local:5000")
 
   def ApiGatewayUrl: String      = s"http://$ApiGatewayHost"
@@ -37,6 +38,7 @@ trait BaseProps {
   def ImageApiUrl: String        = s"http://$ImageApiHost"
   def LearningpathApiUrl: String = s"http://$LearningpathApiHost"
   def SearchApiUrl: String       = s"http://$SearchApiHost"
+  def FrontpageApiUrl: String    = s"http://$FrontpageApiHost"
   def TaxonomyUrl: String        = s"http://$TaxonomyApiHost"
   def disableWarmup: Boolean     = booleanPropOrElse("DISABLE_WARMUP", default = false)
 

--- a/common/src/main/scala/no/ndla/common/model/api/FrontPage.scala
+++ b/common/src/main/scala/no/ndla/common/model/api/FrontPage.scala
@@ -1,17 +1,17 @@
 /*
- * Part of NDLA frontpage-api
- * Copyright (C) 2018 NDLA
+ * Part of NDLA common
+ * Copyright (C) 2024 NDLA
  *
  * See LICENSE
  */
 
-package no.ndla.frontpageapi.model.api
+package no.ndla.common.model.api
 
 import cats.implicits.toFunctorOps
 import com.scalatsi.{TSIType, TSNamedType, TSType}
-import io.circe.{Decoder, Encoder}
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
 import io.circe.syntax.EncoderOps
+import io.circe.{Decoder, Encoder}
 import sttp.tapir.Schema.annotations.description
 
 import scala.annotation.unused
@@ -29,15 +29,17 @@ case class FrontPage(
     @description("List of Menu objects") menu: List[Menu]
 )
 
+object FrontPage {
+  implicit val encodeFrontPage: Encoder[FrontPage] = deriveEncoder
+  implicit val decodeFrontPage: Decoder[FrontPage] = deriveDecoder
+}
+
 object Menu {
   implicit val encodeMenu: Encoder[Menu] = deriveEncoder
   implicit val decodeMenu: Decoder[Menu] = deriveDecoder
 
   implicit val encodeMenuData: Encoder[MenuData] = Encoder.instance { case menu: Menu => menu.asJson }
   implicit val decodeMenuData: Decoder[MenuData] = Decoder[Menu].widen
-
-  implicit val frontPageEncoder: Encoder[FrontPage] = deriveEncoder
-  implicit val frontPageDecoder: Decoder[FrontPage] = deriveDecoder
 
   implicit val menuTSI: TSIType[Menu] = {
     @unused

--- a/frontpage-api/src/main/scala/no/ndla/frontpageapi/controller/FrontPageController.scala
+++ b/frontpage-api/src/main/scala/no/ndla/frontpageapi/controller/FrontPageController.scala
@@ -7,16 +7,17 @@
 
 package no.ndla.frontpageapi.controller
 
-import io.circe.generic.auto._
+import io.circe.generic.auto.*
+import no.ndla.common.model.api.FrontPage
 import no.ndla.frontpageapi.Eff
-import no.ndla.frontpageapi.model.api._
+import no.ndla.frontpageapi.model.api.*
 import no.ndla.frontpageapi.service.{ReadService, WriteService}
-import no.ndla.network.tapir.NoNullJsonPrinter._
+import no.ndla.network.tapir.NoNullJsonPrinter.*
 import no.ndla.network.tapir.Service
 import no.ndla.network.tapir.TapirErrors.errorOutputsFor
 import no.ndla.network.tapir.auth.Permission.FRONTPAGE_API_ADMIN
-import sttp.tapir._
-import sttp.tapir.generic.auto._
+import sttp.tapir.*
+import sttp.tapir.generic.auto.*
 import sttp.tapir.server.ServerEndpoint
 
 trait FrontPageController {

--- a/frontpage-api/src/main/scala/no/ndla/frontpageapi/service/ConverterService.scala
+++ b/frontpage-api/src/main/scala/no/ndla/frontpageapi/service/ConverterService.scala
@@ -8,10 +8,12 @@
 package no.ndla.frontpageapi.service
 
 import no.ndla.frontpageapi.model.domain.Errors.{LanguageNotFoundException, MissingIdException}
-import no.ndla.frontpageapi.model.domain._
+import no.ndla.frontpageapi.model.domain.*
 import no.ndla.frontpageapi.model.{api, domain}
+
 import scala.util.{Failure, Success, Try}
-import cats.implicits._
+import cats.implicits.*
+import no.ndla.common.model
 import no.ndla.frontpageapi.Props
 import no.ndla.language.Language.{findByLanguageOrBestEffort, mergeLanguageFields}
 
@@ -21,11 +23,11 @@ trait ConverterService {
   object ConverterService {
     import props.{BrightcoveAccountId, BrightcovePlayer, RawImageApiUrl}
 
-    private def toApiMenu(menu: domain.Menu): api.Menu =
-      api.Menu(menu.articleId, menu.menu.map(toApiMenu), Some(menu.hideLevel))
+    private def toApiMenu(menu: domain.Menu): model.api.Menu =
+      model.api.Menu(menu.articleId, menu.menu.map(toApiMenu), Some(menu.hideLevel))
 
-    def toApiFrontPage(frontPage: domain.FrontPage): api.FrontPage =
-      api.FrontPage(articleId = frontPage.articleId, menu = frontPage.menu.map(toApiMenu))
+    def toApiFrontPage(frontPage: domain.FrontPage): model.api.FrontPage =
+      model.api.FrontPage(articleId = frontPage.articleId, menu = frontPage.menu.map(toApiMenu))
 
     private def toApiBannerImage(banner: domain.BannerImage): api.BannerImage =
       api.BannerImage(
@@ -187,12 +189,12 @@ trait ConverterService {
         validated <- VisualElementType.validateVisualElement(ve)
       } yield validated
 
-    private def toDomainMenu(menu: api.Menu): domain.Menu = {
-      val apiMenu = menu.menu.map { case x: api.Menu => toDomainMenu(x) }
+    private def toDomainMenu(menu: model.api.Menu): domain.Menu = {
+      val apiMenu = menu.menu.map { case x: model.api.Menu => toDomainMenu(x) }
       domain.Menu(articleId = menu.articleId, menu = apiMenu, hideLevel = menu.hideLevel.getOrElse(false))
     }
 
-    def toDomainFrontPage(page: api.FrontPage): domain.FrontPage = {
+    def toDomainFrontPage(page: model.api.FrontPage): domain.FrontPage = {
       domain.FrontPage(articleId = page.articleId, menu = page.menu.map(toDomainMenu))
     }
 

--- a/frontpage-api/src/main/scala/no/ndla/frontpageapi/service/ReadService.scala
+++ b/frontpage-api/src/main/scala/no/ndla/frontpageapi/service/ReadService.scala
@@ -7,9 +7,10 @@
 
 package no.ndla.frontpageapi.service
 
-import cats.implicits._
-import no.ndla.common.{errors => common}
-import no.ndla.common.implicits._
+import cats.implicits.*
+import no.ndla.common.errors as common
+import no.ndla.common.implicits.*
+import no.ndla.common.model.api.FrontPage
 import no.ndla.frontpageapi.model.api
 import no.ndla.frontpageapi.model.api.SubjectPageId
 import no.ndla.frontpageapi.model.domain.Errors.{LanguageNotFoundException, SubjectPageNotFoundException}
@@ -72,7 +73,7 @@ trait ReadService {
       } yield api
     }
 
-    def getFrontPage: Try[api.FrontPage] = {
+    def getFrontPage: Try[FrontPage] = {
       frontPageRepository.getFrontPage.flatMap {
         case None        => Failure(common.NotFoundException("Front page was not found"))
         case Some(value) => Success(ConverterService.toApiFrontPage(value))

--- a/frontpage-api/src/main/scala/no/ndla/frontpageapi/service/WriteService.scala
+++ b/frontpage-api/src/main/scala/no/ndla/frontpageapi/service/WriteService.scala
@@ -7,6 +7,7 @@
 
 package no.ndla.frontpageapi.service
 
+import no.ndla.common.model.api.FrontPage
 import no.ndla.frontpageapi.Props
 import no.ndla.frontpageapi.model.api
 import no.ndla.frontpageapi.model.domain.Errors.{SubjectPageNotFoundException, ValidationException}
@@ -89,7 +90,7 @@ trait WriteService {
       )
     }
 
-    def createFrontPage(page: api.FrontPage): Try[api.FrontPage] = {
+    def createFrontPage(page: FrontPage): Try[FrontPage] = {
       for {
         domainFrontpage <- Try(ConverterService.toDomainFrontPage(page))
         inserted        <- frontPageRepository.newFrontPage(domainFrontpage)

--- a/frontpage-api/src/test/scala/no/ndla/frontpageapi/controller/FrontPageControllerTest.scala
+++ b/frontpage-api/src/test/scala/no/ndla/frontpageapi/controller/FrontPageControllerTest.scala
@@ -7,8 +7,8 @@
 
 package no.ndla.frontpageapi.controller
 
-import no.ndla.common.errors as common
-import no.ndla.frontpageapi.model.api
+import no.ndla.common.{model, errors as common}
+import no.ndla.common.model.api.FrontPage
 import no.ndla.frontpageapi.{Eff, TestEnvironment, UnitSuite}
 import no.ndla.tapirtesting.TapirControllerTest
 import org.mockito.ArgumentMatchers.any
@@ -96,7 +96,7 @@ class FrontPageControllerTest extends UnitSuite with TestEnvironment with TapirC
   }
 
   test("That POST / returns 200 if auth header does have correct role") {
-    when(writeService.createFrontPage(any)).thenReturn(Success(api.FrontPage(1, List())))
+    when(writeService.createFrontPage(any)).thenReturn(Success(FrontPage(1, List())))
 
     val request =
       quickRequest
@@ -110,7 +110,7 @@ class FrontPageControllerTest extends UnitSuite with TestEnvironment with TapirC
   }
 
   test("That POST / returns 400 if auth header does have correct role but the json body is malformed") {
-    when(writeService.createFrontPage(any)).thenReturn(Success(api.FrontPage(1, List())))
+    when(writeService.createFrontPage(any)).thenReturn(Success(model.api.FrontPage(1, List())))
 
     val request =
       quickRequest
@@ -124,7 +124,7 @@ class FrontPageControllerTest extends UnitSuite with TestEnvironment with TapirC
   }
 
   test("That GET / returns 200 when the frontpage is available") {
-    val frontPage = api.FrontPage(articleId = 1, menu = List.empty)
+    val frontPage = model.api.FrontPage(articleId = 1, menu = List.empty)
 
     when(readService.getFrontPage).thenReturn(Success(frontPage))
     val request = quickRequest.get(uri"http://localhost:$serverPort/frontpage-api/v1/frontpage")

--- a/frontpage-api/src/test/scala/no/ndla/frontpageapi/model/api/FrontPageTest/FrontPageTest.scala
+++ b/frontpage-api/src/test/scala/no/ndla/frontpageapi/model/api/FrontPageTest/FrontPageTest.scala
@@ -11,7 +11,7 @@ import no.ndla.frontpageapi.{TestEnvironment, UnitSuite}
 import io.circe.generic.auto._
 import io.circe.syntax._
 import io.circe.parser._
-import no.ndla.frontpageapi.model.api.{FrontPage, Menu}
+import no.ndla.common.model.api.{FrontPage, Menu}
 
 class FrontPageTest extends UnitSuite with TestEnvironment {
   test("test that circe encoding and decoding works for recursive types") {

--- a/project/frontpageapi.scala
+++ b/project/frontpageapi.scala
@@ -24,9 +24,9 @@ object frontpageapi extends Module {
   lazy val tsSettings: Seq[Def.Setting[_]] = typescriptSettings(
     imports = Seq("no.ndla.frontpageapi.model.api._", "no.ndla.network.tapir._"),
     exports = Seq(
-      "FrontPage",
-      "MenuData",
-      "Menu",
+      "no.ndla.common.model.api.FrontPage",
+      "no.ndla.common.model.api.MenuData",
+      "no.ndla.common.model.api.Menu",
       "FilmFrontPageData",
       "NewOrUpdatedFilmFrontPageData",
       "SubjectPageData",


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/3946

Dersom vi vil ha en penere url enn `https://api.test.ndla.no/article-api/v2/articles/utlysninger/rss.xml` så kan vi nok lage en redirect i proxy elller api-gateway (Avhengig av hva vi vil ha).

PR'en ser litt større ut enn den er, siden jeg endte med å flytte `api.FrontPage` fra `frontpage-api` til `common` for å kunne gjenbruke typen i `article-api` :smile: 