### PR TITLE
Reduce error noise in search-api + extend indexing errors

### DIFF
--- a/article-api/src/main/scala/no/ndla/articleapi/model/api/NDLAErrors.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/model/api/NDLAErrors.scala
@@ -46,7 +46,7 @@ trait ErrorHelpers extends TapirErrorHelpers with StrictLogging {
     case _: PSQLException =>
       DataSource.connectToDatabase()
       ErrorBody(DATABASE_UNAVAILABLE, DATABASE_UNAVAILABLE_DESCRIPTION, clock.now(), 500)
-    case NdlaSearchException(_, Some(rf), _)
+    case NdlaSearchException(_, Some(rf), _, _)
         if rf.error.rootCause
           .exists(x => x.`type` == "search_context_missing_exception" || x.reason == "Cannot parse scroll id") =>
       ErrorBody(INVALID_SEARCH_CONTEXT, INVALID_SEARCH_CONTEXT_DESCRIPTION, clock.now(), 400)

--- a/article-api/src/main/scala/no/ndla/articleapi/service/search/SearchService.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/service/search/SearchService.scala
@@ -123,11 +123,11 @@ trait SearchService {
 
     protected def errorHandler[U](failure: Throwable): Failure[U] = {
       failure match {
-        case NdlaSearchException(_, Some(RequestFailure(status, _, _, _)), _) if status == 404 =>
+        case NdlaSearchException(_, Some(RequestFailure(status, _, _, _)), _, _) if status == 404 =>
           logger.error(s"Index $searchIndex not found. Scheduling a reindex.")
           scheduleIndexDocuments()
           Failure(new IndexNotFoundException(s"Index $searchIndex not found. Scheduling a reindex"))
-        case e: NdlaSearchException =>
+        case e: NdlaSearchException[?] =>
           logger.error(e.getMessage)
           Failure(NdlaSearchException(s"Unable to execute search in $searchIndex", e))
         case t: Throwable => Failure(t)

--- a/audio-api/src/main/scala/no/ndla/audioapi/model/api/Error.scala
+++ b/audio-api/src/main/scala/no/ndla/audioapi/model/api/Error.scala
@@ -51,7 +51,7 @@ trait ErrorHelpers extends TapirErrorHelpers {
     case _: PSQLException =>
       DataSource.connectToDatabase()
       ErrorBody(DATABASE_UNAVAILABLE, DATABASE_UNAVAILABLE_DESCRIPTION, clock.now(), 500)
-    case NdlaSearchException(_, Some(rf), _)
+    case NdlaSearchException(_, Some(rf), _, _)
         if rf.error.rootCause
           .exists(x => x.`type` == "search_context_missing_exception" || x.reason == "Cannot parse scroll id") =>
       invalidSearchContext

--- a/audio-api/src/main/scala/no/ndla/audioapi/service/search/SearchService.scala
+++ b/audio-api/src/main/scala/no/ndla/audioapi/service/search/SearchService.scala
@@ -160,11 +160,11 @@ trait SearchService {
 
     protected def errorHandler[U](failure: Throwable): Failure[U] = {
       failure match {
-        case NdlaSearchException(_, Some(RequestFailure(status, _, _, _)), _) if status == 404 =>
+        case NdlaSearchException(_, Some(RequestFailure(status, _, _, _)), _, _) if status == 404 =>
           logger.error(s"Index $searchIndex not found. Scheduling a reindex.")
           scheduleIndexDocuments()
           Failure(IndexNotFoundException(s"Index $searchIndex not found. Scheduling a reindex"))
-        case e: NdlaSearchException =>
+        case e: NdlaSearchException[?] =>
           logger.error(e.getMessage)
           Failure(NdlaSearchException(s"Unable to execute search in $searchIndex", e))
         case t: Throwable => Failure(t)

--- a/concept-api/src/main/scala/no/ndla/conceptapi/model/api/NDLAErrors.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/model/api/NDLAErrors.scala
@@ -38,7 +38,7 @@ trait ErrorHelpers extends TapirErrorHelpers {
     case o: OptimisticLockException       => errorBody(RESOURCE_OUTDATED, o.getMessage, 409)
     case st: IllegalStatusStateTransition => badRequest(st.getMessage)
     case _: IndexNotFoundException        => errorBody(INDEX_MISSING, INDEX_MISSING_DESCRIPTION, 500)
-    case NdlaSearchException(_, Some(rf), _)
+    case NdlaSearchException(_, Some(rf), _, _)
         if rf.error.rootCause
           .exists(x => x.`type` == "search_context_missing_exception" || x.reason == "Cannot parse scroll id") =>
       errorBody(INVALID_SEARCH_CONTEXT, INVALID_SEARCH_CONTEXT_DESCRIPTION, 400)

--- a/concept-api/src/main/scala/no/ndla/conceptapi/service/search/SearchService.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/service/search/SearchService.scala
@@ -202,11 +202,11 @@ trait SearchService {
 
     protected def errorHandler[U](failure: Throwable): Failure[U] = {
       failure match {
-        case NdlaSearchException(_, Some(RequestFailure(status, _, _, _)), _) if status == 404 =>
+        case NdlaSearchException(_, Some(RequestFailure(status, _, _, _)), _, _) if status == 404 =>
           logger.error(s"Index $searchIndex not found. Scheduling a reindex.")
           scheduleIndexDocuments()
           Failure(IndexNotFoundException(s"Index $searchIndex not found. Scheduling a reindex"))
-        case e: NdlaSearchException =>
+        case e: NdlaSearchException[?] =>
           logger.error(e.getMessage)
           Failure(NdlaSearchException(s"Unable to execute search in $searchIndex", e))
         case t: Throwable => Failure(t)

--- a/draft-api/src/main/scala/no/ndla/draftapi/model/api/NDLAErrors.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/model/api/NDLAErrors.scala
@@ -60,7 +60,7 @@ trait ErrorHelpers extends TapirErrorHelpers {
           logger.error(s"Problem with remote service: ${h.getMessage}")
           ErrorBody(GENERIC, GENERIC_DESCRIPTION, clock.now(), 502)
       }
-    case NdlaSearchException(_, Some(rf), _)
+    case NdlaSearchException(_, Some(rf), _, _)
         if rf.error.rootCause
           .exists(x => x.`type` == "search_context_missing_exception" || x.reason == "Cannot parse scroll id") =>
       ErrorBody(INVALID_SEARCH_CONTEXT, INVALID_SEARCH_CONTEXT_DESCRIPTION, clock.now(), 400)

--- a/draft-api/src/main/scala/no/ndla/draftapi/service/search/SearchService.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/service/search/SearchService.scala
@@ -130,11 +130,11 @@ trait SearchService {
 
     protected def errorHandler[U](failure: Throwable): Failure[U] = {
       failure match {
-        case NdlaSearchException(_, Some(RequestFailure(status, _, _, _)), _) if status == 404 =>
+        case NdlaSearchException(_, Some(RequestFailure(status, _, _, _)), _, _) if status == 404 =>
           logger.error(s"Index $searchIndex not found. Scheduling a reindex.")
           scheduleIndexDocuments()
           Failure(IndexNotFoundException(s"Index $searchIndex not found. Scheduling a reindex"))
-        case e: NdlaSearchException =>
+        case e: NdlaSearchException[?] =>
           logger.error(e.getMessage)
           Failure(NdlaSearchException(s"Unable to execute search in $searchIndex", e))
         case t: Throwable => Failure(t)

--- a/image-api/src/main/scala/no/ndla/imageapi/model/api/Error.scala
+++ b/image-api/src/main/scala/no/ndla/imageapi/model/api/Error.scala
@@ -35,7 +35,7 @@ trait ErrorHelpers extends TapirErrorHelpers {
     case _: PSQLException =>
       DataSource.connectToDatabase()
       errorBody(DATABASE_UNAVAILABLE, DATABASE_UNAVAILABLE_DESCRIPTION, 500)
-    case NdlaSearchException(_, Some(rf), _)
+    case NdlaSearchException(_, Some(rf), _, _)
         if rf.error.rootCause
           .exists(x => x.`type` == "search_context_missing_exception" || x.reason == "Cannot parse scroll id") =>
       errorBody(INVALID_SEARCH_CONTEXT, INVALID_SEARCH_CONTEXT_DESCRIPTION, 400)

--- a/image-api/src/main/scala/no/ndla/imageapi/service/search/SearchService.scala
+++ b/image-api/src/main/scala/no/ndla/imageapi/service/search/SearchService.scala
@@ -111,7 +111,7 @@ trait SearchService {
 
     protected def errorHandler[E](exception: Throwable): Failure[E] = {
       exception match {
-        case e: NdlaSearchException =>
+        case e: NdlaSearchException[?] =>
           e.rf.map(_.status).getOrElse(0) match {
             case notFound: Int if notFound == 404 =>
               logger.error(s"Index ${props.SearchIndex} not found. Scheduling a reindex.")

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/model/api/ErrorHelpers.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/model/api/ErrorHelpers.scala
@@ -52,7 +52,7 @@ trait ErrorHelpers extends TapirErrorHelpers {
       errorBody(DATABASE_UNAVAILABLE, DATABASE_UNAVAILABLE_DESCRIPTION, 500)
     case mse: InvalidLpStatusException =>
       errorBody(MISSING_STATUS, mse.getMessage, 400)
-    case NdlaSearchException(_, Some(rf), _)
+    case NdlaSearchException(_, Some(rf), _, _)
         if rf.error.rootCause
           .exists(x => x.`type` == "search_context_missing_exception" || x.reason == "Cannot parse scroll id") =>
       errorBody(INVALID_SEARCH_CONTEXT, INVALID_SEARCH_CONTEXT_DESCRIPTION, 400)

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/search/SearchService.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/search/SearchService.scala
@@ -307,13 +307,13 @@ trait SearchService extends StrictLogging {
 
     private def errorHandler[T](exception: Throwable): Failure[T] = {
       exception match {
-        case NdlaSearchException(_, Some(RequestFailure(status, _, _, _)), _) if status == 404 =>
+        case NdlaSearchException(_, Some(RequestFailure(status, _, _, _)), _, _) if status == 404 =>
           logger.error(s"Index ${props.SearchIndex} not found. Scheduling a reindex.")
           scheduleIndexDocuments()
           Failure(
             IndexNotFoundException(s"Index ${props.SearchIndex} not found. Scheduling a reindex")
           )
-        case e: NdlaSearchException =>
+        case e: NdlaSearchException[?] =>
           logger.error(e.getMessage)
           Failure(
             NdlaSearchException(

--- a/search-api/src/main/scala/no/ndla/searchapi/controller/SearchController.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/controller/SearchController.scala
@@ -9,6 +9,7 @@
 package no.ndla.searchapi.controller
 
 import cats.implicits.*
+import no.ndla.common.errors.AccessDeniedException
 import no.ndla.common.model.NDLADate
 import no.ndla.common.model.api.CommaSeparatedList.*
 import no.ndla.common.model.domain.draft.DraftStatus
@@ -603,8 +604,14 @@ trait SearchController {
         case Some(token) =>
           feideApiClient.getFeideExtendedUser(Some(token)) match {
             case Success(user) => Success(user.availabilities.toList)
+            case Failure(ex: AccessDeniedException) =>
+              logger.info(
+                s"Access denied when fetching user from feide with accessToken '$token': ${ex.getMessage}",
+                ex
+              )
+              Success(List.empty)
             case Failure(ex) =>
-              logger.error(s"Error when fetching user from feide with accessToken '$token': ${ex.getMessage}")
+              logger.error(s"Error when fetching user from feide with accessToken '$token': ${ex.getMessage}", ex)
               Failure(ex)
           }
       }

--- a/search-api/src/main/scala/no/ndla/searchapi/model/api/Error.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/model/api/Error.scala
@@ -29,7 +29,7 @@ trait ErrorHelpers extends TapirErrorHelpers {
     case v: ValidationException =>
       ValidationErrorBody(VALIDATION, VALIDATION_DESCRIPTION, clock.now(), messages = v.errors.some, 400)
     case ade: AccessDeniedException => forbiddenMsg(ade.getMessage)
-    case NdlaSearchException(_, Some(rf), _)
+    case NdlaSearchException(_, Some(rf), _, _)
         if rf.error.rootCause
           .exists(x => x.`type` == "search_context_missing_exception" || x.reason == "Cannot parse scroll id") =>
       invalidSearchContext

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/SearchService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/SearchService.scala
@@ -310,7 +310,7 @@ trait SearchService {
 
     protected def errorHandler[U](failure: Throwable): Failure[U] = {
       failure match {
-        case e: NdlaSearchException =>
+        case e: NdlaSearchException[?] =>
           e.rf.map(_.status).getOrElse(0) match {
             case notFound: Int if notFound == 404 =>
               val msg = s"Index ${e.rf.flatMap(_.error.index).getOrElse("")} not found. Scheduling a reindex."

--- a/search/src/main/scala/no/ndla/search/Elastic4sClient.scala
+++ b/search/src/main/scala/no/ndla/search/Elastic4sClient.scala
@@ -37,7 +37,7 @@ trait Elastic4sClient {
         request: T
     )(implicit handler: Handler[T, U], mf: Manifest[U], ec: ExecutionContext): Future[Try[RequestSuccess[U]]] = {
       val result = client.execute(request).map {
-        case failure: RequestFailure   => Failure(NdlaSearchException(failure))
+        case failure: RequestFailure   => Failure(NdlaSearchException(request, failure))
         case result: RequestSuccess[U] => Success(result)
       }
 

--- a/search/src/main/scala/no/ndla/search/NdlaSearchException.scala
+++ b/search/src/main/scala/no/ndla/search/NdlaSearchException.scala
@@ -9,15 +9,20 @@ package no.ndla.search
 
 import com.sksamuel.elastic4s.RequestFailure
 
-case class NdlaSearchException(message: String, rf: Option[RequestFailure] = None, ex: Option[Throwable] = None)
-    extends RuntimeException(message)
+case class NdlaSearchException[T](
+    message: String,
+    rf: Option[RequestFailure] = None,
+    ex: Option[Throwable] = None,
+    request: Option[T] = None
+) extends RuntimeException(message)
 
 object NdlaSearchException {
   private def message(
       errorType: String,
       reason: String,
       index: Option[String],
-      shard: Option[String]
+      shard: Option[String],
+      requestString: String
   ): String = {
     val indexError = index.map(idx => s"\nindex: $idx")
     val shardError = shard.map(s => s"\nshard: $s")
@@ -25,20 +30,22 @@ object NdlaSearchException {
        |Error type: $errorType
        |reason: $reason
        |$indexError$shardError
+       |Caused by request: $requestString
        |""".stripMargin
   }
 
-  def apply(rf: RequestFailure): NdlaSearchException = {
+  def apply[T](request: T, rf: RequestFailure): NdlaSearchException[T] = {
     val msg = message(
       rf.error.`type`,
       rf.error.reason,
       rf.error.index,
-      rf.error.shard
+      rf.error.shard,
+      request.toString
     )
     new NdlaSearchException(msg, Some(rf))
   }
 
-  def apply(msg: String, ex: Throwable): NdlaSearchException = {
+  def apply[T](msg: String, ex: Throwable): NdlaSearchException[T] = {
     new NdlaSearchException(msg, ex = Some(ex))
   }
 }


### PR DESCRIPTION
- Slutter å feile dersom feide sier access denied
- Tar med mer informasjon i søke requests som feiler
  - Ser disse relativt ofte med ingen informasjon i, så tenkte vi kunne hive med den faktiske elasticsearch requesten som feiler også for å få litt mer informasjon.
- Logger faktisk feilene dersom indeksering feiler