### PR TITLE
Added decoder and encoder to Arena models

### DIFF
--- a/myndla-api/src/main/scala/no/ndla/myndlaapi/model/api/ArenaUser.scala
+++ b/myndla-api/src/main/scala/no/ndla/myndlaapi/model/api/ArenaUser.scala
@@ -8,6 +8,8 @@
 
 package no.ndla.myndlaapi.model.api
 
+import io.circe.{Decoder, Encoder}
+import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
 import no.ndla.myndlaapi.model.domain.{ArenaGroup, MyNDLAUser}
 import sttp.tapir.Schema.annotations.description
 
@@ -35,5 +37,8 @@ object ArenaUser {
       groups = user.arenaGroups
     )
   }
+
+  implicit val arenaUserEncoder: Encoder[ArenaUser] = deriveEncoder
+  implicit val arenaUserDecoder: Decoder[ArenaUser] = deriveDecoder
 
 }

--- a/myndla-api/src/main/scala/no/ndla/myndlaapi/model/arena/api/Flag.scala
+++ b/myndla-api/src/main/scala/no/ndla/myndlaapi/model/arena/api/Flag.scala
@@ -7,6 +7,8 @@
 
 package no.ndla.myndlaapi.model.arena.api
 
+import io.circe.{Decoder, Encoder}
+import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
 import no.ndla.common.model.NDLADate
 import no.ndla.myndlaapi.model.api.ArenaUser
 import sttp.tapir.Schema.annotations.description
@@ -20,3 +22,8 @@ case class Flag(
     @description("Whether the flag has been resolved or not") isResolved: Boolean,
     @description("The flagging user") flagger: Option[ArenaUser]
 )
+
+object Flag {
+  implicit val flagEncoder: Encoder[Flag] = deriveEncoder
+  implicit val flagDecoder: Decoder[Flag] = deriveDecoder
+}

--- a/myndla-api/src/main/scala/no/ndla/myndlaapi/model/arena/api/Post.scala
+++ b/myndla-api/src/main/scala/no/ndla/myndlaapi/model/arena/api/Post.scala
@@ -49,20 +49,5 @@ object Post {
 }
 
 object PostWrapper {
-  def apply(
-      id: Long,
-      content: String,
-      created: NDLADate,
-      updated: NDLADate,
-      owner: Option[ArenaUser],
-      flags: Option[List[Flag]],
-      topicId: Long,
-      replies: List[PostWrapper],
-      upvotes: Int,
-      upvoted: Boolean
-  ): PostWrapper = {
-    Post(id, content, created, updated, owner, flags, topicId, replies, upvotes, upvoted)
-  }
-
   implicit val wrapperAlias: TSNamedType[PostWrapper] = TSType.alias[PostWrapper]("IPostWrapper", Post.postTSI.get)
 }

--- a/myndla-api/src/main/scala/no/ndla/myndlaapi/model/arena/api/Post.scala
+++ b/myndla-api/src/main/scala/no/ndla/myndlaapi/model/arena/api/Post.scala
@@ -7,7 +7,11 @@
 
 package no.ndla.myndlaapi.model.arena.api
 
+import cats.implicits.toFunctorOps
 import com.scalatsi.{TSIType, TSNamedType, TSType}
+import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
+import io.circe.syntax.EncoderOps
+import io.circe.{Decoder, Encoder}
 import no.ndla.common.model.NDLADate
 import no.ndla.myndlaapi.model.api.ArenaUser
 import sttp.tapir.Schema.annotations.description
@@ -36,8 +40,29 @@ object Post {
     implicit val postWrapper: TSNamedType[PostWrapper] = TSType.external[PostWrapper]("IPostWrapper")
     TSType.fromCaseClass[Post]
   }
+
+  implicit val postEncoder: Encoder[Post] = deriveEncoder
+  implicit val postDecoder: Decoder[Post] = deriveDecoder
+
+  implicit val postDataEncoder: Encoder[PostWrapper] = Encoder.instance { case post: Post => post.asJson }
+  implicit val postDataDecoder: Decoder[PostWrapper] = Decoder[Post].widen
 }
 
 object PostWrapper {
+  def apply(
+      id: Long,
+      content: String,
+      created: NDLADate,
+      updated: NDLADate,
+      owner: Option[ArenaUser],
+      flags: Option[List[Flag]],
+      topicId: Long,
+      replies: List[PostWrapper],
+      upvotes: Int,
+      upvoted: Boolean
+  ): PostWrapper = {
+    Post(id, content, created, updated, owner, flags, topicId, replies, upvotes, upvoted)
+  }
+
   implicit val wrapperAlias: TSNamedType[PostWrapper] = TSType.alias[PostWrapper]("IPostWrapper", Post.postTSI.get)
 }


### PR DESCRIPTION
Retur typen til en reply ble til  `{ Post: ArenaPost }`. La merke til at Folder hadde encoder og decoders så implemnterte det samme for Post. 