### PR TITLE
validation: Make `data-image-id` optional for `key-figure` embeds

### DIFF
--- a/validation/src/main/resources/embed-tag-rules.json
+++ b/validation/src/main/resources/embed-tag-rules.json
@@ -1085,7 +1085,7 @@
         {
           "name": "data-image-id",
           "validation": {
-            "required": true,
+            "required": false,
             "dataType": "NUMBER"
           }
         },


### PR DESCRIPTION
Related to https://github.com/NDLANO/Issues/issues/4165