### PR TITLE
Return full resource for /recent

### DIFF
--- a/myndla-api/src/main/scala/no/ndla/myndlaapi/controller/FolderController.scala
+++ b/myndla-api/src/main/scala/no/ndla/myndlaapi/controller/FolderController.scala
@@ -147,7 +147,7 @@ trait FolderController {
       .in("recent")
       .in(queryRecentSize)
       .errorOut(errorOutputsFor(400, 401, 403, 404))
-      .out(jsonBody[Seq[String]])
+      .out(jsonBody[Seq[Resource]])
       .serverLogicPure { case (queryRecentSize) =>
         folderReadService.getRecentFavorite(queryRecentSize).handleErrorsOrOk
       }

--- a/myndla-api/src/main/scala/no/ndla/myndlaapi/service/FolderReadService.scala
+++ b/myndla-api/src/main/scala/no/ndla/myndlaapi/service/FolderReadService.scala
@@ -273,9 +273,12 @@ trait FolderReadService {
       folderRepository.getAllFavorites(session)
     }
 
-    def getRecentFavorite(size: Option[Int]): Try[Seq[String]] = {
+    def getRecentFavorite(size: Option[Int]): Try[List[Resource]] = {
       implicit val session: DBSession = folderRepository.getSession(true)
-      folderRepository.getRecentFavorited(size)(session)
+      folderRepository.getRecentFavorited(size)(session) match {
+        case Failure(ex)    => Failure(ex)
+        case Success(value) => value.traverse(r => folderConverterService.toApiResource(r, isOwner = false))
+      }
     }
 
     def getFavouriteStatsForResource(


### PR DESCRIPTION
Trengte visst litt mer data! Returnerer hele resource-objektet istedenfor her