### PR TITLE
oembed-proxy: Fix youtube playlist support

### DIFF
--- a/oembed-proxy/src/main/scala/no/ndla/oembedproxy/model/OEmbedProvider.scala
+++ b/oembed-proxy/src/main/scala/no/ndla/oembedproxy/model/OEmbedProvider.scala
@@ -33,7 +33,7 @@ case class OEmbedProvider(
   private def _requestUrl(url: String, maxWidth: Option[String], maxHeight: Option[String]): String = {
     endpoints.collectFirst { case e if e.supports(url) && e.url.nonEmpty => e } match {
       case None =>
-        val validUrls = endpoints.flatMap(_.url)
+        val validUrls = endpoints.map(_.url)
         throw ProviderNotSupportedException(
           s"The provider '$providerName' does not support the provided url '$url'. Must be one of [${validUrls.mkString(",")}]"
         )

--- a/oembed-proxy/src/main/scala/no/ndla/oembedproxy/service/OEmbedConverterService.scala
+++ b/oembed-proxy/src/main/scala/no/ndla/oembedproxy/service/OEmbedConverterService.scala
@@ -39,7 +39,7 @@ object OEmbedConverterService {
   }
 
   def handleYoutubeRequestUrl(url: String): String = {
-    val filtered = filterQueryNames(url.replaceAll("&amp;", "&"), Set("v"))
+    val filtered = filterQueryNames(url.replaceAll("&amp;", "&"), Set("v", "list"))
 
     filtered.path.parts.toList match {
       case "embed" :: videoId :: _ => idToYoutubeUrl(videoId)

--- a/oembed-proxy/src/main/scala/no/ndla/oembedproxy/service/ProviderService.scala
+++ b/oembed-proxy/src/main/scala/no/ndla/oembedproxy/service/ProviderService.scala
@@ -60,8 +60,8 @@ trait ProviderService {
           "http(s?)://*.youtube.com/watch*",
           "http(s?)://*.youtube.com/v/*",
           "http(s?)://youtu.be/*",
-          "http(s?)://*.youtube.com/playlist?list=*",
-          "http(s?)://youtube.com/playlist?list=*",
+          "http(s?)://*.youtube.com/playlist\\?list=*",
+          "http(s?)://youtube.com/playlist\\?list=*",
           "http(s?)://*.youtube.com/shorts*"
         )
       ),

--- a/oembed-proxy/src/test/scala/no/ndla/oembedproxy/service/OEmbedConverterServiceTest.scala
+++ b/oembed-proxy/src/test/scala/no/ndla/oembedproxy/service/OEmbedConverterServiceTest.scala
@@ -102,7 +102,7 @@ class OEmbedConverterServiceTest extends UnitSuite with TestEnvironment {
     OEmbedConverterService.addYoutubeTimestampIfdefinedInRequest(requestUrl, oembed).html should be(expectedResult)
   }
 
-  test("handleYoutubeRequestUrl should strip all query params except 'v'") {
+  test("handleYoutubeRequestUrl should strip all query params except 'v' and 'list'") {
     OEmbedConverterService.handleYoutubeRequestUrl("http://youtube.com/watch?start=1&v=123asdf") should equal(
       "http://youtube.com/watch?v=123asdf"
     )
@@ -113,6 +113,10 @@ class OEmbedConverterServiceTest extends UnitSuite with TestEnvironment {
       "http://youtube.com/watch?v=123asdf&;amptime_continue=43"
     ) should equal("http://youtube.com/watch?v=123asdf")
     OEmbedConverterService.handleYoutubeRequestUrl("notanurl") should equal("notanurl")
+
+    OEmbedConverterService.handleYoutubeRequestUrl("https://www.youtube.com/playlist?list=PLJBPGA24dsn_HLSn6bmA8ajn-9AVGCWje") should be(
+      "https://www.youtube.com/playlist?list=PLJBPGA24dsn_HLSn6bmA8ajn-9AVGCWje"
+    )
   }
 
   test("handleYoutubeRequestUrl should convert /embed and /v urls to youtu.be") {

--- a/oembed-proxy/src/test/scala/no/ndla/oembedproxy/service/ProviderServiceTest.scala
+++ b/oembed-proxy/src/test/scala/no/ndla/oembedproxy/service/ProviderServiceTest.scala
@@ -73,4 +73,10 @@ class ProviderServiceTest extends UnitSuite with TestEnvironment {
     val providers = providerService.loadProvidersFromRequest(mock[NdlaRequest])
     providers.size should be(1)
   }
+
+  test("That youtube provider supports playlists") {
+    providerService.YoutubeEndpoint.supports(
+      "https://youtube.com/playlist?list=PLJBPGA24dsn_HLSn6bmA8ajn-9AVGCWje"
+    ) should be(true)
+  }
 }


### PR DESCRIPTION
Ser ut som vi har prøvd å støtte dette tidligere men ikke helt fått det til.
Dette fikser :smile: 

Kan testes med å forsøke å embed'e en spilleliste:

/oembed-proxy/v1/oembed?url=https%3A%2F%2Fwww.youtube.com%2Fplaylist%3Flist%3DPLJBPGA24dsn_HLSn6bmA8ajn-9AVGCWje