### PR TITLE
draft-api: Rewrite sideEffects in attempt to locate the flakyness

### DIFF
--- a/draft-api/src/main/scala/no/ndla/draftapi/model/domain/StateTransition.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/model/domain/StateTransition.scala
@@ -8,7 +8,7 @@
 package no.ndla.draftapi.model.domain
 
 import no.ndla.common.model.domain.draft.{Draft, DraftStatus}
-import no.ndla.draftapi.service.SideEffect.SideEffect
+import no.ndla.draftapi.service.SideEffect
 import no.ndla.network.tapir.auth.Permission.DRAFT_API_WRITE
 import no.ndla.network.tapir.auth.{Permission, TokenUser}
 

--- a/draft-api/src/test/scala/no/ndla/draftapi/service/StateTransitionRulesTest.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/service/StateTransitionRulesTest.scala
@@ -165,7 +165,7 @@ class StateTransitionRulesTest extends UnitSuite with TestEnvironment {
 
     val (Success(res), sideEffect) =
       doTransitionWithoutSideEffect(InProcessArticle, PUBLISHED, TestData.userWithAdminAccess, false)
-    sideEffect.map(sf => sf(res, false, TestData.userWithAdminAccess).get.status should equal(expectedStatus))
+    sideEffect.map(sf => sf.run(res, false, TestData.userWithAdminAccess).get.status should equal(expectedStatus))
 
     val captor = ArgumentCaptor.forClass(classOf[Draft])
     verify(articleApiClient, times(1))
@@ -189,7 +189,7 @@ class StateTransitionRulesTest extends UnitSuite with TestEnvironment {
 
     val (Success(res), sideEffect) =
       doTransitionWithoutSideEffect(PublishedArticle, UNPUBLISHED, TestData.userWithAdminAccess, false)
-    sideEffect.map(sf => sf(res, false, TestData.userWithAdminAccess).get.status should equal(expectedStatus))
+    sideEffect.map(sf => sf.run(res, false, TestData.userWithAdminAccess).get.status should equal(expectedStatus))
 
     val captor = ArgumentCaptor.forClass(classOf[Draft])
 
@@ -208,7 +208,7 @@ class StateTransitionRulesTest extends UnitSuite with TestEnvironment {
 
     val (Success(res), sideEffect) =
       doTransitionWithoutSideEffect(UnpublishedArticle, ARCHIVED, TestData.userWithPublishAccess, false)
-    sideEffect.map(sf => sf(res, false, TestData.userWithAdminAccess).get.status should equal(expectedStatus))
+    sideEffect.map(sf => sf.run(res, false, TestData.userWithAdminAccess).get.status should equal(expectedStatus))
 
     verify(articleIndexService, times(0))
       .deleteDocument(UnpublishedArticle.id.get)
@@ -236,7 +236,7 @@ class StateTransitionRulesTest extends UnitSuite with TestEnvironment {
     val learningPath    = TestData.sampleLearningPath
     when(learningpathApiClient.getLearningpathsWithId(any[Long], any)).thenReturn(Success(Seq(learningPath)))
 
-    val res = StateTransitionRules.unpublishArticle(article, false, TestData.userWithAdminAccess)
+    val res = StateTransitionRules.unpublishArticle.run(article, false, TestData.userWithAdminAccess)
     res.isFailure should be(true)
   }
 
@@ -249,7 +249,7 @@ class StateTransitionRulesTest extends UnitSuite with TestEnvironment {
     when(searchApiClient.publishedWhereUsed(any[Long], any)).thenReturn(Seq(SearchHit(1, Title("Title", "nb"))))
 
     val Failure(res: ValidationException) =
-      StateTransitionRules.checkIfArticleIsInUse(article, false, TestData.userWithAdminAccess)
+      StateTransitionRules.checkIfArticleIsInUse.run(article, false, TestData.userWithAdminAccess)
     res.errors should equal(
       Seq(
         ValidationMessage("status.current", "Article is in use in these published article(s) 1 (Title)")
@@ -264,7 +264,7 @@ class StateTransitionRulesTest extends UnitSuite with TestEnvironment {
     when(learningpathApiClient.getLearningpathsWithId(eqTo(articleId), any)).thenReturn(Success(Seq(learningPath)))
     when(draftRepository.getIdFromExternalId(any[String])(any[DBSession])).thenReturn(Some(articleId))
 
-    val res = StateTransitionRules.unpublishArticle(article, false, TestData.userWithAdminAccess)
+    val res = StateTransitionRules.unpublishArticle.run(article, false, TestData.userWithAdminAccess)
     res.isFailure should be(true)
   }
 
@@ -280,7 +280,7 @@ class StateTransitionRulesTest extends UnitSuite with TestEnvironment {
     when(searchApiClient.draftsWhereUsed(any[Long], any)).thenReturn(Seq.empty)
     when(searchApiClient.publishedWhereUsed(any[Long], any)).thenReturn(Seq.empty)
 
-    val res = StateTransitionRules.unpublishArticle(article, false, TestData.userWithAdminAccess)
+    val res = StateTransitionRules.unpublishArticle.run(article, false, TestData.userWithAdminAccess)
     res.isSuccess should be(true)
     verify(articleApiClient, times(1)).unpublishArticle(eqTo(article), any)
   }
@@ -293,7 +293,7 @@ class StateTransitionRulesTest extends UnitSuite with TestEnvironment {
     when(taxonomyApiClient.queryNodes(articleId)).thenReturn(Success(List.empty))
 
     val Failure(res: ValidationException) =
-      StateTransitionRules.checkIfArticleIsInUse(article, false, TestData.userWithAdminAccess)
+      StateTransitionRules.checkIfArticleIsInUse.run(article, false, TestData.userWithAdminAccess)
     res.errors.head.message should equal("Learningpath(s) 1 (Title) contains a learning step that uses this article")
   }
 
@@ -305,7 +305,7 @@ class StateTransitionRulesTest extends UnitSuite with TestEnvironment {
     when(draftRepository.getIdFromExternalId(any[String])(any[DBSession])).thenReturn(Some(articleId))
 
     val Failure(res: ValidationException) =
-      StateTransitionRules.checkIfArticleIsInUse(article, false, TestData.userWithAdminAccess)
+      StateTransitionRules.checkIfArticleIsInUse.run(article, false, TestData.userWithAdminAccess)
     res.errors.head.message should equal("Learningpath(s) 1 (Title) contains a learning step that uses this article")
   }
 
@@ -319,7 +319,7 @@ class StateTransitionRulesTest extends UnitSuite with TestEnvironment {
     when(articleApiClient.unpublishArticle(eqTo(article), any)).thenReturn(Success(article))
     when(taxonomyApiClient.queryNodes(articleId)).thenReturn(Success(List.empty))
 
-    val res = StateTransitionRules.checkIfArticleIsInUse(article, false, TestData.userWithAdminAccess)
+    val res = StateTransitionRules.checkIfArticleIsInUse.run(article, false, TestData.userWithAdminAccess)
     res.isSuccess should be(true)
   }
 
@@ -429,7 +429,7 @@ class StateTransitionRulesTest extends UnitSuite with TestEnvironment {
 
     val (Success(res), sideEffect) =
       doTransitionWithoutSideEffect(InProcessArticle, PUBLISHED, TestData.userWithAdminAccess, false)
-    sideEffect.map(sf => sf(res, false, TestData.userWithAdminAccess).get.status should equal(expectedStatus))
+    sideEffect.map(sf => sf.run(res, false, TestData.userWithAdminAccess).get.status should equal(expectedStatus))
 
     val captor = ArgumentCaptor.forClass(classOf[Draft])
     verify(articleApiClient, times(1))

--- a/draft-api/src/test/scala/no/ndla/draftapi/service/WriteServiceTest.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/service/WriteServiceTest.scala
@@ -106,6 +106,10 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
     })
   }
 
+  override def afterEach(): Unit = {
+    scala.util.Properties.clearProp("DEBUG_FLAKE")
+  }
+
   test("newArticle should insert a given article") {
     when(draftRepository.getExternalIdsFromId(any[Long])(any[DBSession])).thenReturn(List.empty)
     when(contentValidator.validateArticle(any[Draft])).thenReturn(Success(article))
@@ -1560,6 +1564,7 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
   }
 
   test("That started is reset when published via PUBLISHED field") {
+    scala.util.Properties.setProp("DEBUG_FLAKE", "true")
     when(articleApiClient.updateArticle(any, any, any, any, any, any)).thenAnswer((i: InvocationOnMock) => {
       Success(i.getArgument[Draft](1))
     })


### PR DESCRIPTION
Utvider `SideEffect` til å bli en klasse med navn og funksjon for å enklere kunne debugge.
Legger også på et debuggingsflagg som bare er enablet i en flaky test.

Forhåpentligvis så vil dette hjelpe oss når vi får den flaky testen til å være flaky igjen :shrug: 