### PR TITLE
myndla-api: Add support for subcategories

### DIFF
--- a/myndla-api/src/main/resources/no/ndla/myndlaapi/db/migration/V10__subcategories.sql
+++ b/myndla-api/src/main/resources/no/ndla/myndlaapi/db/migration/V10__subcategories.sql
@@ -1,0 +1,2 @@
+ALTER TABLE categories
+    ADD COLUMN parent_category_id BIGINT DEFAULT NULL;

--- a/myndla-api/src/main/scala/no/ndla/myndlaapi/controller/ArenaController.scala
+++ b/myndla-api/src/main/scala/no/ndla/myndlaapi/controller/ArenaController.scala
@@ -70,7 +70,7 @@ trait ArenaController {
       .requireMyNDLAUser(requireArena = true)
       .serverLogicPure { user =>
         { case (followed, sort) =>
-          arenaReadService.getCategories(user, followed, sort)().handleErrorsOrOk
+          arenaReadService.getCategories(user, followed, sort, None)().handleErrorsOrOk
         }
       }
 
@@ -106,17 +106,17 @@ trait ArenaController {
 
     def sortCategories: ServerEndpoint[Any, Eff] = endpoint.put
       .in("categories" / "sort")
+      .in(query[Option[Long]]("category-parent-id").description("Which parent to sort the categories for, if any"))
       .summary("Sort categories")
       .description("Sort categories")
       .in(jsonBody[List[Long]].description("List of category ids in the order they should be sorted"))
       .out(jsonBody[List[Category]])
       .errorOut(errorOutputsFor(401, 403))
       .requireMyNDLAUser(requireArenaAdmin = true)
-      .serverLogicPure {
-        user =>
-          { sortedIds =>
-            arenaReadService.sortCategories(sortedIds, user).handleErrorsOrOk
-          }
+      .serverLogicPure { user =>
+        { case (parentId, sortedIds) =>
+          arenaReadService.sortCategories(parentId, sortedIds, user).handleErrorsOrOk
+        }
       }
 
     def getTopic: ServerEndpoint[Any, Eff] = endpoint.get

--- a/myndla-api/src/main/scala/no/ndla/myndlaapi/integration/nodebb/NodebbModels.scala
+++ b/myndla-api/src/main/scala/no/ndla/myndlaapi/integration/nodebb/NodebbModels.scala
@@ -10,7 +10,8 @@ package no.ndla.myndlaapi.integration.nodebb
 case class CategoryInList(
     cid: Long,
     name: String,
-    description: String
+    description: String,
+    children: List[CategoryInList]
 )
 
 case class Categories(

--- a/myndla-api/src/main/scala/no/ndla/myndlaapi/model/arena/api/Category.scala
+++ b/myndla-api/src/main/scala/no/ndla/myndlaapi/model/arena/api/Category.scala
@@ -18,5 +18,9 @@ case class Category(
     @description("Count of posts in the category") postCount: Long,
     @description("Whether the requesting user is following the category") isFollowing: Boolean,
     @description("Whether the category is visible to regular users") visible: Boolean,
-    @description("Where the category is sorted when sorting by rank") rank: Int
+    @description("Where the category is sorted when sorting by rank") rank: Int,
+    @description("The id of the parent category if any") parentCategoryId: Option[Long],
+    @description("Count of subcategories in the category") categoryCount: Long,
+    @description("Categories in the category") subcategories: List[Category],
+    @description("Breadcrumb path of categories") breadcrumbs: List[CategoryBreadcrumb]
 )

--- a/myndla-api/src/main/scala/no/ndla/myndlaapi/model/arena/api/CategoryBreadcrumb.scala
+++ b/myndla-api/src/main/scala/no/ndla/myndlaapi/model/arena/api/CategoryBreadcrumb.scala
@@ -1,0 +1,16 @@
+/*
+ * Part of NDLA myndla-api
+ * Copyright (C) 2024 NDLA
+ *
+ * See LICENSE
+ */
+
+package no.ndla.myndlaapi.model.arena.api
+
+import sttp.tapir.Schema.annotations.description
+
+@description("Arena category data")
+case class CategoryBreadcrumb(
+    @description("The category's id") id: Long,
+    @description("The category's title") title: String
+)

--- a/myndla-api/src/main/scala/no/ndla/myndlaapi/model/arena/api/CategoryWithTopics.scala
+++ b/myndla-api/src/main/scala/no/ndla/myndlaapi/model/arena/api/CategoryWithTopics.scala
@@ -21,5 +21,9 @@ case class CategoryWithTopics(
     @description("Topics in the category") topics: List[Topic],
     @description("Whether the requesting user is following the category") isFollowing: Boolean,
     @description("Whether the category is visible to regular users") visible: Boolean,
-    @description("Where the category is sorted when sorting by rank") rank: Int
+    @description("Where the category is sorted when sorting by rank") rank: Int,
+    @description("The id of the parent category if any") parentCategoryId: Option[Long],
+    @description("Count of subcategories in the category") categoryCount: Long,
+    @description("Categories in the category") subcategories: List[Category],
+    @description("Breadcrumb path of categories") breadcrumbs: List[CategoryBreadcrumb]
 )

--- a/myndla-api/src/main/scala/no/ndla/myndlaapi/model/arena/api/NewCategory.scala
+++ b/myndla-api/src/main/scala/no/ndla/myndlaapi/model/arena/api/NewCategory.scala
@@ -13,5 +13,6 @@ import sttp.tapir.Schema.annotations.description
 case class NewCategory(
     @description("The category's title") title: String,
     @description("The category's description") description: String,
-    @description("Whether the category is visible to users") visible: Boolean
+    @description("Whether the category is visible to users") visible: Boolean,
+    @description("The id of the parent category if any") parentCategoryId: Option[Long]
 )

--- a/myndla-api/src/main/scala/no/ndla/myndlaapi/model/arena/domain/Category.scala
+++ b/myndla-api/src/main/scala/no/ndla/myndlaapi/model/arena/domain/Category.scala
@@ -16,13 +16,15 @@ case class Category(
     title: String,
     description: String,
     visible: Boolean,
-    rank: Int
+    rank: Int,
+    parentCategoryId: Option[Long]
 )
 
 case class InsertCategory(
     title: String,
     description: String,
-    visible: Boolean
+    visible: Boolean,
+    parentCategoryId: Option[Long]
 )
 
 object Category extends SQLSyntaxSupport[Category] {
@@ -39,7 +41,8 @@ object Category extends SQLSyntaxSupport[Category] {
       title = rs.string(colNameWrapper("title")),
       description = rs.string(colNameWrapper("description")),
       visible = rs.boolean(colNameWrapper("visible")),
-      rank = rs.int(colNameWrapper("rank"))
+      rank = rs.int(colNameWrapper("rank")),
+      parentCategoryId = rs.longOpt(colNameWrapper("parent_category_id"))
     )
   }
 

--- a/myndla-api/src/main/scala/no/ndla/myndlaapi/service/ConverterService.scala
+++ b/myndla-api/src/main/scala/no/ndla/myndlaapi/service/ConverterService.scala
@@ -21,7 +21,9 @@ trait ConverterService {
         category: domain.Category,
         topicCount: Long,
         postCount: Long,
-        isFollowing: Boolean
+        isFollowing: Boolean,
+        subcategories: List[api.Category],
+        breadcrumbs: List[api.CategoryBreadcrumb]
     ): api.Category = {
       api.Category(
         id = category.id,
@@ -31,7 +33,11 @@ trait ConverterService {
         postCount = postCount,
         isFollowing = isFollowing,
         visible = category.visible,
-        rank = category.rank
+        rank = category.rank,
+        parentCategoryId = category.parentCategoryId,
+        subcategories = subcategories,
+        categoryCount = subcategories.size.toLong,
+        breadcrumbs = breadcrumbs
       )
     }
 

--- a/myndla-api/src/test/scala/no/ndla/myndlaapi/e2e/ArenaTest.scala
+++ b/myndla-api/src/test/scala/no/ndla/myndlaapi/e2e/ArenaTest.scala
@@ -142,7 +142,7 @@ class ArenaTest
   )
 
   def createCategory(title: String, description: String, shouldSucceed: Boolean = true): Response[String] = {
-    val newCategory = api.NewCategory(title = title, description = description, visible = true)
+    val newCategory = api.NewCategory(title = title, description = description, visible = true, parentCategoryId = None)
     val inBody      = newCategory.asJson.noSpaces
     val res = simpleHttpClient.send(
       quickRequest
@@ -219,7 +219,20 @@ class ArenaTest
     val categories = io.circe.parser.parse(fetchCategoriesResponse.body).flatMap(_.as[List[api.Category]]).toTry.get
     categories.size should be(1)
     categories.head should be(
-      api.Category(1, "title", "description", 0, 0, isFollowing = false, visible = true, rank = 1)
+      api.Category(
+        1,
+        "title",
+        "description",
+        0,
+        0,
+        isFollowing = false,
+        visible = true,
+        rank = 1,
+        parentCategoryId = None,
+        categoryCount = 0,
+        subcategories = List.empty,
+        breadcrumbs = List(api.CategoryBreadcrumb(1, "title"))
+      )
     )
   }
 
@@ -289,7 +302,11 @@ class ArenaTest
       ),
       isFollowing = false,
       visible = true,
-      rank = 1
+      rank = 1,
+      categoryCount = 0,
+      subcategories = List.empty,
+      parentCategoryId = None,
+      breadcrumbs = List(api.CategoryBreadcrumb(1, "title"))
     )
 
     val categoryResp = simpleHttpClient.send(

--- a/typescript/types-backend/myndla-api.ts
+++ b/typescript/types-backend/myndla-api.ts
@@ -24,6 +24,15 @@ export interface ICategory {
   isFollowing: boolean
   visible: boolean
   rank: number
+  parentCategoryId?: number
+  categoryCount: number
+  subcategories: ICategory[]
+  breadcrumbs: ICategoryBreadcrumb[]
+}
+
+export interface ICategoryBreadcrumb {
+  id: number
+  title: string
 }
 
 export interface ICategoryWithTopics {
@@ -38,6 +47,10 @@ export interface ICategoryWithTopics {
   isFollowing: boolean
   visible: boolean
   rank: number
+  parentCategoryId?: number
+  categoryCount: number
+  subcategories: ICategory[]
+  breadcrumbs: ICategoryBreadcrumb[]
 }
 
 export interface IConfigMeta {
@@ -105,6 +118,7 @@ export interface INewCategory {
   title: string
   description: string
   visible: boolean
+  parentCategoryId?: number
 }
 
 export interface INewFlag {


### PR DESCRIPTION
Legger til støtte for underkategorier
Brødsmulestier er nok ikke det mest optimaliserte i verden, men jeg går ut i fra at ytelsen ikke blir veldig påvirket pga mengden data. Lokal benchmark viste <10ms forskjell i alle fall.

