### PR TITLE
Remove test-fixtures based on whether database is available

### DIFF
--- a/article-api/src/main/scala/no/ndla/articleapi/DBMigrator.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/DBMigrator.scala
@@ -8,7 +8,7 @@
 
 package no.ndla.articleapi
 
-import no.ndla.articleapi.db.migrationwithdependencies._
+import no.ndla.articleapi.db.migrationwithdependencies.*
 import no.ndla.articleapi.integration.DataSource
 import org.flywaydb.core.Flyway
 

--- a/article-api/src/test/scala/no/ndla/articleapi/repository/ArticleRepositoryTest.scala
+++ b/article-api/src/test/scala/no/ndla/articleapi/repository/ArticleRepositoryTest.scala
@@ -38,30 +38,23 @@ class ArticleRepositoryTest
     }
   }
 
-  def databaseIsAvailable: Boolean = Try(repository.articleCount).isSuccess
-
   override def beforeAll(): Unit = {
     super.beforeAll()
-    Try {
-      ConnectionPool.singleton(new DataSourceConnectionPool(dataSource))
-      if (serverIsListening) {
-        migrator.migrate()
-      }
+    ConnectionPool.singleton(new DataSourceConnectionPool(dataSource))
+    if (serverIsListening) {
+      migrator.migrate()
     }
   }
 
   override def beforeEach(): Unit = {
     repository = new ArticleRepository
-    if (databaseIsAvailable)
-      repository.getAllIds().foreach(articleId => repository.deleteMaxRevision(articleId.articleId))
+    repository.getAllIds().foreach(articleId => repository.deleteMaxRevision(articleId.articleId))
   }
 
   override def afterEach(): Unit =
-    if (databaseIsAvailable)
-      repository.getAllIds().foreach(articleId => repository.deleteMaxRevision(articleId.articleId))
+    repository.getAllIds().foreach(articleId => repository.deleteMaxRevision(articleId.articleId))
 
   test("getAllIds returns a list with all ids in the database") {
-    assume(databaseIsAvailable, "Database is unavailable")
     val externalIdsAndRegularIds = (100 to 150).map(_.toString).zipWithIndex
     externalIdsAndRegularIds.foreach { case (exId, id) =>
       repository.updateArticleFromDraftApi(sampleArticle.copy(id = Some(id.toLong)), List(exId))
@@ -71,7 +64,6 @@ class ArticleRepositoryTest
   }
 
   test("getIdFromExternalId works with all ids") {
-    assume(databaseIsAvailable, "Database is unavailable")
     val inserted1 = repository.updateArticleFromDraftApi(sampleArticle.copy(id = Some(1)), List("6000", "10"))
     val inserted2 = repository.updateArticleFromDraftApi(sampleArticle.copy(id = Some(2)), List("6001", "11"))
 
@@ -82,7 +74,6 @@ class ArticleRepositoryTest
   }
 
   test("getArticleIdsFromExternalId should return ArticleIds object with externalIds") {
-    assume(databaseIsAvailable, "Database is unavailable")
     val externalIds = List("1", "6010", "6011", "5084", "763", "8881", "1919")
     val inserted    = repository.updateArticleFromDraftApi(sampleArticle, externalIds)
     val inserted2   = repository.updateArticleFromDraftApi(sampleArticle.copy(revision = Some(2)), externalIds)
@@ -93,7 +84,6 @@ class ArticleRepositoryTest
   }
 
   test("updateArticleFromDraftApi should update all columns with data from draft-api") {
-    assume(databaseIsAvailable, "Database is unavailable")
 
     val externalIds = List("123", "456")
     val sampleArticle: Article =
@@ -105,8 +95,6 @@ class ArticleRepositoryTest
   }
 
   test("Fetching external ids works as expected") {
-    assume(databaseIsAvailable, "Database is unavailable")
-
     val externalIds        = List("1", "2", "3")
     val idWithExternals    = repository.updateArticleFromDraftApi(sampleArticle.copy(id = Some(1)), externalIds)
     val idWithoutExternals = repository.updateArticleFromDraftApi(sampleArticle.copy(id = Some(2)), List.empty)
@@ -121,7 +109,6 @@ class ArticleRepositoryTest
   }
 
   test("updating with a valid article with a that is not in database will be recreated") {
-    assume(databaseIsAvailable, "Database is unavailable")
     val article = TestData.sampleDomainArticle.copy(id = Some(110))
 
     val x = repository.updateArticleFromDraftApi(article, List.empty)
@@ -131,7 +118,6 @@ class ArticleRepositoryTest
   }
 
   test("deleting article should ignore missing articles") {
-    assume(databaseIsAvailable, "Database is unavailable")
     val article = TestData.sampleDomainArticle.copy(id = Some(Integer.MAX_VALUE))
 
     val deletedId = repository.deleteMaxRevision(article.id.get)
@@ -139,8 +125,6 @@ class ArticleRepositoryTest
   }
 
   test("That getArticlesByPage returns all latest articles") {
-    assume(databaseIsAvailable, "Database is unavailable")
-
     val art1 = repository.updateArticleFromDraftApi(sampleArticle.copy(id = Some(1)), List.empty).get
     val art2 = repository.updateArticleFromDraftApi(sampleArticle.copy(id = Some(2)), List.empty).get
     val art3 = repository.updateArticleFromDraftApi(sampleArticle.copy(id = Some(3)), List.empty).get
@@ -154,8 +138,6 @@ class ArticleRepositoryTest
   }
 
   test("That stored articles are retrieved exactly as they were stored") {
-    assume(databaseIsAvailable, "Database is unavailable")
-
     val art1 = repository.updateArticleFromDraftApi(TestData.sampleArticleWithByNcSa.copy(id = Some(1)), List.empty).get
     val art2 =
       repository.updateArticleFromDraftApi(TestData.sampleArticleWithPublicDomain.copy(id = Some(2)), List.empty).get
@@ -168,7 +150,6 @@ class ArticleRepositoryTest
   }
 
   test("getTags returns non-duplicate tags and correct number of them") {
-    assume(databaseIsAvailable, "Database is unavailable")
     val sampleArticle1 = TestData.sampleDomainArticle2
       .copy(
         id = Some(1L),
@@ -252,7 +233,6 @@ class ArticleRepositoryTest
   }
 
   test("Dumping articles should ignore unpublished ones") {
-    assume(databaseIsAvailable, "Database is unavailable")
     val articleId = 110L
     val article   = TestData.sampleDomainArticle.copy(id = Some(articleId))
 
@@ -270,7 +250,6 @@ class ArticleRepositoryTest
   }
 
   test("That fetching with slugs works as expected with revisions") {
-    assume(databaseIsAvailable, "Database is unavailable")
     val articleId = 110L
     val article   = TestData.sampleDomainArticle.copy(id = Some(articleId), slug = Some("Detti-er-ein-slug"))
 

--- a/article-api/src/test/scala/no/ndla/articleapi/service/search/ArticleSearchServiceTest.scala
+++ b/article-api/src/test/scala/no/ndla/articleapi/service/search/ArticleSearchServiceTest.scala
@@ -17,7 +17,6 @@ import no.ndla.common.model.domain._
 import no.ndla.language.Language
 import no.ndla.mapping.License.{CC_BY_NC_SA, Copyrighted, PublicDomain}
 import no.ndla.scalatestsuite.IntegrationSuite
-import org.scalatest.Outcome
 
 import scala.util.Success
 
@@ -29,12 +28,6 @@ class ArticleSearchServiceTest
   import props._
 
   e4sClient = Elastic4sClientFactory.getClient(elasticSearchHost.getOrElse("http://localhost:9200"))
-
-  // Skip tests if no docker environment available
-  override def withFixture(test: NoArgTest): Outcome = {
-    assume(elasticSearchContainer.isSuccess)
-    super.withFixture(test)
-  }
 
   override val articleSearchService = new ArticleSearchService
   override val articleIndexService: ArticleIndexService = new ArticleIndexService {

--- a/audio-api/src/test/scala/no/ndla/audioapi/service/search/AudioSearchServiceTest.scala
+++ b/audio-api/src/test/scala/no/ndla/audioapi/service/search/AudioSearchServiceTest.scala
@@ -18,7 +18,6 @@ import no.ndla.common.model.domain.{Author, Tag, Title}
 import no.ndla.scalatestsuite.IntegrationSuite
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
-import org.scalatest.Outcome
 
 import scala.util.Success
 
@@ -216,12 +215,6 @@ class AudioSearchServiceTest
     Some(1),
     None
   )
-
-  // Skip tests if no docker environment available
-  override def withFixture(test: NoArgTest): Outcome = {
-    assume(elasticSearchContainer.isSuccess)
-    super.withFixture(test)
-  }
 
   override def beforeAll(): Unit = {
     super.beforeAll()

--- a/audio-api/src/test/scala/no/ndla/audioapi/service/search/SeriesSearchServiceTest.scala
+++ b/audio-api/src/test/scala/no/ndla/audioapi/service/search/SeriesSearchServiceTest.scala
@@ -13,7 +13,6 @@ import no.ndla.audioapi.model.{Sort, domain}
 import no.ndla.audioapi.{TestData, TestEnvironment, UnitSuite}
 import no.ndla.common.model.{domain => common}
 import no.ndla.scalatestsuite.IntegrationSuite
-import org.scalatest.Outcome
 
 import scala.util.Success
 
@@ -29,12 +28,6 @@ class SeriesSearchServiceTest
   }
   override val searchConverterService = new SearchConverterService
   override val converterService       = new ConverterService
-
-  // Skip tests if no docker environment available
-  override def withFixture(test: NoArgTest): Outcome = {
-    assume(elasticSearchContainer.isSuccess)
-    super.withFixture(test)
-  }
 
   val seriesToIndex: Seq[Series] = Seq(
     TestData.SampleSeries.copy(

--- a/audio-api/src/test/scala/no/ndla/audioapi/service/search/TagIndexServiceTest.scala
+++ b/audio-api/src/test/scala/no/ndla/audioapi/service/search/TagIndexServiceTest.scala
@@ -9,17 +9,10 @@ package no.ndla.audioapi.service.search
 
 import no.ndla.audioapi.{TestData, TestEnvironment}
 import no.ndla.scalatestsuite.IntegrationSuite
-import org.scalatest.Outcome
 
 class TagIndexServiceTest extends IntegrationSuite(EnableElasticsearchContainer = true) with TestEnvironment {
 
   e4sClient = Elastic4sClientFactory.getClient(elasticSearchHost.getOrElse("http://localhost:9200"))
-
-  // Skip tests if no docker environment available
-  override def withFixture(test: NoArgTest): Outcome = {
-    assume(elasticSearchContainer.isSuccess)
-    super.withFixture(test)
-  }
 
   override val tagIndexService: TagIndexService = new TagIndexService {
     override val indexShards = 1

--- a/audio-api/src/test/scala/no/ndla/audioapi/service/search/TagSearchServiceTest.scala
+++ b/audio-api/src/test/scala/no/ndla/audioapi/service/search/TagSearchServiceTest.scala
@@ -11,19 +11,12 @@ import no.ndla.audioapi.{TestData, TestEnvironment}
 import no.ndla.audioapi.model.domain.AudioMetaInformation
 import no.ndla.common.model.{domain => common}
 import no.ndla.scalatestsuite.IntegrationSuite
-import org.scalatest.Outcome
 
 import scala.util.Success
 
 class TagSearchServiceTest extends IntegrationSuite(EnableElasticsearchContainer = true) with TestEnvironment {
 
   e4sClient = Elastic4sClientFactory.getClient(elasticSearchHost.getOrElse("http://localhost:9200"))
-
-  // Skip tests if no docker environment available
-  override def withFixture(test: NoArgTest): Outcome = {
-    assume(elasticSearchContainer.isSuccess)
-    super.withFixture(test)
-  }
 
   override val tagSearchService = new TagSearchService
   override val tagIndexService: TagIndexService = new TagIndexService {

--- a/concept-api/src/test/scala/no/ndla/conceptapi/repository/DraftConceptRepositoryTest.scala
+++ b/concept-api/src/test/scala/no/ndla/conceptapi/repository/DraftConceptRepositoryTest.scala
@@ -14,7 +14,6 @@ import no.ndla.common.model.domain.concept.ConceptContent
 import no.ndla.conceptapi.TestData.*
 import no.ndla.conceptapi.{TestData, TestEnvironment, UnitSuite}
 import no.ndla.scalatestsuite.IntegrationSuite
-import org.scalatest.Outcome
 import scalikejdbc.*
 
 import java.net.Socket
@@ -28,21 +27,6 @@ class DraftConceptRepositoryTest
   override val dataSource: HikariDataSource = testDataSource.get
   override val migrator                     = new DBMigrator
   var repository: DraftConceptRepository    = _
-
-  // Skip tests if no docker environment available
-  override def withFixture(test: NoArgTest): Outcome = {
-    postgresContainer match {
-      case Failure(ex) =>
-        println(s"Postgres container not running, cancelling '${this.getClass.getName}'")
-        println(s"Got exception: ${ex.getMessage}")
-        ex.printStackTrace()
-      case _ =>
-    }
-    if (!sys.env.getOrElse("CI", "false").toBoolean) {
-      assume(postgresContainer.isSuccess, "Docker environment unavailable for postgres container")
-    }
-    super.withFixture(test)
-  }
 
   def emptyTestDatabase: Boolean = {
     DB autoCommit (implicit session => {
@@ -59,11 +43,9 @@ class DraftConceptRepositoryTest
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    Try {
-      if (serverIsListening) {
-        DataSource.connectToDatabase()
-        migrator.migrate()
-      }
+    if (serverIsListening) {
+      DataSource.connectToDatabase()
+      migrator.migrate()
     }
   }
 

--- a/concept-api/src/test/scala/no/ndla/conceptapi/service/search/DraftConceptSearchServiceTest.scala
+++ b/concept-api/src/test/scala/no/ndla/conceptapi/service/search/DraftConceptSearchServiceTest.scala
@@ -16,7 +16,6 @@ import no.ndla.conceptapi.model.domain.*
 import no.ndla.conceptapi.model.search.DraftSearchSettings
 import no.ndla.language.Language
 import no.ndla.scalatestsuite.IntegrationSuite
-import org.scalatest.Outcome
 
 import scala.util.Success
 import no.ndla.common.model.NDLADate
@@ -39,12 +38,6 @@ import java.util.UUID
 class DraftConceptSearchServiceTest extends IntegrationSuite(EnableElasticsearchContainer = true) with TestEnvironment {
   import props.{DefaultLanguage, DefaultPageSize}
   e4sClient = Elastic4sClientFactory.getClient(elasticSearchHost.getOrElse("http://localhost:9200"))
-
-  // Skip tests if no docker environment available
-  override def withFixture(test: NoArgTest): Outcome = {
-    assume(elasticSearchContainer.isSuccess)
-    super.withFixture(test)
-  }
 
   val indexName: String = UUID.randomUUID().toString
   override val draftConceptSearchService: DraftConceptSearchService = new DraftConceptSearchService {

--- a/concept-api/src/test/scala/no/ndla/conceptapi/service/search/PublishedConceptSearchServiceTest.scala
+++ b/concept-api/src/test/scala/no/ndla/conceptapi/service/search/PublishedConceptSearchServiceTest.scala
@@ -16,7 +16,6 @@ import no.ndla.conceptapi.model.search
 import no.ndla.conceptapi.*
 import no.ndla.language.Language
 import no.ndla.scalatestsuite.IntegrationSuite
-import org.scalatest.Outcome
 
 import java.time.LocalDateTime
 import scala.util.Success
@@ -39,12 +38,6 @@ class PublishedConceptSearchServiceTest
     with TestEnvironment {
   import props.{DefaultLanguage, DefaultPageSize}
   e4sClient = Elastic4sClientFactory.getClient(elasticSearchHost.getOrElse("http://localhost:9200"))
-
-  // Skip tests if no docker environment available
-  override def withFixture(test: NoArgTest): Outcome = {
-    assume(elasticSearchContainer.isSuccess)
-    super.withFixture(test)
-  }
 
   override val publishedConceptSearchService = new PublishedConceptSearchService
   override val publishedConceptIndexService: PublishedConceptIndexService = new PublishedConceptIndexService {

--- a/draft-api/src/test/scala/no/ndla/draftapi/repository/DraftRepositoryTest.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/repository/DraftRepositoryTest.scala
@@ -16,32 +16,17 @@ import no.ndla.draftapi.model.domain.*
 import no.ndla.network.tapir.auth.{Permission, TokenUser}
 import no.ndla.scalatestsuite.IntegrationSuite
 import org.mockito.Mockito.when
-import org.scalatest.Outcome
 import scalikejdbc.*
 
 import java.net.Socket
 import java.util.UUID
-import scala.util.{Failure, Success, Try}
+import scala.util.{Success, Try}
 
 class DraftRepositoryTest extends IntegrationSuite(EnablePostgresContainer = true) with TestEnvironment {
   override val dataSource: HikariDataSource = testDataSource.get
   override val migrator: DBMigrator         = new DBMigrator
   var repository: ArticleRepository         = _
-
-  // Skip tests if no docker environment available
-  override def withFixture(test: NoArgTest): Outcome = {
-    postgresContainer match {
-      case Failure(ex) =>
-        println(s"Postgres container not running, cancelling '${this.getClass.getName}'")
-        println(s"Got exception: ${ex.getMessage}")
-        ex.printStackTrace()
-      case _ =>
-    }
-    assume(postgresContainer.isSuccess)
-    super.withFixture(test)
-  }
-
-  val sampleArticle: Draft = TestData.sampleArticleWithByNcSa
+  val sampleArticle: Draft                  = TestData.sampleArticleWithByNcSa
 
   def emptyTestDatabase(): Unit = DB autoCommit (implicit session => {
     sql"delete from articledata;".execute()(session)
@@ -73,11 +58,9 @@ class DraftRepositoryTest extends IntegrationSuite(EnablePostgresContainer = tru
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    Try {
-      DataSource.connectToDatabase()
-      if (serverIsListening) {
-        migrator.migrate()
-      }
+    DataSource.connectToDatabase()
+    if (serverIsListening) {
+      migrator.migrate()
     }
   }
 

--- a/draft-api/src/test/scala/no/ndla/draftapi/repository/UserDataRepositoryTest.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/repository/UserDataRepositoryTest.scala
@@ -14,7 +14,6 @@ import java.net.Socket
 import no.ndla.draftapi.{TestData, TestEnvironment}
 import no.ndla.scalatestsuite.IntegrationSuite
 import org.postgresql.util.PSQLException
-import org.scalatest.Outcome
 import scalikejdbc.*
 
 import scala.util.{Failure, Success, Try}
@@ -23,19 +22,6 @@ class UserDataRepositoryTest extends IntegrationSuite(EnablePostgresContainer = 
   override val dataSource: HikariDataSource = testDataSource.get
   override val migrator: DBMigrator         = new DBMigrator
   var repository: UserDataRepository        = _
-
-  // Skip tests if no docker environment available
-  override def withFixture(test: NoArgTest): Outcome = {
-    postgresContainer match {
-      case Failure(ex) =>
-        println(s"Postgres container not running, cancelling '${this.getClass.getName}'")
-        println(s"Got exception: ${ex.getMessage}")
-        ex.printStackTrace()
-      case _ =>
-    }
-    assume(postgresContainer.isSuccess)
-    super.withFixture(test)
-  }
 
   def emptyTestDatabase: Boolean = {
     DB autoCommit (implicit session => {
@@ -70,11 +56,9 @@ class UserDataRepositoryTest extends IntegrationSuite(EnablePostgresContainer = 
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    Try {
-      DataSource.connectToDatabase()
-      if (serverIsListening) {
-        migrator.migrate()
-      }
+    DataSource.connectToDatabase()
+    if (serverIsListening) {
+      migrator.migrate()
     }
   }
 

--- a/draft-api/src/test/scala/no/ndla/draftapi/service/search/ArticleSearchServiceTest.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/service/search/ArticleSearchServiceTest.scala
@@ -15,7 +15,6 @@ import no.ndla.draftapi._
 import no.ndla.draftapi.model.domain._
 import no.ndla.language.Language
 import no.ndla.scalatestsuite.IntegrationSuite
-import org.scalatest.Outcome
 
 import scala.util.Success
 
@@ -23,12 +22,6 @@ class ArticleSearchServiceTest extends IntegrationSuite(EnableElasticsearchConta
   import props.{DefaultLanguage, DefaultPageSize, MaxPageSize}
 
   e4sClient = Elastic4sClientFactory.getClient(elasticSearchHost.getOrElse("http://localhost:9200"))
-
-  // Skip tests if no docker environment available
-  override def withFixture(test: NoArgTest): Outcome = {
-    assume(elasticSearchContainer.isSuccess)
-    super.withFixture(test)
-  }
 
   override val articleSearchService = new ArticleSearchService
   override val articleIndexService: ArticleIndexService = new ArticleIndexService {

--- a/draft-api/src/test/scala/no/ndla/draftapi/service/search/GrepCodesIndexServiceTest.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/service/search/GrepCodesIndexServiceTest.scala
@@ -9,17 +9,10 @@ package no.ndla.draftapi.service.search
 
 import no.ndla.draftapi._
 import no.ndla.scalatestsuite.IntegrationSuite
-import org.scalatest.Outcome
 
 class GrepCodesIndexServiceTest extends IntegrationSuite(EnableElasticsearchContainer = true) with TestEnvironment {
 
   e4sClient = Elastic4sClientFactory.getClient(elasticSearchHost.getOrElse("http://localhost:9200"))
-
-  // Skip tests if no docker environment available
-  override def withFixture(test: NoArgTest): Outcome = {
-    assume(elasticSearchContainer.isSuccess)
-    super.withFixture(test)
-  }
 
   override val grepCodesIndexService: GrepCodesIndexService = new GrepCodesIndexService {
     override val indexShards = 1

--- a/draft-api/src/test/scala/no/ndla/draftapi/service/search/GrepCodesSearchServiceTest.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/service/search/GrepCodesSearchServiceTest.scala
@@ -9,7 +9,6 @@ package no.ndla.draftapi.service.search
 
 import no.ndla.draftapi._
 import no.ndla.scalatestsuite.IntegrationSuite
-import org.scalatest.Outcome
 
 import scala.util.Success
 import no.ndla.common.model.domain.draft.Draft
@@ -17,13 +16,6 @@ import no.ndla.common.model.domain.draft.Draft
 class GrepCodesSearchServiceTest extends IntegrationSuite(EnableElasticsearchContainer = true) with TestEnvironment {
 
   e4sClient = Elastic4sClientFactory.getClient(elasticSearchHost.getOrElse("http://localhost:9200"))
-
-  // Skip tests if no docker environment available
-  override def withFixture(test: NoArgTest): Outcome = {
-    elasticSearchContainer.get
-    assume(elasticSearchContainer.isSuccess)
-    super.withFixture(test)
-  }
 
   override val grepCodesSearchService = new GrepCodesSearchService
   override val grepCodesIndexService: GrepCodesIndexService = new GrepCodesIndexService {

--- a/draft-api/src/test/scala/no/ndla/draftapi/service/search/TagIndexServiceTest.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/service/search/TagIndexServiceTest.scala
@@ -9,17 +9,10 @@ package no.ndla.draftapi.service.search
 
 import no.ndla.draftapi._
 import no.ndla.scalatestsuite.IntegrationSuite
-import org.scalatest.Outcome
 
 class TagIndexServiceTest extends IntegrationSuite(EnableElasticsearchContainer = true) with TestEnvironment {
 
   e4sClient = Elastic4sClientFactory.getClient(elasticSearchHost.getOrElse("http://localhost:9200"))
-
-  // Skip tests if no docker environment available
-  override def withFixture(test: NoArgTest): Outcome = {
-    assume(elasticSearchContainer.isSuccess)
-    super.withFixture(test)
-  }
 
   override val tagIndexService: TagIndexService = new TagIndexService {
     override val indexShards = 1

--- a/draft-api/src/test/scala/no/ndla/draftapi/service/search/TagSearchServiceTest.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/service/search/TagSearchServiceTest.scala
@@ -10,7 +10,6 @@ package no.ndla.draftapi.service.search
 import no.ndla.common.model.domain._
 import no.ndla.draftapi._
 import no.ndla.scalatestsuite.IntegrationSuite
-import org.scalatest.Outcome
 
 import scala.util.Success
 import no.ndla.common.model.domain.draft.Draft
@@ -18,12 +17,6 @@ import no.ndla.common.model.domain.draft.Draft
 class TagSearchServiceTest extends IntegrationSuite(EnableElasticsearchContainer = true) with TestEnvironment {
 
   e4sClient = Elastic4sClientFactory.getClient(elasticSearchHost.getOrElse("http://localhost:9200"))
-
-  // Skip tests if no docker environment available
-  override def withFixture(test: NoArgTest): Outcome = {
-    assume(elasticSearchContainer.isSuccess)
-    super.withFixture(test)
-  }
 
   override val tagSearchService = new TagSearchService
   override val tagIndexService: TagIndexService = new TagIndexService {

--- a/image-api/src/test/scala/no/ndla/imageapi/repository/ImageRepositoryTest.scala
+++ b/image-api/src/test/scala/no/ndla/imageapi/repository/ImageRepositoryTest.scala
@@ -35,11 +35,6 @@ class ImageRepositoryTest extends IntegrationSuite(EnablePostgresContainer = tru
     }
   }
 
-  def databaseIsAvailable: Boolean = {
-    val res = Try(repository.imageCount)
-    res.isSuccess
-  }
-
   def emptyTestDatabase: Boolean =
     DB autoCommit (implicit session => {
       sql"delete from imagemetadata;".execute()(session)
@@ -47,21 +42,18 @@ class ImageRepositoryTest extends IntegrationSuite(EnablePostgresContainer = tru
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    Try {
-      DataSource.connectToDatabase()
-      if (serverIsListening) {
-        migrator.migrate()
-      }
+    DataSource.connectToDatabase()
+    if (serverIsListening) {
+      migrator.migrate()
     }
   }
 
   override def beforeEach(): Unit = {
     repository = new ImageRepository
-    if (databaseIsAvailable) { emptyTestDatabase }
+    emptyTestDatabase
   }
 
   test("That inserting and retrieving images works as expected") {
-    assume(databaseIsAvailable)
     postgresContainer.map(x => println(x.getJdbcUrl))
     val image1 = TestData.bjorn.copy(id = None, images = None, titles = Seq(ImageTitle("KyllingFisk", "nb")))
 
@@ -82,7 +74,6 @@ class ImageRepositoryTest extends IntegrationSuite(EnablePostgresContainer = tru
   }
 
   test("That fetching images based on path works") {
-    assume(databaseIsAvailable)
     val path1 = "/some-path1.jpg"
     val path2 = "/some-path123.png"
     val path3 = "/some-path555.png"
@@ -105,7 +96,6 @@ class ImageRepositoryTest extends IntegrationSuite(EnablePostgresContainer = tru
   }
 
   test("that fetching based on path works with and without slash") {
-    assume(databaseIsAvailable)
     val path1         = "/slash-path1.jpg"
     val imageFile1    = TestData.bjorn.images.get.head.copy(fileName = path1)
     val image1        = TestData.bjorn.copy(id = None, images = Some(Seq(imageFile1)))
@@ -128,7 +118,6 @@ class ImageRepositoryTest extends IntegrationSuite(EnablePostgresContainer = tru
   }
 
   test("That fetching image from url where there exists multiple works") {
-    assume(databaseIsAvailable)
     val path1        = "/fetch-path1.jpg"
     val imageFile1   = TestData.bjorn.images.get.head.copy(fileName = path1)
     val image1       = TestData.bjorn.copy(id = None, images = Some(Seq(imageFile1)))
@@ -141,7 +130,6 @@ class ImageRepositoryTest extends IntegrationSuite(EnablePostgresContainer = tru
   }
 
   test("That fetching image from url with special characters are escaped") {
-    assume(databaseIsAvailable)
     val path1        = "/path1.jpg"
     val imageFile1   = TestData.bjorn.images.get.head.copy(fileName = path1)
     val image1       = TestData.bjorn.copy(id = None, images = Some(Seq(imageFile1)))

--- a/image-api/src/test/scala/no/ndla/imageapi/service/search/ImageSearchServiceTest.scala
+++ b/image-api/src/test/scala/no/ndla/imageapi/service/search/ImageSearchServiceTest.scala
@@ -21,7 +21,7 @@ import no.ndla.network.tapir.auth.TokenUser
 import no.ndla.scalatestsuite.IntegrationSuite
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
-import org.scalatest.{Outcome, PrivateMethodTester}
+import org.scalatest.PrivateMethodTester
 
 import scala.util.Success
 
@@ -32,12 +32,6 @@ class ImageSearchServiceTest
     with PrivateMethodTester {
   import TestData.searchSettings
   import props.{DefaultPageSize, MaxPageSize}
-
-  // Skip tests if no docker environment available
-  override def withFixture(test: NoArgTest): Outcome = {
-    assume(elasticSearchContainer.isSuccess)
-    super.withFixture(test)
-  }
 
   e4sClient = Elastic4sClientFactory.getClient(elasticSearchHost.getOrElse("http://localhost:9200"))
 

--- a/image-api/src/test/scala/no/ndla/imageapi/service/search/TagSearchServiceTest.scala
+++ b/image-api/src/test/scala/no/ndla/imageapi/service/search/TagSearchServiceTest.scala
@@ -11,7 +11,6 @@ import no.ndla.common.model.{domain => common}
 import no.ndla.imageapi.model.domain.Sort
 import no.ndla.imageapi.{TestEnvironment, UnitSuite}
 import no.ndla.scalatestsuite.IntegrationSuite
-import org.scalatest.Outcome
 
 import scala.util.Success
 import no.ndla.imageapi.model.domain.ImageMetaInformation
@@ -22,12 +21,6 @@ class TagSearchServiceTest
     with TestEnvironment {
 
   e4sClient = Elastic4sClientFactory.getClient(elasticSearchHost.getOrElse("http://localhost:9200"))
-
-  // Skip tests if no docker environment available
-  override def withFixture(test: NoArgTest): Outcome = {
-    assume(elasticSearchContainer.isSuccess)
-    super.withFixture(test)
-  }
 
   val indexName = "tags-testing"
   override val tagSearchService: TagSearchService = new TagSearchService {

--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/repository/LearningPathRepositoryComponentIntegrationTest.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/repository/LearningPathRepositoryComponentIntegrationTest.scala
@@ -16,10 +16,9 @@ import no.ndla.learningpathapi.*
 import no.ndla.learningpathapi.model.domain.*
 import no.ndla.scalatestsuite.IntegrationSuite
 import org.mockito.Mockito.when
-import org.scalatest.Outcome
 import scalikejdbc.*
 
-import scala.util.{Failure, Try}
+import scala.util.Try
 
 class LearningPathRepositoryComponentIntegrationTest
     extends IntegrationSuite(EnablePostgresContainer = true, schemaName = "learningpathapi_test")
@@ -30,21 +29,6 @@ class LearningPathRepositoryComponentIntegrationTest
   override val migrator                     = new DBMigrator
 
   var repository: LearningPathRepository = _
-
-  // Skip tests if no docker environment available
-  override def withFixture(test: NoArgTest): Outcome = {
-    postgresContainer match {
-      case Failure(ex) =>
-        println(s"Postgres container not running, cancelling '${this.getClass.getName}'")
-        println(s"Got exception: ${ex.getMessage}")
-        ex.printStackTrace()
-      case _ =>
-    }
-    if (!sys.env.getOrElse("CI", "false").toBoolean) {
-      assume(postgresContainer.isSuccess, "Docker environment unavailable for postgres container")
-    }
-    super.withFixture(test)
-  }
 
   val clinton: Author                  = Author("author", "Hilla the Hun")
   val license                          = "publicdomain"

--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/search/SearchServiceTest.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/search/SearchServiceTest.scala
@@ -19,7 +19,6 @@ import no.ndla.learningpathapi.{TestEnvironment, UnitSuite}
 import no.ndla.scalatestsuite.IntegrationSuite
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.doReturn
-import org.scalatest.Outcome
 
 import scala.util.Success
 
@@ -29,12 +28,6 @@ class SearchServiceTest
     with TestEnvironment {
   import props.{DefaultPageSize, MaxPageSize}
   e4sClient = Elastic4sClientFactory.getClient(elasticSearchHost.get)
-  // Skip tests if no docker environment available
-  override def withFixture(test: NoArgTest): Outcome = {
-    assume(elasticSearchContainer.isSuccess)
-    super.withFixture(test)
-  }
-
   override val searchConverterService: SearchConverterService = new SearchConverterService
   override val searchIndexService: SearchIndexService = new SearchIndexService {
     override val indexShards: Int = 1 // 1 shard for accurate scoring in tests

--- a/myndla-api/src/test/scala/no/ndla/myndlaapi/repository/FolderRepositoryTest.scala
+++ b/myndla-api/src/test/scala/no/ndla/myndlaapi/repository/FolderRepositoryTest.scala
@@ -15,12 +15,11 @@ import no.ndla.myndlaapi.model.domain.{Folder, FolderResource, FolderStatus, New
 import no.ndla.myndlaapi.{TestData, TestEnvironment, UnitSuite}
 import no.ndla.scalatestsuite.IntegrationSuite
 import org.mockito.Mockito.when
-import org.scalatest.Outcome
 import scalikejdbc.*
 
 import java.net.Socket
 import java.util.UUID
-import scala.util.{Failure, Success, Try}
+import scala.util.{Success, Try}
 
 class FolderRepositoryTest
     extends IntegrationSuite(EnablePostgresContainer = true)
@@ -29,19 +28,6 @@ class FolderRepositoryTest
   override val dataSource: HikariDataSource = testDataSource.get
   override val migrator: DBMigrator         = new DBMigrator
   var repository: FolderRepository          = _
-
-  // Skip tests if no docker environment available
-  override def withFixture(test: NoArgTest): Outcome = {
-    postgresContainer match {
-      case Failure(ex) =>
-        println(s"Postgres container not running, cancelling '${this.getClass.getName}'")
-        println(s"Got exception: ${ex.getMessage}")
-        ex.printStackTrace()
-      case _ =>
-    }
-    assume(postgresContainer.isSuccess)
-    super.withFixture(test)
-  }
 
   def emptyTestDatabase: Boolean = {
     DB autoCommit (implicit session => {
@@ -72,11 +58,9 @@ class FolderRepositoryTest
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    Try {
-      DataSource.connectToDatabase()
-      if (serverIsListening) {
-        migrator.migrate()
-      }
+    DataSource.connectToDatabase()
+    if (serverIsListening) {
+      migrator.migrate()
     }
   }
 

--- a/search-api/src/test/scala/no/ndla/searchapi/service/search/ArticleIndexServiceTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/service/search/ArticleIndexServiceTest.scala
@@ -21,7 +21,7 @@ import no.ndla.searchapi.model.domain.{IndexingBundle, LearningResourceType}
 import no.ndla.searchapi.model.search.{SearchableArticle, SearchableGrepContext}
 import no.ndla.searchapi.{TestData, TestEnvironment, UnitSuite}
 
-import scala.util.{Failure, Success}
+import scala.util.Success
 
 class ArticleIndexServiceTest
     extends IntegrationSuite(EnableElasticsearchContainer = true)
@@ -29,20 +29,6 @@ class ArticleIndexServiceTest
     with TestEnvironment {
 
   e4sClient = Elastic4sClientFactory.getClient(elasticSearchHost.getOrElse(""))
-  // Skip tests if no docker environment available
-  override def withFixture(test: NoArgTest) = {
-    elasticSearchContainer match {
-      case Failure(ex) =>
-        println(s"Elasticsearch container not running, cancelling '${this.getClass.getName}'")
-        println(s"Got exception: ${ex.getMessage}")
-        ex.printStackTrace()
-      case _ =>
-    }
-
-    assume(elasticSearchContainer.isSuccess)
-    super.withFixture(test)
-  }
-
   override val articleIndexService: ArticleIndexService = new ArticleIndexService {
     override val indexShards = 1
   }

--- a/search-api/src/test/scala/no/ndla/searchapi/service/search/DraftConceptIndexServiceTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/service/search/DraftConceptIndexServiceTest.scala
@@ -19,28 +19,12 @@ import no.ndla.searchapi.model.domain.LearningResourceType
 import no.ndla.searchapi.model.search.SearchableConcept
 import no.ndla.searchapi.{TestData, TestEnvironment, UnitSuite}
 
-import scala.util.Failure
-
 class DraftConceptIndexServiceTest
     extends IntegrationSuite(EnableElasticsearchContainer = true)
     with UnitSuite
     with TestEnvironment {
 
   e4sClient = Elastic4sClientFactory.getClient(elasticSearchHost.getOrElse(""))
-  // Skip tests if no docker environment available
-  override def withFixture(test: NoArgTest) = {
-    elasticSearchContainer match {
-      case Failure(ex) =>
-        println(s"Elasticsearch container not running, cancelling '${this.getClass.getName}'")
-        println(s"Got exception: ${ex.getMessage}")
-        ex.printStackTrace()
-      case _ =>
-    }
-
-    assume(elasticSearchContainer.isSuccess)
-    super.withFixture(test)
-  }
-
   override val draftConceptIndexService: DraftConceptIndexService = new DraftConceptIndexService {
     override val indexShards = 1
   }

--- a/search-api/src/test/scala/no/ndla/searchapi/service/search/DraftIndexServiceTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/service/search/DraftIndexServiceTest.scala
@@ -17,10 +17,9 @@ import no.ndla.searchapi.model.domain.IndexingBundle
 import no.ndla.searchapi.{TestData, TestEnvironment, UnitSuite}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
-import org.scalatest.Outcome
 
 import java.util.UUID
-import scala.util.{Failure, Success}
+import scala.util.Success
 
 class DraftIndexServiceTest
     extends IntegrationSuite(EnableElasticsearchContainer = true)
@@ -28,19 +27,6 @@ class DraftIndexServiceTest
     with TestEnvironment {
 
   e4sClient = Elastic4sClientFactory.getClient(elasticSearchHost.getOrElse(""))
-  // Skip tests if no docker environment available
-  override def withFixture(test: NoArgTest): Outcome = {
-    elasticSearchContainer match {
-      case Failure(ex) =>
-        println(s"Elasticsearch container not running, cancelling '${this.getClass.getName}'")
-        println(s"Got exception: ${ex.getMessage}")
-        ex.printStackTrace()
-      case _ =>
-    }
-
-    assume(elasticSearchContainer.isSuccess)
-    super.withFixture(test)
-  }
 
   override val draftIndexService: DraftIndexService = new DraftIndexService {
     override val indexShards = 1

--- a/search-api/src/test/scala/no/ndla/searchapi/service/search/IndexServiceTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/service/search/IndexServiceTest.scala
@@ -10,25 +10,11 @@ package no.ndla.searchapi.service.search
 import com.sksamuel.elastic4s.ElasticDsl._
 import no.ndla.scalatestsuite.IntegrationSuite
 import no.ndla.searchapi.TestEnvironment
-import org.scalatest.Outcome
 
-import scala.util.{Failure, Success}
+import scala.util.Success
 
 class IndexServiceTest extends IntegrationSuite(EnableElasticsearchContainer = true) with TestEnvironment {
   e4sClient = Elastic4sClientFactory.getClient(elasticSearchHost.getOrElse(""))
-  // Skip tests if no docker environment available
-  override def withFixture(test: NoArgTest): Outcome = {
-    elasticSearchContainer match {
-      case Failure(ex) =>
-        println(s"Elasticsearch container not running, cancelling '${this.getClass.getName}'")
-        println(s"Got exception: ${ex.getMessage}")
-        ex.printStackTrace()
-      case _ =>
-    }
-
-    assume(elasticSearchContainer.isSuccess)
-    super.withFixture(test)
-  }
 
   val testIndexPrefix = "searchapi-index-service-test"
 

--- a/search-api/src/test/scala/no/ndla/searchapi/service/search/LearningPathIndexServiceTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/service/search/LearningPathIndexServiceTest.scala
@@ -17,9 +17,8 @@ import no.ndla.searchapi.model.domain.learningpath.{Description, LearningStep, S
 import no.ndla.searchapi.{TestData, TestEnvironment, UnitSuite}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
-import org.scalatest.Outcome
 
-import scala.util.{Failure, Success}
+import scala.util.Success
 
 class LearningPathIndexServiceTest
     extends IntegrationSuite(EnableElasticsearchContainer = true)
@@ -27,19 +26,6 @@ class LearningPathIndexServiceTest
     with TestEnvironment {
 
   e4sClient = Elastic4sClientFactory.getClient(elasticSearchHost.getOrElse(""))
-  // Skip tests if no docker environment available
-  override def withFixture(test: NoArgTest): Outcome = {
-    elasticSearchContainer match {
-      case Failure(ex) =>
-        println(s"Elasticsearch container not running, cancelling '${this.getClass.getName}'")
-        println(s"Got exception: ${ex.getMessage}")
-        ex.printStackTrace()
-      case _ =>
-    }
-
-    assume(elasticSearchContainer.isSuccess)
-    super.withFixture(test)
-  }
 
   override val learningPathIndexService: LearningPathIndexService = new LearningPathIndexService {
     override val indexShards = 1

--- a/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceAtomicTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceAtomicTest.scala
@@ -25,28 +25,14 @@ import no.ndla.searchapi.model.domain.{IndexingBundle, LearningResourceType, Sor
 import no.ndla.searchapi.model.search.SearchType
 import no.ndla.searchapi.model.taxonomy.*
 import no.ndla.searchapi.{TestData, TestEnvironment}
-import org.scalatest.Outcome
 
 import java.util.UUID
-import scala.util.{Failure, Success, Try}
+import scala.util.{Success, Try}
 
 class MultiDraftSearchServiceAtomicTest
     extends IntegrationSuite(EnableElasticsearchContainer = true)
     with TestEnvironment {
   e4sClient = Elastic4sClientFactory.getClient(elasticSearchHost.getOrElse(""))
-  // Skip tests if no docker environment available
-  override def withFixture(test: NoArgTest): Outcome = {
-    elasticSearchContainer match {
-      case Failure(ex) =>
-        println(s"Elasticsearch container not running, cancelling '${this.getClass.getName}'")
-        println(s"Got exception: ${ex.getMessage}")
-        ex.printStackTrace()
-      case _ =>
-    }
-
-    assume(elasticSearchContainer.isSuccess)
-    super.withFixture(test)
-  }
 
   override val articleIndexService: ArticleIndexService = new ArticleIndexService {
     override val indexShards = 1

--- a/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceTest.scala
@@ -14,31 +14,16 @@ import no.ndla.language.Language.AllLanguages
 import no.ndla.network.tapir.NonEmptyString
 import no.ndla.scalatestsuite.IntegrationSuite
 import no.ndla.searchapi.TestData.*
-import no.ndla.searchapi.{TestData, TestEnvironment}
 import no.ndla.searchapi.model.api.MetaImage
 import no.ndla.searchapi.model.domain.{IndexingBundle, LearningResourceType, Sort}
-import org.scalatest.Outcome
+import no.ndla.searchapi.{TestData, TestEnvironment}
 
-import scala.util.{Failure, Success}
+import scala.util.Success
 
 class MultiDraftSearchServiceTest extends IntegrationSuite(EnableElasticsearchContainer = true) with TestEnvironment {
   import props.{DefaultPageSize, MaxPageSize}
 
   e4sClient = Elastic4sClientFactory.getClient(elasticSearchHost.getOrElse(""))
-  // Skip tests if no docker environment available
-  override def withFixture(test: NoArgTest): Outcome = {
-    elasticSearchContainer match {
-      case Failure(ex) =>
-        println(s"Elasticsearch container not running, cancelling '${this.getClass.getName}'")
-        println(s"Got exception: ${ex.getMessage}")
-        ex.printStackTrace()
-      case _ =>
-    }
-
-    assume(elasticSearchContainer.isSuccess)
-    super.withFixture(test)
-  }
-
   override val articleIndexService: ArticleIndexService = new ArticleIndexService {
     override val indexShards = 1
   }

--- a/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceAtomicTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceAtomicTest.scala
@@ -16,26 +16,11 @@ import no.ndla.searchapi.TestData.{core, generateContexts, subjectMaterial}
 import no.ndla.searchapi.model.domain.IndexingBundle
 import no.ndla.searchapi.model.taxonomy.*
 import no.ndla.searchapi.{TestData, TestEnvironment}
-import org.scalatest.Outcome
 
-import scala.util.{Failure, Success}
+import scala.util.Success
 
 class MultiSearchServiceAtomicTest extends IntegrationSuite(EnableElasticsearchContainer = true) with TestEnvironment {
   e4sClient = Elastic4sClientFactory.getClient(elasticSearchHost.getOrElse(""))
-
-  // Skip tests if no docker environment available
-  override def withFixture(test: NoArgTest): Outcome = {
-    elasticSearchContainer match {
-      case Failure(ex) =>
-        println(s"Elasticsearch container not running, cancelling '${this.getClass.getName}'")
-        println(s"Got exception: ${ex.getMessage}")
-        ex.printStackTrace()
-      case _ =>
-    }
-
-    assume(elasticSearchContainer.isSuccess)
-    super.withFixture(test)
-  }
 
   override val articleIndexService: ArticleIndexService = new ArticleIndexService {
     override val indexShards = 1

--- a/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceTest.scala
@@ -8,8 +8,8 @@
 package no.ndla.searchapi.service.search
 
 import no.ndla.common.model.NDLADate
-import no.ndla.common.model.domain.{ArticleType, Availability}
 import no.ndla.common.model.domain.article.Article
+import no.ndla.common.model.domain.{ArticleType, Availability}
 import no.ndla.language.Language.AllLanguages
 import no.ndla.network.tapir.NonEmptyString
 import no.ndla.scalatestsuite.IntegrationSuite
@@ -18,9 +18,8 @@ import no.ndla.searchapi.model.api.MetaImage
 import no.ndla.searchapi.model.domain.learningpath.LearningPath
 import no.ndla.searchapi.model.domain.{IndexingBundle, LearningResourceType, Sort}
 import no.ndla.searchapi.{TestData, TestEnvironment, UnitSuite}
-import org.scalatest.Outcome
 
-import scala.util.{Failure, Success}
+import scala.util.Success
 
 class MultiSearchServiceTest
     extends IntegrationSuite(EnableElasticsearchContainer = true)
@@ -29,20 +28,6 @@ class MultiSearchServiceTest
   import props.DefaultPageSize
 
   e4sClient = Elastic4sClientFactory.getClient(elasticSearchHost.getOrElse(""))
-
-  // Skip tests if no docker environment available
-  override def withFixture(test: NoArgTest): Outcome = {
-    elasticSearchContainer match {
-      case Failure(ex) =>
-        println(s"Elasticsearch container not running, cancelling '${this.getClass.getName}'")
-        println(s"Got exception: ${ex.getMessage}")
-        ex.printStackTrace()
-      case _ =>
-    }
-
-    assume(elasticSearchContainer.isSuccess)
-    super.withFixture(test)
-  }
 
   override val articleIndexService: ArticleIndexService = new ArticleIndexService {
     override val indexShards = 1


### PR DESCRIPTION
Dette gjør at vi ikke lenger støtter å kjøre grønt uten docker, men jeg tenker det driver vi ikke med uansett så la gå.
Fikser også så feilene Lars støtte på tidligere vil dukke opp tydeligere når migreringene feiler i tester.