### PR TITLE
oembed-proxy: Support http urls for youtube

### DIFF
--- a/oembed-proxy/src/main/scala/no/ndla/oembedproxy/service/ProviderService.scala
+++ b/oembed-proxy/src/main/scala/no/ndla/oembedproxy/service/ProviderService.scala
@@ -57,12 +57,12 @@ trait ProviderService {
     val YoutubeEndpoint: OEmbedEndpoint = OEmbedEndpoint(
       Some(
         List(
-          "https://*.youtube.com/watch*",
-          "https://*.youtube.com/v/*",
-          "https://youtu.be/*",
-          "https://*.youtube.com/playlist?list=*",
-          "https://youtube.com/playlist?list=*",
-          "https://*.youtube.com/shorts*"
+          "http(s?)://*.youtube.com/watch*",
+          "http(s?)://*.youtube.com/v/*",
+          "http(s?)://youtu.be/*",
+          "http(s?)://*.youtube.com/playlist?list=*",
+          "http(s?)://youtube.com/playlist?list=*",
+          "http(s?)://*.youtube.com/shorts*"
         )
       ),
       Some("https://www.youtube.com/oembed"),


### PR DESCRIPTION
Ser at vi får noen 500 feil fordi provideren matcher uten schema, også finner den ingen endepunkter for schemaet.

Sånn _eegentlig_ så burde vi sikkert ikke tillate å lagre url'er med http, men jeg ser youtube provideren oppgraderer de til https uansett, så for akkurat denne så er det nok uproblematisk 😄 