### PR TITLE
myndla-api: Add query param to filter on resource types in /recent

### DIFF
--- a/common/src/main/scala/no/ndla/common/model/domain/ResourceType.scala
+++ b/common/src/main/scala/no/ndla/common/model/domain/ResourceType.scala
@@ -10,6 +10,8 @@ package no.ndla.common.model.domain
 import com.scalatsi.TypescriptType.{TSLiteralString, TSUnion}
 import com.scalatsi.{TSNamedType, TSType}
 import enumeratum.*
+import sttp.tapir.Codec.PlainCodec
+import sttp.tapir.codec.enumeratum.*
 
 sealed abstract class ResourceType(override val entryName: String) extends EnumEntry {
   override def toString: String = entryName
@@ -17,6 +19,8 @@ sealed abstract class ResourceType(override val entryName: String) extends EnumE
 
 object ResourceType extends Enum[ResourceType] with CirceEnum[ResourceType] {
   override val values: IndexedSeq[ResourceType] = findValues
+
+  implicit val codec: PlainCodec[ResourceType] = plainCodecEnumEntry[ResourceType]
 
   implicit val enumTsType: TSNamedType[ResourceType] =
     TSType.alias[ResourceType]("ResourceType", TSUnion(values.map(e => TSLiteralString(e.entryName))))

--- a/common/src/main/scala/no/ndla/common/model/domain/ResourceType.scala
+++ b/common/src/main/scala/no/ndla/common/model/domain/ResourceType.scala
@@ -11,6 +11,7 @@ import com.scalatsi.TypescriptType.{TSLiteralString, TSUnion}
 import com.scalatsi.{TSNamedType, TSType}
 import enumeratum.*
 import sttp.tapir.Codec.PlainCodec
+import sttp.tapir.Schema
 import sttp.tapir.codec.enumeratum.*
 
 sealed abstract class ResourceType(override val entryName: String) extends EnumEntry {
@@ -21,7 +22,7 @@ object ResourceType extends Enum[ResourceType] with CirceEnum[ResourceType] {
   override val values: IndexedSeq[ResourceType] = findValues
 
   implicit val codec: PlainCodec[ResourceType] = plainCodecEnumEntry[ResourceType]
-
+  implicit val schema: Schema[ResourceType]    = schemaForEnumEntry[ResourceType]
   implicit val enumTsType: TSNamedType[ResourceType] =
     TSType.alias[ResourceType]("ResourceType", TSUnion(values.map(e => TSLiteralString(e.entryName))))
 

--- a/myndla-api/src/main/scala/no/ndla/myndlaapi/controller/FolderController.scala
+++ b/myndla-api/src/main/scala/no/ndla/myndlaapi/controller/FolderController.scala
@@ -63,7 +63,7 @@ trait FolderController {
     private val queryExcludeResourceTypes =
       listQuery[ResourceType]("exclude")
         .description(
-          s"Which resource types to exclude. Available values are ${ResourceType.values.mkString(", ")}. If None all resource types are included. To provide multiple resource types, separate by comma (,)."
+          s"Which resource types to exclude. If None all resource types are included. To provide multiple resource types, separate by comma (,)."
         )
 
     import io.circe.generic.auto._

--- a/myndla-api/src/main/scala/no/ndla/myndlaapi/controller/FolderController.scala
+++ b/myndla-api/src/main/scala/no/ndla/myndlaapi/controller/FolderController.scala
@@ -7,6 +7,8 @@
 
 package no.ndla.myndlaapi.controller
 
+import no.ndla.common.model.api.CommaSeparatedList.*
+import no.ndla.common.model.domain.ResourceType
 import no.ndla.myndlaapi.Eff
 import no.ndla.myndlaapi.model.api.{
   Folder,
@@ -58,6 +60,11 @@ trait FolderController {
     private val queryRecentSize =
       query[Option[Int]]("size")
         .description("How many latest favorited resources to return")
+    private val queryExcludeResourceTypes =
+      listQuery[ResourceType]("exclude")
+        .description(
+          s"Which resource types to exclude. Available values are ${ResourceType.values.mkString(", ")}. If None all resource types are included. To provide multiple resource types, separate by comma (,)."
+        )
 
     import io.circe.generic.auto._
 
@@ -146,10 +153,13 @@ trait FolderController {
       .in("resources")
       .in("recent")
       .in(queryRecentSize)
+      .in(queryExcludeResourceTypes)
       .errorOut(errorOutputsFor(400, 401, 403, 404))
       .out(jsonBody[Seq[Resource]])
-      .serverLogicPure { case (queryRecentSize) =>
-        folderReadService.getRecentFavorite(queryRecentSize).handleErrorsOrOk
+      .serverLogicPure { case (queryRecentSize, queryExcludeResourceTypes) =>
+        folderReadService
+          .getRecentFavorite(queryRecentSize, queryExcludeResourceTypes.values)
+          .handleErrorsOrOk
       }
 
     private def createFolderResource: ServerEndpoint[Any, Eff] = endpoint.post

--- a/myndla-api/src/main/scala/no/ndla/myndlaapi/service/FolderReadService.scala
+++ b/myndla-api/src/main/scala/no/ndla/myndlaapi/service/FolderReadService.scala
@@ -13,6 +13,7 @@ import no.ndla.common.Clock
 import no.ndla.common.errors.NotFoundException
 import no.ndla.common.implicits.TryQuestionMark
 import no.ndla.common.model.api.SingleResourceStats
+import no.ndla.common.model.domain.ResourceType
 import no.ndla.myndlaapi.FavoriteFolderDefaultName
 import no.ndla.myndlaapi.model.api.{ExportedUserData, Folder, Resource}
 import no.ndla.myndlaapi.model.{api, domain}
@@ -273,9 +274,9 @@ trait FolderReadService {
       folderRepository.getAllFavorites(session)
     }
 
-    def getRecentFavorite(size: Option[Int]): Try[List[Resource]] = {
+    def getRecentFavorite(size: Option[Int], excludeResourceTypes: List[ResourceType]): Try[List[Resource]] = {
       implicit val session: DBSession = folderRepository.getSession(true)
-      folderRepository.getRecentFavorited(size)(session) match {
+      folderRepository.getRecentFavorited(size, excludeResourceTypes)(session) match {
         case Failure(ex)    => Failure(ex)
         case Success(value) => value.traverse(r => folderConverterService.toApiResource(r, isOwner = false))
       }


### PR DESCRIPTION
- Legger til mulighet for å filtrere ut resource types

**Er det noe lurt jeg må gjøre for å få til at return-typen(ResourceType) oppdateres basert på eventuelle exclude-filtre man sender inn?** 