### PR TITLE
Add support for , [ ] ( ) * in urls.

### DIFF
--- a/validation/src/main/scala/no/ndla/validation/TagValidator.scala
+++ b/validation/src/main/scala/no/ndla/validation/TagValidator.scala
@@ -567,7 +567,7 @@ object TagValidator {
       field: TagRules.Field
   ): Option[ValidationMessage] = {
     val domainRegex =
-      "https?:\\/\\/(www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-zA-Z0-9()]{1,6}\\b([-a-zA-Z0-9()$;@:%_\\+.~#?&//=!]*)"
+      "https?:\\/\\/(www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-zA-Z0-9()]{1,6}\\b([-a-zA-Z0-9()$;@:%_\\+.,\\[\\]\\(\\)\\*~#?&//=!]*)"
 
     if (!field.validation.required && value.isEmpty) {
       return None

--- a/validation/src/test/scala/no/ndla/validation/EmbedTagRulesTest.scala
+++ b/validation/src/test/scala/no/ndla/validation/EmbedTagRulesTest.scala
@@ -166,6 +166,22 @@ class EmbedTagRulesTest extends UnitSuite {
         Seq.empty
       )
     }
+    {
+      val url =
+        "https://kartiskolen.no/mobile.html?topic=geologi&lang=nb&bgLayer=vanlig_grunnkart&mobile=true&layers=bergarter_oversikt,bergarter_detaljer&layers_opacity=0.6,0.6&X=6758065.33&Y=8776.16&zoom=10"
+      val embedString =
+        s"""<$EmbedTagName
+           | data-resource="iframe"
+           | data-url="$url"
+           | data-type="iframe"
+           | data-title="Kart i skolen"
+           |/>""".stripMargin
+
+      val result = TagValidator.validate("test", embedString)
+      result should be(
+        Seq.empty
+      )
+    }
   }
 
   test("Fields with dataType EMAIL should have legal email") {


### PR DESCRIPTION
Nok en karturl som ikkje blei godkjent. 

Basert på https://documentation.mapp.com/1.0/en/url-encoding-and-what-characters-are-valid-in-a-uri-36147771.html har eg lagt til `[]()` og * i tillegg til ,.