### PR TITLE
Ignores docs with null object because of failed imports.

### DIFF
--- a/article-api/src/main/scala/no/ndla/articleapi/repository/ArticleRepository.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/repository/ArticleRepository.scala
@@ -338,9 +338,9 @@ trait ArticleRepository {
     )(implicit session: DBSession = ReadOnlyAutoSession): Option[ArticleIds] = {
       val ar = Article.syntax("ar")
       sql"""select distinct article_id, external_id
-      from ${Article.as(ar)}
-      where $externalId=ANY(ar.external_id)
-      and ar.document is not NULL"""
+        from ${Article.as(ar)}
+        where $externalId=ANY(ar.external_id)
+        and ar.document is not NULL"""
         .map(rs =>
           ArticleIds(
             rs.long("article_id"),

--- a/article-api/src/main/scala/no/ndla/articleapi/repository/ArticleRepository.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/repository/ArticleRepository.scala
@@ -337,7 +337,10 @@ trait ArticleRepository {
         externalId: String
     )(implicit session: DBSession = ReadOnlyAutoSession): Option[ArticleIds] = {
       val ar = Article.syntax("ar")
-      sql"select distinct article_id, external_id from ${Article.as(ar)} where $externalId=ANY(ar.external_id)"
+      sql"""select distinct article_id, external_id
+      from ${Article.as(ar)}
+      where $externalId=ANY(ar.external_id)
+      and ar.document is not NULL"""
         .map(rs =>
           ArticleIds(
             rs.long("article_id"),

--- a/integration-tests/src/test/scala/no/ndla/integrationtests/draftapi/articleapi/ArticleApiClientTest.scala
+++ b/integration-tests/src/test/scala/no/ndla/integrationtests/draftapi/articleapi/ArticleApiClientTest.scala
@@ -10,7 +10,7 @@ package no.ndla.integrationtests.draftapi.articleapi
 import no.ndla.articleapi.ArticleApiProperties
 import no.ndla.common.model.domain.Priority
 import no.ndla.common.model.domain.draft.Draft
-import no.ndla.common.model.{NDLADate, domain => common}
+import no.ndla.common.model.{NDLADate, domain as common}
 import no.ndla.draftapi.model.api.ContentId
 import no.ndla.integrationtests.UnitSuite
 import no.ndla.network.AuthUser
@@ -39,7 +39,7 @@ class ArticleApiClientTest
   val WeNeedThisToMakeTheTestsWorkNoIdeaWhyReadTheComment: Set[String] = HtmlTagRules.PermittedHTML.tags
 
   val articleApiPort: Int         = findFreePort
-  val pgc: PostgreSQLContainer[_] = postgresContainer.get
+  val pgc: PostgreSQLContainer[?] = postgresContainer.get
   val esHost: String              = elasticSearchHost.get
   val articleApiProperties: ArticleApiProperties = new ArticleApiProperties {
     override def ApplicationPort: Int = articleApiPort
@@ -61,8 +61,8 @@ class ArticleApiClientTest
     articleApi = new articleapi.MainClass(articleApiProperties)
     Future { articleApi.run() }: Unit
     blockUntil(() => {
-      import sttp.client3.quick._
-      val req = quickRequest.get(uri"$articleApiBaseUrl/health")
+      import sttp.client3.quick.*
+      val req = quickRequest.get(uri"$articleApiBaseUrl/health/readiness")
       val res = Try(simpleHttpClient.send(req))
       println(res)
       res.map(_.code.code) == Success(200)

--- a/integration-tests/src/test/scala/no/ndla/integrationtests/searchapi/articleapi/ArticleApiClientTest.scala
+++ b/integration-tests/src/test/scala/no/ndla/integrationtests/searchapi/articleapi/ArticleApiClientTest.scala
@@ -31,7 +31,7 @@ class ArticleApiClientTest
   override val searchConverterService = new SearchConverterService
 
   val articleApiPort: Int         = findFreePort
-  val pgc: PostgreSQLContainer[_] = postgresContainer.get
+  val pgc: PostgreSQLContainer[?] = postgresContainer.get
   val esHost: String              = elasticSearchHost.get
   val articleApiProperties: ArticleApiProperties = new ArticleApiProperties {
     override def ApplicationPort: Int = articleApiPort
@@ -54,8 +54,8 @@ class ArticleApiClientTest
     Future { articleApi.run() }: Unit
 
     blockUntil(() => {
-      import sttp.client3.quick._
-      val req = quickRequest.get(uri"$articleApiBaseUrl/health")
+      import sttp.client3.quick.*
+      val req = quickRequest.get(uri"$articleApiBaseUrl/health/readiness")
       val res = Try(simpleHttpClient.send(req))
       res.map(_.code.code) == Success(200)
     })

--- a/integration-tests/src/test/scala/no/ndla/integrationtests/searchapi/draftapi/DraftApiClientTest.scala
+++ b/integration-tests/src/test/scala/no/ndla/integrationtests/searchapi/draftapi/DraftApiClientTest.scala
@@ -32,7 +32,7 @@ class DraftApiClientTest
   override val searchConverterService = new SearchConverterService
 
   val draftApiPort: Int           = findFreePort
-  val pgc: PostgreSQLContainer[_] = postgresContainer.get
+  val pgc: PostgreSQLContainer[?] = postgresContainer.get
   val esHost: String              = elasticSearchHost.get
   val draftApiProperties: DraftApiProperties = new DraftApiProperties {
     override def ApplicationPort: Int = draftApiPort
@@ -55,8 +55,8 @@ class DraftApiClientTest
     draftApi = new draftapi.MainClass(draftApiProperties)
     Future { draftApi.run() }: Unit
     blockUntil(() => {
-      import sttp.client3.quick._
-      val req = quickRequest.get(uri"$draftApiBaseUrl/health")
+      import sttp.client3.quick.*
+      val req = quickRequest.get(uri"$draftApiBaseUrl/health/readiness")
       val res = Try(simpleHttpClient.send(req))
       res.map(_.code.code) == Success(200)
     })

--- a/integration-tests/src/test/scala/no/ndla/integrationtests/searchapi/learningpathapi/LearningpathApiClientTest.scala
+++ b/integration-tests/src/test/scala/no/ndla/integrationtests/searchapi/learningpathapi/LearningpathApiClientTest.scala
@@ -33,7 +33,7 @@ class LearningpathApiClientTest
   override val searchConverterService = new SearchConverterService
 
   val learningpathApiPort: Int    = findFreePort
-  val pgc: PostgreSQLContainer[_] = postgresContainer.get
+  val pgc: PostgreSQLContainer[?] = postgresContainer.get
   val esHost: String              = elasticSearchHost.get
   val learningpathApiProperties: LearningpathApiProperties = new LearningpathApiProperties {
     override def ApplicationPort: Int = learningpathApiPort
@@ -56,8 +56,8 @@ class LearningpathApiClientTest
     learningpathApi = new learningpathapi.MainClass(learningpathApiProperties)
     Future { learningpathApi.run() }: Unit
     blockUntil(() => {
-      import sttp.client3.quick._
-      val req = quickRequest.get(uri"$learningpathApiBaseUrl/health")
+      import sttp.client3.quick.*
+      val req = quickRequest.get(uri"$learningpathApiBaseUrl/health/readiness")
       val res = Try(simpleHttpClient.send(req))
       res.map(_.code.code) == Success(200)
     })


### PR DESCRIPTION
Sjekka databasen og såg at en artikkel som feila på dette endepunktet hadde et innslag med null i document-feltet. Dette vil fikse den iden samt eventuelle tilsvarende. 
Denne feiler i dag https://api.test.ndla.no/article-api/v2/articles/external_ids/60733