### PR TITLE
Attempt fixing test-flake by using `doAnswer` over `thenAnswer`

### DIFF
--- a/draft-api/src/test/scala/no/ndla/draftapi/service/WriteServiceTest.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/service/WriteServiceTest.scala
@@ -1565,9 +1565,10 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
 
   test("That started is reset when published via PUBLISHED field") {
     scala.util.Properties.setProp("DEBUG_FLAKE", "true")
-    when(articleApiClient.updateArticle(any, any, any, any, any, any)).thenAnswer((i: InvocationOnMock) => {
-      Success(i.getArgument[Draft](1))
-    })
+    doAnswer((i: InvocationOnMock) => { Success(i.getArgument[Draft](1)) })
+      .when(articleApiClient)
+      .updateArticle(any, any, any, any, any, any)
+
     val existing = TestData.sampleDomainArticle.copy(
       started = true,
       status = TestData.statusWithInProcess,


### PR DESCRIPTION
Etter å ha sett de [forbedrede loggene](https://github.com/NDLANO/backend/actions/runs/8938510461/job/24552783936?pr=464#step:7:62) når flake skjedde, så tror jeg at denne mocken er problemet.
Vet ikke egentlig hvorfor, men har sett `thenReturn` lage trøbbel vs `doReturn` tidligere, så tenkte å prøve samme fiksen her.
