### PR TITLE
Filter learningresources independent of taxonomy

### DIFF
--- a/search-api/src/main/scala/no/ndla/searchapi/controller/SearchController.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/controller/SearchController.scala
@@ -87,7 +87,7 @@ trait SearchController {
     private val resourceTypes =
       listQuery[String]("resource-types")
         .description(
-          "Return only learning resources of specific type(s). To provide multiple types, separate by comma (,)."
+          "Return only learning resources with specific taxonomy type(s), e.g. 'urn:resourcetype:learningpath'. To provide multiple types, separate by comma (,)."
         )
     private val learningResourceIds =
       listQuery[Long]("ids")
@@ -110,7 +110,7 @@ trait SearchController {
     private val contextTypes =
       listQuery[String]("context-types")
         .description(
-          s"A comma separated list of context-types the learning resources should be filtered by. Available values is ${LearningResourceType.values
+          s"A comma separated list of types the learning resources should be filtered by. Available values is ${LearningResourceType.values
               .mkString(", ")}"
         )
     private val groupTypes =

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/ArticleIndexService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/ArticleIndexService.scala
@@ -21,7 +21,7 @@ import no.ndla.searchapi.model.search.SearchType
 import scala.util.Try
 
 trait ArticleIndexService {
-  this: SearchConverterService with IndexService with ArticleApiClient with Props =>
+  this: SearchConverterService & IndexService & ArticleApiClient & Props =>
   val articleIndexService: ArticleIndexService
 
   class ArticleIndexService extends StrictLogging with IndexService[Article] {

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/DraftIndexService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/DraftIndexService.scala
@@ -22,7 +22,7 @@ import no.ndla.searchapi.model.search.SearchType
 import scala.util.Try
 
 trait DraftIndexService {
-  this: SearchConverterService with IndexService with DraftApiClient with Props =>
+  this: SearchConverterService & IndexService & DraftApiClient & Props =>
   import props.SearchIndex
   val draftIndexService: DraftIndexService
 

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/IndexService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/IndexService.scala
@@ -26,13 +26,8 @@ import no.ndla.searchapi.model.domain.{IndexingBundle, ReindexResult}
 import scala.util.{Failure, Success, Try}
 
 trait IndexService {
-  this: Elastic4sClient
-    with SearchApiClient
-    with BaseIndexService
-    with TaxonomyApiClient
-    with GrepApiClient
-    with Props
-    with MyNDLAApiClient =>
+  this: Elastic4sClient & SearchApiClient & BaseIndexService & TaxonomyApiClient & GrepApiClient & Props &
+    MyNDLAApiClient =>
 
   trait IndexService[D <: Content] extends BaseIndexService with StrictLogging {
     val apiClient: SearchApiClient
@@ -138,7 +133,9 @@ trait IndexService {
       })
     }
 
-    def sendToElastic(indexName: String, indexingBundle: IndexingBundle)(implicit d: Decoder[D]): Try[(Int, Int)] = {
+    private def sendToElastic(indexName: String, indexingBundle: IndexingBundle)(implicit
+        d: Decoder[D]
+    ): Try[(Int, Int)] = {
 
       val chunks = apiClient.getChunks[D]
       val results = chunks
@@ -201,7 +198,7 @@ trait IndexService {
       }
     }
 
-    val hyphDecompounderTokenFilter: CompoundWordTokenFilter = CompoundWordTokenFilter(
+    private val hyphDecompounderTokenFilter: CompoundWordTokenFilter = CompoundWordTokenFilter(
       name = "hyphenation_decompounder",
       `type` = HyphenationDecompounder,
       wordListPath = Some("compound-words-norwegian-wordlist.txt"),

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/LearningPathIndexService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/LearningPathIndexService.scala
@@ -22,7 +22,7 @@ import no.ndla.searchapi.model.search.SearchType
 import scala.util.Try
 
 trait LearningPathIndexService {
-  this: SearchConverterService with IndexService with LearningPathApiClient with Props =>
+  this: SearchConverterService & IndexService & LearningPathApiClient & Props =>
   import props.SearchIndex
   val learningPathIndexService: LearningPathIndexService
 

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/MultiSearchService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/MultiSearchService.scala
@@ -164,7 +164,7 @@ trait MultiSearchService {
       val articleTypeFilter = Some(
         boolQuery().should(settings.articleTypes.map(articleType => termQuery("articleType", articleType)))
       )
-      val learningResourceTypeFilter = Some(
+      val learningResourceTypeFilter = Option.when(settings.learningResourceTypes.nonEmpty)(
         boolQuery().should(
           settings.learningResourceTypes.map(resourceType => termQuery("learningResourceType", resourceType.entryName))
         )

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/MultiSearchService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/MultiSearchService.scala
@@ -7,7 +7,7 @@
 
 package no.ndla.searchapi.service.search
 
-import com.sksamuel.elastic4s.ElasticDsl._
+import com.sksamuel.elastic4s.ElasticDsl.*
 import com.sksamuel.elastic4s.requests.searches.queries.Query
 import com.sksamuel.elastic4s.requests.searches.queries.compound.BoolQuery
 import com.typesafe.scalalogging.StrictLogging
@@ -29,14 +29,8 @@ import scala.util.{Failure, Success, Try}
 import no.ndla.common.model.domain.Content
 
 trait MultiSearchService {
-  this: Elastic4sClient
-    with SearchConverterService
-    with SearchService
-    with IndexService
-    with ArticleIndexService
-    with LearningPathIndexService
-    with Props
-    with ErrorHelpers =>
+  this: Elastic4sClient & SearchConverterService & SearchService & IndexService & ArticleIndexService &
+    LearningPathIndexService & Props & ErrorHelpers =>
 
   val multiSearchService: MultiSearchService
 
@@ -44,7 +38,7 @@ trait MultiSearchService {
     import props.{ElasticSearchIndexMaxResultWindow, ElasticSearchScrollKeepAlive, SearchIndex}
 
     override val searchIndex: List[String] = List(SearchType.Articles, SearchType.LearningPaths).map(SearchIndex)
-    override val indexServices: List[IndexService[_ <: Content]] = List(articleIndexService, learningPathIndexService)
+    override val indexServices: List[IndexService[? <: Content]] = List(articleIndexService, learningPathIndexService)
 
     def matchingQuery(settings: SearchSettings): Try[SearchResult] = {
 
@@ -170,7 +164,11 @@ trait MultiSearchService {
       val articleTypeFilter = Some(
         boolQuery().should(settings.articleTypes.map(articleType => termQuery("articleType", articleType)))
       )
-      val taxonomyContextTypeFilter   = contextTypeFilter(settings.learningResourceTypes)
+      val learningResourceTypeFilter = Some(
+        boolQuery().should(
+          settings.learningResourceTypes.map(resourceType => termQuery("learningResourceType", resourceType.entryName))
+        )
+      )
       val taxonomyResourceTypesFilter = resourceTypeFilter(settings.resourceTypes, settings.filterByNoResourceType)
       val taxonomySubjectFilter       = subjectFilter(settings.subjects, settings.filterInactive)
       val taxonomyRelevanceFilter     = relevanceFilter(settings.relevanceIds, settings.subjects)
@@ -187,10 +185,10 @@ trait MultiSearchService {
         licenseFilter,
         idFilter,
         articleTypeFilter,
+        learningResourceTypeFilter,
         languageFilter,
         taxonomySubjectFilter,
         taxonomyResourceTypesFilter,
-        taxonomyContextTypeFilter,
         supportedLanguageFilter,
         taxonomyRelevanceFilter,
         taxonomyContextActiveFilter,

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
@@ -55,7 +55,7 @@ import scala.jdk.CollectionConverters.*
 import scala.util.{Success, Try}
 
 trait SearchConverterService {
-  this: DraftApiClient with TaxonomyApiClient with ConverterService with Props with MyNDLAApiClient =>
+  this: DraftApiClient & TaxonomyApiClient & ConverterService & Props & MyNDLAApiClient =>
   val searchConverterService: SearchConverterService
 
   class SearchConverterService extends StrictLogging {
@@ -302,13 +302,13 @@ trait SearchConverterService {
         id: String,
         resourceTypes: List[MyNDLAResourceType]
     ): Try[Long] = {
-      (indexingBundle.myndlaBundle match {
+      indexingBundle.myndlaBundle match {
         case Some(value) => Success(value.getFavorites(id, resourceTypes))
         case None =>
           myndlaapiClient
             .getStatsFor(id, resourceTypes)
             .map(_.map(_.favourites).sum)
-      })
+      }
     }
 
     def asSearchableConcept(c: Concept, indexingBundle: IndexingBundle): Try[SearchableConcept] = {
@@ -544,7 +544,7 @@ trait SearchConverterService {
           .lastOption
       }
 
-      val highlightKeys: Option[Map[String, _]] = Option(result.highlight)
+      val highlightKeys: Option[Map[String, ?]] = Option(result.highlight)
       val matchLanguage                         = keyToLanguage(highlightKeys.getOrElse(Map()).keys)
 
       matchLanguage match {

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/SearchService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/SearchService.scala
@@ -7,8 +7,8 @@
 
 package no.ndla.searchapi.service.search
 
-import cats.implicits._
-import com.sksamuel.elastic4s.ElasticDsl._
+import cats.implicits.*
+import com.sksamuel.elastic4s.ElasticDsl.*
 import com.sksamuel.elastic4s.handlers.searches.suggestion.{DirectGenerator, PhraseSuggestion}
 import com.sksamuel.elastic4s.requests.searches.queries.compound.BoolQuery
 import com.sksamuel.elastic4s.requests.searches.queries.{NestedQuery, Query, SimpleStringQuery}
@@ -24,8 +24,8 @@ import no.ndla.search.AggregationBuilder.getAggregationsFromResult
 import no.ndla.search.{Elastic4sClient, IndexNotFoundException, NdlaSearchException, SearchLanguage}
 import no.ndla.searchapi.Props
 import no.ndla.searchapi.model.api.{MultiSearchSuggestion, MultiSearchSummary, SearchSuggestion, SuggestOption}
-import no.ndla.searchapi.model.domain.Sort._
-import no.ndla.searchapi.model.domain._
+import no.ndla.searchapi.model.domain.Sort.*
+import no.ndla.searchapi.model.domain.*
 import no.ndla.searchapi.model.search.SearchType
 
 import java.lang.Math.max
@@ -33,12 +33,12 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
 
 trait SearchService {
-  this: Elastic4sClient with IndexService with SearchConverterService with StrictLogging with Props =>
+  this: Elastic4sClient & IndexService & SearchConverterService & StrictLogging & Props =>
 
   trait SearchService {
     import props.{DefaultLanguage, ElasticSearchScrollKeepAlive, MaxPageSize}
     val searchIndex: List[String]
-    val indexServices: List[IndexService[_]]
+    val indexServices: List[IndexService[?]]
 
     /** Returns hit as summary
       *
@@ -179,7 +179,7 @@ trait SearchService {
       }.toSeq
     }
 
-    def getSuggestion(results: Seq[SuggestionResult]): Seq[SearchSuggestion] = {
+    private def getSuggestion(results: Seq[SuggestionResult]): Seq[SearchSuggestion] = {
       results.map(result =>
         SearchSuggestion(
           text = result.text,
@@ -190,7 +190,7 @@ trait SearchService {
       )
     }
 
-    def mapToSuggestOption(optionsMap: Map[String, Any]): SuggestOption = {
+    private def mapToSuggestOption(optionsMap: Map[String, Any]): SuggestOption = {
       val text  = optionsMap.getOrElse("text", "")
       val score = optionsMap.getOrElse("score", 1)
       SuggestOption(

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/TaxonomyFiltering.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/TaxonomyFiltering.scala
@@ -24,7 +24,7 @@ trait TaxonomyFiltering {
 
   private val mustNotBeConceptQuery = termsQuery("learningResourceType", notConceptType)
 
-  def mustBeConceptOr(query: Query): Query = {
+  private def mustBeConceptOr(query: Query): Query = {
     val newQuery = query match {
       case nested: NestedQuery if nested.path == "contexts" => nested.ignoreUnmapped(true)
       case query                                            => query
@@ -111,15 +111,6 @@ trait TaxonomyFiltering {
       )
     }
   }
-
-  protected def contextTypeFilter(contextTypes: List[LearningResourceType]): Option[BoolQuery] =
-    if (contextTypes.isEmpty) None
-    else {
-      val taxonomyContextQuery =
-        contextTypes.map(ct => nestedQuery("contexts", termQuery("contexts.contextType", ct.entryName)))
-
-      Some(boolQuery().should(taxonomyContextQuery))
-    }
 
   protected def contextActiveFilter(filterInactive: Boolean): Option[Query] =
     if (filterInactive) {

--- a/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceTest.scala
@@ -538,14 +538,15 @@ class MultiSearchServiceTest
     search.results.map(_.id) should be(Seq(1, 2, 3, 5, 6, 7, 8, 9, 10, 11, 12))
   }
 
-  test("That filtering on learningpath learningresourcetype returns learningpaths in structure") {
+  test("That filtering on learningpath learningresourcetype returns learningpaths") {
     val Success(search) = multiSearchService.matchingQuery(
       searchSettings.copy(language = "*", learningResourceTypes = List(LearningResourceType.LearningPath))
     )
 
-    search.totalCount should be(5)
-    search.results.map(_.id) should be(Seq(1, 2, 3, 4, 5))
+    search.totalCount should be(6)
+    search.results.map(_.id) should be(Seq(1, 2, 3, 4, 5, 6))
     search.results.filter(_.contexts.nonEmpty).map(_.contexts.head.contextType) should be(
+      // only 5 learningpaths with contexts
       Seq.fill(5) { LearningResourceType.LearningPath.toString }
     )
   }


### PR DESCRIPTION
Filtrering på context-types gir kun treff på kontekster. Men vi har redefinert parameteret til å være læringsressurser, og det er uavhengig av om den finnes i struktur eller ikkje.
Dette løser problemet der favorittmerka læringsstier som er fjerna fra struktur forsvinner fra delte mapper.