### PR TITLE
Støtter $ og ; i urler for å ta høgde for gapminder.

### DIFF
--- a/validation/src/main/scala/no/ndla/validation/EmbedTagRules.scala
+++ b/validation/src/main/scala/no/ndla/validation/EmbedTagRules.scala
@@ -7,7 +7,7 @@
 
 package no.ndla.validation
 
-import enumeratum._
+import enumeratum.*
 
 import scala.io.Source
 import scala.language.postfixOps

--- a/validation/src/main/scala/no/ndla/validation/TagValidator.scala
+++ b/validation/src/main/scala/no/ndla/validation/TagValidator.scala
@@ -566,7 +566,7 @@ object TagValidator {
       field: TagRules.Field
   ): Option[ValidationMessage] = {
     val domainRegex =
-      "https?:\\/\\/(www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-zA-Z0-9()]{1,6}\\b([-a-zA-Z0-9()@:%_\\+.~#?&//=]*)"
+      "https?:\\/\\/(www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-zA-Z0-9()]{1,6}\\b([-a-zA-Z0-9()$;@:%_\\+.~#?&//=]*)"
 
     if (!field.validation.required && value.isEmpty) {
       return None

--- a/validation/src/test/scala/no/ndla/validation/EmbedTagRulesTest.scala
+++ b/validation/src/test/scala/no/ndla/validation/EmbedTagRulesTest.scala
@@ -133,6 +133,25 @@ class EmbedTagRulesTest extends UnitSuite {
     }
   }
 
+  test("Field with dataType URL should accept funky embed urls") {
+    {
+      val url =
+        "https://www.gapminder.org/tools/#$ui$chart$cursorMode=plus&opacitySelectDim:0.39;;&model$markers$bubble$encoding$size$data$space@=geo&=time;;&scale$domain:null&type:null&zoomed:null;;&x$data$concept=time&space@=time;;&scale$domain:null&zoomed:null&type:null;;&frame$extrapolate:51;&trail$data$filter$markers$bra=1800&nor=1800&uga=1800;;;;;;;;&chart-type=bubbles&url=v1"
+      val embedString =
+        s"""<$EmbedTagName
+           | data-resource="iframe"
+           | data-url="$url"
+           | data-type="iframe"
+           | data-title="Gapminder"
+           |/>""".stripMargin
+
+      val result = TagValidator.validate("test", embedString)
+      result should be(
+        Seq.empty
+      )
+    }
+  }
+
   test("Fields with dataType EMAIL should have legal email") {
     {
       val embedString =


### PR DESCRIPTION
Urlen i testklassen ligger lagra i apiet i dag, så dette må til for å kunne redigere artikkelen.