### PR TITLE
Add alternative display of favourited resources. Expand test.

### DIFF
--- a/myndla-api/src/main/scala/no/ndla/myndlaapi/model/api/Stats.scala
+++ b/myndla-api/src/main/scala/no/ndla/myndlaapi/model/api/Stats.scala
@@ -20,7 +20,8 @@ case class Stats(
     @description("The total number of created tags") numberOfTags: Long,
     @description("The total number of favourited subjects") numberOfSubjects: Long,
     @description("The total number of shared folders") numberOfSharedFolders: Long,
-    @description("Stats for type resources") favouritedResources: List[ResourceStats]
+    @description("Stats for type resources") favouritedResources: List[ResourceStats],
+    @description("Stats for favourited resources") favourited: Map[String, Long]
 )
 
 object Stats {

--- a/myndla-api/src/main/scala/no/ndla/myndlaapi/service/FolderReadService.scala
+++ b/myndla-api/src/main/scala/no/ndla/myndlaapi/service/FolderReadService.scala
@@ -286,6 +286,7 @@ trait FolderReadService {
       implicit val session: DBSession = folderRepository.getSession(true)
       val groupedResources            = folderRepository.numberOfResourcesGrouped()
       val favouritedResources         = groupedResources.map(gr => api.ResourceStats(gr._2, gr._1))
+      val favourited                  = groupedResources.map(gr => gr._2 -> gr._1).toMap
       for {
         numberOfUsers         <- userRepository.numberOfUsers()
         numberOfFolders       <- folderRepository.numberOfFolders()
@@ -300,7 +301,8 @@ trait FolderReadService {
           numberOfTags,
           numberOfSubjects,
           numberOfSharedFolders,
-          favouritedResources
+          favouritedResources,
+          favourited
         )
       } yield stats
     }

--- a/myndla-api/src/test/scala/no/ndla/myndlaapi/controller/StatsControllerTest.scala
+++ b/myndla-api/src/test/scala/no/ndla/myndlaapi/controller/StatsControllerTest.scala
@@ -22,7 +22,7 @@ class StatsControllerTest extends UnitTestSuite with TestEnvironment with TapirC
   val controller: StatsController = new StatsController()
 
   test("That getting stats returns in fact stats") {
-    when(folderReadService.getStats).thenReturn(Some(Stats(1, 2, 3, 4, 5, 6, List.empty)))
+    when(folderReadService.getStats).thenReturn(Some(Stats(1, 2, 3, 4, 5, 6, List.empty, Map.empty)))
 
     val response = simpleHttpClient.send(quickRequest.get(uri"http://localhost:$serverPort/myndla-api/v1/stats"))
     response.code.code should be(200)

--- a/myndla-api/src/test/scala/no/ndla/myndlaapi/service/FolderReadServiceTest.scala
+++ b/myndla-api/src/test/scala/no/ndla/myndlaapi/service/FolderReadServiceTest.scala
@@ -14,7 +14,7 @@ import no.ndla.myndlaapi.TestData.{emptyApiFolder, emptyDomainFolder, emptyDomai
 import no.ndla.myndlaapi.model.api
 import no.ndla.myndlaapi.{TestData, TestEnvironment}
 import no.ndla.myndlaapi.model.domain
-import no.ndla.myndlaapi.model.api.{Folder, Owner}
+import no.ndla.myndlaapi.model.api.{Folder, Owner, ResourceStats}
 import no.ndla.myndlaapi.model.domain.{FolderStatus, MyNDLAGroup, MyNDLAUser, Resource, UserRole}
 import no.ndla.scalatestsuite.UnitTestSuite
 import org.mockito.ArgumentMatchers.{any, eq as eqTo}
@@ -412,9 +412,21 @@ class FolderReadServiceTest extends UnitTestSuite with TestEnvironment {
     when(folderRepository.numberOfTags()(any)).thenReturn(Some(10))
     when(userRepository.numberOfFavouritedSubjects()(any)).thenReturn(Some(15))
     when(folderRepository.numberOfSharedFolders()(any)).thenReturn(Some(5))
-    when(folderRepository.numberOfResourcesGrouped()(any)).thenReturn(List.empty)
+    when(folderRepository.numberOfResourcesGrouped()(any))
+      .thenReturn(List((1, "article"), (2, "learningpath"), (3, "video")))
 
-    service.getStats.get should be(api.Stats(5, 10, 20, 10, 15, 5, List.empty))
+    service.getStats.get should be(
+      api.Stats(
+        5,
+        10,
+        20,
+        10,
+        15,
+        5,
+        List(ResourceStats("article", 1), ResourceStats("learningpath", 2), ResourceStats("video", 3)),
+        Map("article" -> 1, "learningpath" -> 2, "video" -> 3)
+      )
+    )
   }
 
   test("That getSharedFolder returns an unshared folder if requested by the owner") {


### PR DESCRIPTION
Guttorm ville ha et format på stats som var lettere å lese inn i airbyte. Legger på en map på formatet
```
"favourites": {
    "learningpath": 452,
    "image": 37,
    "audio": 2,
    "multidisciplinary": 26,
    "article": 8223,
    "folder": 1,
    "video": 13,
    "concept": 10
  }
```