### PR TITLE
myndla-api: Add hacky trait wrapper to avoid scala-tsi recursion bug

### DIFF
--- a/myndla-api/src/main/scala/no/ndla/myndlaapi/model/arena/api/Post.scala
+++ b/myndla-api/src/main/scala/no/ndla/myndlaapi/model/arena/api/Post.scala
@@ -7,9 +7,14 @@
 
 package no.ndla.myndlaapi.model.arena.api
 
+import com.scalatsi.{TSIType, TSNamedType, TSType}
 import no.ndla.common.model.NDLADate
 import no.ndla.myndlaapi.model.api.ArenaUser
 import sttp.tapir.Schema.annotations.description
+
+import scala.annotation.unused
+
+sealed trait PostWrapper
 
 @description("Arena post data")
 case class Post(
@@ -20,7 +25,19 @@ case class Post(
     @description("The post owner") owner: Option[ArenaUser],
     @description("The flags that have been added to post. Only visible to admins.") flags: Option[List[Flag]],
     @description("The id of the parenting topic") topicId: Long,
-    @description("The replies to the post") replies: List[Post],
+    @description("The replies to the post") replies: List[PostWrapper],
     @description("Number of upvotes on the post") upvotes: Int,
     @description("Flag saying if the logged in user has upvoted or not") upvoted: Boolean
-)
+) extends PostWrapper
+
+object Post {
+  implicit val postTSI: TSIType[Post] = {
+    @unused
+    implicit val postWrapper: TSNamedType[PostWrapper] = TSType.external[PostWrapper]("IPostWrapper")
+    TSType.fromCaseClass[Post]
+  }
+}
+
+object PostWrapper {
+  implicit val wrapperAlias: TSNamedType[PostWrapper] = TSType.alias[PostWrapper]("IPostWrapper", Post.postTSI.get)
+}

--- a/myndla-api/src/test/scala/no/ndla/myndlaapi/e2e/ArenaTest.scala
+++ b/myndla-api/src/test/scala/no/ndla/myndlaapi/e2e/ArenaTest.scala
@@ -691,7 +691,7 @@ class ArenaTest
     topicTry.posts.items.length should be(2)
     topicTry.posts.items.head.replies.length should be(0)
     topicTry.posts.items.last.replies.length should be(1)
-    topicTry.posts.items.last.replies.last.replies.last should be(post3Try.get)
+    topicTry.posts.items.last.replies.asInstanceOf[List[api.Post]].last.replies.last should be(post3Try.get)
 
   }
 
@@ -757,7 +757,7 @@ class ArenaTest
     val categoryIdT       = io.circe.parser.parse(createCategoryRes.body).flatMap(_.as[api.Category]).toTry
     val categoryId        = categoryIdT.get.id
 
-    val topic = createTopic("Topic title", "Topic description", categoryId, token = userToken)
+    val topic   = createTopic("Topic title", "Topic description", categoryId, token = userToken)
     val topicT  = io.circe.parser.parse(topic.body).flatMap(_.as[api.Topic]).toTry
     val topicId = topicT.get.id
 
@@ -765,8 +765,8 @@ class ArenaTest
     val ownPostT  = io.circe.parser.parse(ownPost.body).flatMap(_.as[api.Post]).toTry
     val ownPostId = ownPostT.get.id
 
-    val otherPost = createPost("Innhold i posten", topicId, toPostId = Some(ownPostId))
-    val otherPostT = CirceUtil.tryParseAs[api.Post](otherPost.body).get
+    val otherPost   = createPost("Innhold i posten", topicId, toPostId = Some(ownPostId))
+    val otherPostT  = CirceUtil.tryParseAs[api.Post](otherPost.body).get
     val otherPostId = otherPostT.id
 
     val upvoteOwnPost = simpleHttpClient.send(
@@ -781,7 +781,6 @@ class ArenaTest
     upvoteOwnPost.code.code should be(200)
     upvoteOwnPostT.upvotes should be(0)
     upvoteOwnPostT.upvoted should be(false)
-
 
     val firstUpvote = simpleHttpClient.send(
       quickRequest

--- a/project/myndlaapi.scala
+++ b/project/myndlaapi.scala
@@ -57,6 +57,7 @@ object myndlaapi extends Module {
       "PaginatedPosts",
       "PaginatedNewPostNotifications",
       "Post",
+      "PostWrapper",
       "Stats",
       "SingleResourceStats",
       "UserFolder"

--- a/typescript/types-backend/myndla-api.ts
+++ b/typescript/types-backend/myndla-api.ts
@@ -3,11 +3,11 @@
 export type ArenaGroup = "ADMIN"
 
 export interface IArenaUser {
-  id: "circular reference error"
-  displayName: "circular reference error"
-  username: "circular reference error"
-  location: "circular reference error"
-  groups: "circular reference error"
+  id: number
+  displayName: string
+  username: string
+  location: string
+  groups: ArenaGroup[]
 }
 
 export interface IBreadcrumb {
@@ -200,10 +200,12 @@ export interface IPost {
   owner?: IArenaUser
   flags?: IFlag[]
   topicId: number
-  replies: IPost[]
+  replies: IPostWrapper[]
   upvotes: number
   upvoted: boolean
 }
+
+export type IPostWrapper = IPost
 
 export interface IResource {
   id: string


### PR DESCRIPTION
Dette fikser feilen vi hadde med `circular reference error" typene med litt omdirigering.

Litt hacky, men det fungerer :smile: 