### PR TITLE
oembed-proxy: Fix generic server error

### DIFF
--- a/oembed-proxy/src/main/scala/no/ndla/oembedproxy/model/OEmbedEndpoint.scala
+++ b/oembed-proxy/src/main/scala/no/ndla/oembedproxy/model/OEmbedEndpoint.scala
@@ -13,7 +13,7 @@ import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
 
 case class OEmbedEndpoint(
     schemes: Option[List[String]],
-    url: Option[String],
+    url: String,
     discovery: Option[Boolean],
     formats: Option[List[String]],
     mandatoryQueryParams: Option[List[(String, String)]]

--- a/oembed-proxy/src/main/scala/no/ndla/oembedproxy/model/OEmbedProvider.scala
+++ b/oembed-proxy/src/main/scala/no/ndla/oembedproxy/model/OEmbedProvider.scala
@@ -33,7 +33,10 @@ case class OEmbedProvider(
   private def _requestUrl(url: String, maxWidth: Option[String], maxHeight: Option[String]): String = {
     endpoints.collectFirst { case e if e.supports(url) && e.url.isDefined => e } match {
       case None =>
-        throw new RuntimeException(s"The provider '$providerName' has no embed-url available")
+        val validUrls = endpoints.flatMap(_.url)
+        throw ProviderNotSupportedException(
+          s"The provider '$providerName' does not support the provided url '$url'. Must be one of [${validUrls.mkString(",")}]"
+        )
       case Some(endpoint) =>
         val embedUrl = endpoint.url.get.replace("{format}", "json") // Some providers have {format} instead of ?format=
         val width    = maxWidth.map(("maxwidth", _)).toList

--- a/oembed-proxy/src/main/scala/no/ndla/oembedproxy/model/OEmbedProvider.scala
+++ b/oembed-proxy/src/main/scala/no/ndla/oembedproxy/model/OEmbedProvider.scala
@@ -31,14 +31,14 @@ case class OEmbedProvider(
   }
 
   private def _requestUrl(url: String, maxWidth: Option[String], maxHeight: Option[String]): String = {
-    endpoints.collectFirst { case e if e.supports(url) && e.url.isDefined => e } match {
+    endpoints.collectFirst { case e if e.supports(url) && e.url.nonEmpty => e } match {
       case None =>
         val validUrls = endpoints.flatMap(_.url)
         throw ProviderNotSupportedException(
           s"The provider '$providerName' does not support the provided url '$url'. Must be one of [${validUrls.mkString(",")}]"
         )
       case Some(endpoint) =>
-        val embedUrl = endpoint.url.get.replace("{format}", "json") // Some providers have {format} instead of ?format=
+        val embedUrl = endpoint.url.replace("{format}", "json") // Some providers have {format} instead of ?format=
         val width    = maxWidth.map(("maxwidth", _)).toList
         val height   = maxHeight.map(("maxheight", _)).toList
         val params = List(("url", url), ("format", "json")) ++ endpoint.mandatoryQueryParams.getOrElse(

--- a/oembed-proxy/src/main/scala/no/ndla/oembedproxy/service/ProviderService.scala
+++ b/oembed-proxy/src/main/scala/no/ndla/oembedproxy/service/ProviderService.scala
@@ -32,7 +32,7 @@ trait ProviderService {
     val NdlaFrontendEndpoint: OEmbedEndpoint =
       OEmbedEndpoint(
         Some(props.NdlaApprovedUrl),
-        Some(props.NdlaFrontendOembedServiceUrl),
+        props.NdlaFrontendOembedServiceUrl,
         None,
         None,
         None
@@ -41,7 +41,7 @@ trait ProviderService {
     val ListingFrontendEndpoint: OEmbedEndpoint =
       OEmbedEndpoint(
         Some(props.ListingFrontendApprovedUrls),
-        Some(props.ListingFrontendOembedServiceUrl),
+        props.ListingFrontendOembedServiceUrl,
         None,
         None,
         None
@@ -65,7 +65,7 @@ trait ProviderService {
           "http(s?)://*.youtube.com/shorts*"
         )
       ),
-      Some("https://www.youtube.com/oembed"),
+      "https://www.youtube.com/oembed",
       None,
       None,
       None
@@ -82,7 +82,7 @@ trait ProviderService {
     val H5PApprovedUrls: List[String] = List(props.NdlaH5PApprovedUrl)
 
     val H5PEndpoint: OEmbedEndpoint =
-      OEmbedEndpoint(Some(H5PApprovedUrls), Some(s"${props.NdlaH5POembedProvider}/oembed"), None, None, None)
+      OEmbedEndpoint(Some(H5PApprovedUrls), s"${props.NdlaH5POembedProvider}/oembed", None, None, None)
 
     val H5PProvider: OEmbedProvider =
       OEmbedProvider("H5P", props.NdlaH5POembedProvider, List(H5PEndpoint))
@@ -103,7 +103,7 @@ trait ProviderService {
     )
 
     val TedEndpoint: OEmbedEndpoint =
-      OEmbedEndpoint(Some(TedApprovedUrls), Some("https://www.ted.com/services/v1/oembed.json"), None, None, None)
+      OEmbedEndpoint(Some(TedApprovedUrls), "https://www.ted.com/services/v1/oembed.json", None, None, None)
     val TedProvider: OEmbedProvider = OEmbedProvider("Ted", "https://ted.com", List(TedEndpoint), removeQueryString)
 
     val IssuuApprovedUrls: List[String] = List("http://issuu.com/*", "https://issuu.com/*")
@@ -111,7 +111,7 @@ trait ProviderService {
     val IssuuEndpoint: OEmbedEndpoint =
       OEmbedEndpoint(
         Some(IssuuApprovedUrls),
-        Some("https://issuu.com/oembed"),
+        "https://issuu.com/oembed",
         None,
         None,
         Some(List(("iframe", "true")))
@@ -137,7 +137,7 @@ trait ProviderService {
         case Success(providers) =>
           providers
             .filter(_.endpoints.nonEmpty)
-            .filter(_.endpoints.forall(endpoint => endpoint.url.isDefined))
+            .filter(_.endpoints.forall(endpoint => endpoint.url.nonEmpty))
         case Failure(ex) =>
           logger.error(s"Failed to load providers from ${request.uri}.")
           throw new DoNotUpdateMemoizeException(ex.getMessage)

--- a/oembed-proxy/src/test/scala/no/ndla/oembedproxy/model/OEmbedEndpointTest.scala
+++ b/oembed-proxy/src/test/scala/no/ndla/oembedproxy/model/OEmbedEndpointTest.scala
@@ -12,7 +12,7 @@ import no.ndla.oembedproxy.UnitSuite
 
 class OEmbedEndpointTest extends UnitSuite {
 
-  val dummyEndpoint: OEmbedEndpoint = OEmbedEndpoint(None, None, None, None, None)
+  val dummyEndpoint: OEmbedEndpoint = OEmbedEndpoint(None, "", None, None, None)
 
   test("That matches returns true for a matching expression") {
     dummyEndpoint.matches("http://www.ndla.no/*/test", "http://www.ndla.no/123123/test") should be(right = true)

--- a/oembed-proxy/src/test/scala/no/ndla/oembedproxy/model/OEmbedProviderTest.scala
+++ b/oembed-proxy/src/test/scala/no/ndla/oembedproxy/model/OEmbedProviderTest.scala
@@ -16,13 +16,13 @@ class OEmbedProviderTest extends UnitSuite {
     OEmbedProvider("youtube", "https://www.youtube.com", List())
 
   val ndlaEndpoint: OEmbedEndpoint =
-    OEmbedEndpoint(Some(List("https://ndla.no/*/123")), Some("https://ndla.no/oembed"), None, None, None)
+    OEmbedEndpoint(Some(List("https://ndla.no/*/123")), "https://ndla.no/oembed", None, None, None)
 
   val ndlaListEndpoint: OEmbedEndpoint =
-    OEmbedEndpoint(Some(List("https://liste.ndla.no/*")), Some("https://liste.ndla.no/oembed"), None, None, None)
+    OEmbedEndpoint(Some(List("https://liste.ndla.no/*")), "https://liste.ndla.no/oembed", None, None, None)
 
   val youtubeEndpoint: OEmbedEndpoint =
-    OEmbedEndpoint(Some(List("https://www.youtube.com/*")), Some("https://www.youtube.com/oembed"), None, None, None)
+    OEmbedEndpoint(Some(List("https://www.youtube.com/*")), "https://www.youtube.com/oembed", None, None, None)
 
   test("That hostMatches returns true for same host, regardless of protocol") {
     youtubeProvider.hostMatches("https://www.youtube.com") should be(right = true)
@@ -55,8 +55,8 @@ class OEmbedProviderTest extends UnitSuite {
   }
 
   test("That requestUrl throws exception when no endpoints have embedUrl defined") {
-    assertResult("The provider 'youtube' has no embed-url available") {
-      intercept[RuntimeException] {
+    assertResult("The provider 'youtube' does not support the provided url 'random'. Must be one of []") {
+      intercept[ProviderNotSupportedException] {
         youtubeProvider.requestUrl("random", None, None)
       }.getMessage
     }
@@ -64,7 +64,7 @@ class OEmbedProviderTest extends UnitSuite {
 
   test("That {format} is replaced in embedUrl") {
     val endpoint =
-      youtubeEndpoint.copy(url = Some("https://www.youtube.com/oembed.{format}"))
+      youtubeEndpoint.copy(url = "https://www.youtube.com/oembed.{format}")
     val requestUrl = youtubeProvider
       .copy(endpoints = List(endpoint))
       .requestUrl("https://www.youtube.com/v/ABC", None, None)
@@ -72,7 +72,7 @@ class OEmbedProviderTest extends UnitSuite {
   }
 
   test("That maxwidth is appended correctly") {
-    val endpoint = youtubeEndpoint.copy(url = Some("https://youtube.com/oembed"))
+    val endpoint = youtubeEndpoint.copy(url = "https://youtube.com/oembed")
     val requestUrl = youtubeProvider
       .copy(endpoints = List(endpoint))
       .requestUrl("https://www.youtube.com/v/ABC", Some("100"), None)
@@ -80,7 +80,7 @@ class OEmbedProviderTest extends UnitSuite {
   }
 
   test("That maxheight is appended correctly") {
-    val endpoint = youtubeEndpoint.copy(url = Some("https://youtube.com/oembed"))
+    val endpoint = youtubeEndpoint.copy(url = "https://youtube.com/oembed")
     val requestUrl = youtubeProvider
       .copy(endpoints = List(endpoint))
       .requestUrl("https://www.youtube.com/v/ABC", None, Some("100"))
@@ -88,7 +88,7 @@ class OEmbedProviderTest extends UnitSuite {
   }
 
   test("That both maxwidth and maxheight are appended correctly") {
-    val endpoint = youtubeEndpoint.copy(url = Some("https://youtube.com/oembed"))
+    val endpoint = youtubeEndpoint.copy(url = "https://youtube.com/oembed")
     val requestUrl = youtubeProvider
       .copy(endpoints = List(endpoint))
       .requestUrl("https://www.youtube.com/v/ABC", Some("100"), Some("200"))

--- a/oembed-proxy/src/test/scala/no/ndla/oembedproxy/service/OEmbedServiceTest.scala
+++ b/oembed-proxy/src/test/scala/no/ndla/oembedproxy/service/OEmbedServiceTest.scala
@@ -23,7 +23,7 @@ class OEmbedServiceTest extends UnitSuite with TestEnvironment {
   val ndlaProvider: OEmbedProvider = OEmbedProvider(
     "ndla",
     "https://ndla.no",
-    List(OEmbedEndpoint(Some(List("https://ndla.no/*")), Some("https://ndla.no/oembed"), None, None, None))
+    List(OEmbedEndpoint(Some(List("https://ndla.no/*")), "https://ndla.no/oembed", None, None, None))
   )
 
   val youtubeProvider: OEmbedProvider = OEmbedProvider(
@@ -32,7 +32,7 @@ class OEmbedServiceTest extends UnitSuite with TestEnvironment {
     List(
       OEmbedEndpoint(
         Some(List("https://www.youtube.com/*")),
-        Some("https://www.youtube.com/oembed"),
+        "https://www.youtube.com/oembed",
         Some(true),
         None,
         None

--- a/oembed-proxy/src/test/scala/no/ndla/oembedproxy/service/ProviderServiceTest.scala
+++ b/oembed-proxy/src/test/scala/no/ndla/oembedproxy/service/ProviderServiceTest.scala
@@ -22,7 +22,7 @@ class ProviderServiceTest extends UnitSuite with TestEnvironment {
   val IncompleteProvider: OEmbedProvider = OEmbedProvider(
     "gfycat",
     "https://gfycat.com",
-    List(OEmbedEndpoint(Some(List("http://gfycat.com/*")), None, None, None, None))
+    List(OEmbedEndpoint(Some(List("http://gfycat.com/*")), "", None, None, None))
   )
 
   val CompleteProvider: OEmbedProvider = OEmbedProvider(
@@ -31,7 +31,7 @@ class ProviderServiceTest extends UnitSuite with TestEnvironment {
     List(
       OEmbedEndpoint(
         Some(List("http://ifttt.com/recipes/*")),
-        Some("http://www.ifttt.com/oembed/"),
+        "http://www.ifttt.com/oembed/",
         Some(true),
         None,
         None


### PR DESCRIPTION
Fjerner muligheten til å lage endpoints uten `url`, og returnerer 422 dersom noen spør om en url som ikke er valid i provideren istedenfor 500.
