### PR TITLE
Add voteCount to topic

### DIFF
--- a/myndla-api/src/main/scala/no/ndla/myndlaapi/model/arena/api/Topic.scala
+++ b/myndla-api/src/main/scala/no/ndla/myndlaapi/model/arena/api/Topic.scala
@@ -20,5 +20,6 @@ case class Topic(
     @description("The id of the parenting category") categoryId: Long,
     @description("Whether the requesting user is following the topic") isFollowing: Boolean,
     @description("Whether the topic is locked or not") isLocked: Boolean,
-    @description("Whether the topic is pinned to the top of the category") isPinned: Boolean
+    @description("Whether the topic is pinned to the top of the category") isPinned: Boolean,
+    @description("The total number of votes on the posts in the topic") voteCount: Long
 )

--- a/myndla-api/src/main/scala/no/ndla/myndlaapi/model/arena/domain/database/Compiled.scala
+++ b/myndla-api/src/main/scala/no/ndla/myndlaapi/model/arena/domain/database/Compiled.scala
@@ -27,7 +27,8 @@ case class CompiledTopic(
     topic: domain.Topic,
     owner: Option[MyNDLAUser],
     postCount: Long,
-    isFollowing: Boolean
+    isFollowing: Boolean,
+    voteCount: Long
 )
 
 case class CompiledNotification(

--- a/myndla-api/src/main/scala/no/ndla/myndlaapi/repository/ArenaRepository.scala
+++ b/myndla-api/src/main/scala/no/ndla/myndlaapi/repository/ArenaRepository.scala
@@ -885,7 +885,7 @@ trait ArenaRepository {
              select ${t.resultAll}, ${u.resultAll}, ${tf.resultAll},
                (select count(*) from ${domain.Post.table} where topic_id = ${t.id}) as postCount,
                (select count(*) > 0 from ${domain.TopicFollow.table} where topic_id = ${t.id} and user_id = ${requester.id}) as isFollowing,
-               (select count(*) from ${domain.Post.table} where topic_id = ${t.id} inner join ${domain.PostUpvote.table} on ${p.id} = ${pu.post_id}) as voteCount
+               (select count(*) from ${domain.Post.table} inner join ${domain.PostUpvote.table} on ${p.id} = ${pu.post_id} where topic_id = ${t.id}) as voteCount
              from ${domain.Topic.as(t)}
              left join ${MyNDLAUser.as(u)} on ${u.id} = ${t.ownerId}
              left join ${domain.TopicFollow.as(tf)} on ${tf.topic_id} = ${t.id}
@@ -1120,7 +1120,7 @@ trait ArenaRepository {
                 (select count(*) > 0 from ${domain.TopicFollow.table} where topic_id = ${ts(
             t
           ).id} and user_id = ${requester.id}) as isFollowing,
-                (select count(*) from ${domain.Post.table} where topic_id = ${t.id} inner join ${domain.PostUpvote.table} on ${p.id} = ${pu.post_id}) as voteCount
+                (select count(*) from ${domain.Post.table} inner join ${domain.PostUpvote.table} on ${p.id} = ${pu.post_id} where topic_id = ${t.id}) as voteCount
               from (
                   select ${t.resultAll}, (select max(pp.created) from posts pp where pp.topic_id = ${t.id}) as newest_post_date
                   from ${domain.Topic.as(t)}
@@ -1208,7 +1208,7 @@ trait ArenaRepository {
                 (select count(*) > 0 from ${domain.TopicFollow.table} where topic_id = ${ts(
             t
           ).id} and user_id = ${requester.id}) as isFollowing,
-                (select count(*) from ${domain.Post.table} where topic_id = ${t.id} inner join ${domain.PostUpvote.table} on ${p.id} = ${pu.post_id}) as voteCount
+                (select count(*) from ${domain.Post.table} inner join ${domain.PostUpvote.table} on ${p.id} = ${pu.post_id} where topic_id = ${t.id}) as voteCount
               from (
                   select ${t.resultAll}, (select max(pp.created) from posts pp where pp.topic_id = ${t.id}) as newest_post_date
                   from ${domain.Topic.as(t)}

--- a/myndla-api/src/main/scala/no/ndla/myndlaapi/repository/ArenaRepository.scala
+++ b/myndla-api/src/main/scala/no/ndla/myndlaapi/repository/ArenaRepository.scala
@@ -1125,7 +1125,9 @@ trait ArenaRepository {
                 ${ts.resultAll},
                 ${u.resultAll},
                 (select count(*) from ${domain.Post.table} where topic_id = ${ts(t).id}) as postCount,
-                (select count(*) > 0 from ${domain.TopicFollow.table} where topic_id = ${ts(t).id} and user_id = ${requester.id}) as isFollowing,
+                (select count(*) > 0 from ${domain.TopicFollow.table} where topic_id = ${ts(
+            t
+          ).id} and user_id = ${requester.id}) as isFollowing,
                 (
                   select count(*)
                   from ${domain.PostUpvote.table} pu

--- a/myndla-api/src/main/scala/no/ndla/myndlaapi/service/ArenaReadService.scala
+++ b/myndla-api/src/main/scala/no/ndla/myndlaapi/service/ArenaReadService.scala
@@ -370,7 +370,7 @@ trait ArenaReadService {
           _ <- arenaRepository.postPost(topic.id, newTopic.initialPost.content, user.id, created, created, None)(
             session
           )
-          compiledTopic = CompiledTopic(topic, Some(user), 1, isFollowing = true)
+          compiledTopic = CompiledTopic(topic, Some(user), 1, isFollowing = true, 0)
         } yield converterService.toApiTopic(compiledTopic)
       }
     }

--- a/myndla-api/src/main/scala/no/ndla/myndlaapi/service/ConverterService.scala
+++ b/myndla-api/src/main/scala/no/ndla/myndlaapi/service/ConverterService.scala
@@ -51,7 +51,8 @@ trait ConverterService {
         categoryId = compiledTopic.topic.category_id,
         isFollowing = compiledTopic.isFollowing,
         isLocked = compiledTopic.topic.locked,
-        isPinned = compiledTopic.topic.pinned
+        isPinned = compiledTopic.topic.pinned,
+        voteCount = compiledTopic.voteCount
       )
     }
 

--- a/myndla-api/src/test/scala/no/ndla/myndlaapi/e2e/ArenaTest.scala
+++ b/myndla-api/src/test/scala/no/ndla/myndlaapi/e2e/ArenaTest.scala
@@ -286,7 +286,7 @@ class ArenaTest
           isFollowing = true,
           isLocked = false,
           isPinned = false,
-          voteCount = 2
+          voteCount = 0
         ),
         api.Topic(
           id = 2,
@@ -298,7 +298,7 @@ class ArenaTest
           isFollowing = true,
           isLocked = false,
           isPinned = false,
-          voteCount = 2
+          voteCount = 0
         ),
         api.Topic(
           id = 3,
@@ -310,7 +310,7 @@ class ArenaTest
           isFollowing = true,
           isLocked = false,
           isPinned = false,
-          voteCount = 2
+          voteCount = 0
         )
       ),
       isFollowing = false,

--- a/myndla-api/src/test/scala/no/ndla/myndlaapi/e2e/ArenaTest.scala
+++ b/myndla-api/src/test/scala/no/ndla/myndlaapi/e2e/ArenaTest.scala
@@ -285,7 +285,8 @@ class ArenaTest
           categoryId = 1,
           isFollowing = true,
           isLocked = false,
-          isPinned = false
+          isPinned = false,
+          voteCount = 2
         ),
         api.Topic(
           id = 2,
@@ -296,7 +297,8 @@ class ArenaTest
           categoryId = 1,
           isFollowing = true,
           isLocked = false,
-          isPinned = false
+          isPinned = false,
+          voteCount = 2
         ),
         api.Topic(
           id = 3,
@@ -307,7 +309,8 @@ class ArenaTest
           categoryId = 1,
           isFollowing = true,
           isLocked = false,
-          isPinned = false
+          isPinned = false,
+          voteCount = 2
         )
       ),
       isFollowing = false,

--- a/myndla-api/src/test/scala/no/ndla/myndlaapi/repository/ArenaRepositoryTest.scala
+++ b/myndla-api/src/test/scala/no/ndla/myndlaapi/repository/ArenaRepositoryTest.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA backend.myndla-api
+ * Part of NDLA myndla-api
  * Copyright (C) 2024 NDLA
  *
  * See LICENSE

--- a/myndla-api/src/test/scala/no/ndla/myndlaapi/repository/ArenaRepositoryTest.scala
+++ b/myndla-api/src/test/scala/no/ndla/myndlaapi/repository/ArenaRepositoryTest.scala
@@ -1,0 +1,255 @@
+/*
+ * Part of NDLA backend.myndla-api
+ * Copyright (C) 2024 NDLA
+ *
+ * See LICENSE
+ */
+
+package no.ndla.myndlaapi.repository
+
+import com.zaxxer.hikari.HikariDataSource
+import no.ndla.common.model.NDLADate
+import no.ndla.myndlaapi.model.arena.domain.InsertCategory
+import no.ndla.myndlaapi.model.domain.{MyNDLAUserDocument, UserRole}
+import no.ndla.myndlaapi.{TestEnvironment, UnitSuite}
+import no.ndla.scalatestsuite.IntegrationSuite
+
+class ArenaRepositoryTest
+    extends IntegrationSuite(EnablePostgresContainer = true, schemaName = "myndlaapi_test")
+    with UnitSuite
+    with TestEnvironment {
+  override val dataSource: HikariDataSource = testDataSource.get
+  override val migrator                     = new DBMigrator
+
+  override val arenaRepository: ArenaRepository = new ArenaRepository
+  override val userRepository: UserRepository   = new UserRepository
+
+  def emptyTestDatabase(): Unit = {
+    arenaRepository.withSession(implicit session => {
+      arenaRepository.deleteAllFollows.get
+      arenaRepository.deleteAllPosts.get
+      arenaRepository.deleteAllTopics.get
+      arenaRepository.deleteAllCategories.get
+      arenaRepository.resetSequences.get
+      userRepository.deleteAllUsers.get
+      userRepository.resetSequences.get
+    })
+  }
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    DataSource.connectToDatabase()
+    migrator.migrate()
+  }
+
+  override def beforeEach(): Unit = {
+    DataSource.connectToDatabase()
+    emptyTestDatabase()
+  }
+
+  test("That inserting and retrieving categories and topics works as expected") {
+    val now = NDLADate.now()
+    val user = MyNDLAUserDocument(
+      favoriteSubjects = List(),
+      userRole = UserRole.EMPLOYEE,
+      lastUpdated = now,
+      organization = "org",
+      groups = List(),
+      username = "test",
+      displayName = "Test Testesen",
+      email = "example@example.com",
+      arenaEnabled = true,
+      arenaGroups = List(),
+      shareName = true
+    )
+    val feideId = "feideId1"
+
+    arenaRepository.withSession { session =>
+      userRepository.reserveFeideIdIfNotExists(feideId)(session).get
+      val user1 = userRepository.insertUser(feideId, user)(session).get
+
+      val cat1 = arenaRepository
+        .insertCategory(
+          InsertCategory(
+            title = "Category 1",
+            description = "Category 1 description",
+            visible = true,
+            parentCategoryId = None
+          )
+        )(session)
+        .get
+
+      val top1 = arenaRepository
+        .insertTopic(
+          categoryId = cat1.id,
+          title = "Topic 1",
+          ownerId = user1.id,
+          created = now,
+          updated = now,
+          locked = false,
+          pinned = false
+        )(session)
+        .get
+
+      val topic = arenaRepository.getTopic(top1.id, user1)(session).get
+      topic.get.topic.title should be("Topic 1")
+
+      val paginated = arenaRepository.getTopicsPaginated(0, 10, user1)(session).get
+      paginated._1.head.topic.title should be("Topic 1")
+    }
+  }
+
+  test("That post count is updated when post is inserted") {
+    val now = NDLADate.now()
+    val user = MyNDLAUserDocument(
+      favoriteSubjects = List(),
+      userRole = UserRole.EMPLOYEE,
+      lastUpdated = now,
+      organization = "org",
+      groups = List(),
+      username = "test",
+      displayName = "Test Testesen",
+      email = "example@example.com",
+      arenaEnabled = true,
+      arenaGroups = List(),
+      shareName = true
+    )
+    val feideId = "feideId1"
+
+    arenaRepository.withSession { session =>
+      userRepository.reserveFeideIdIfNotExists(feideId)(session).get
+      val user1 = userRepository.insertUser(feideId, user)(session).get
+
+      val cat1 = arenaRepository
+        .insertCategory(
+          InsertCategory(
+            title = "Category 1",
+            description = "Category 1 description",
+            visible = true,
+            parentCategoryId = None
+          )
+        )(session)
+        .get
+
+      val top1 = arenaRepository
+        .insertTopic(
+          categoryId = cat1.id,
+          title = "Topic 1",
+          ownerId = user1.id,
+          created = now,
+          updated = now,
+          locked = false,
+          pinned = false
+        )(session)
+        .get
+
+      val topic = arenaRepository.getTopic(top1.id, user1)(session).get
+      topic.get.postCount should be(0)
+
+      arenaRepository
+        .postPost(
+          topicId = top1.id,
+          content = "Post 1",
+          ownerId = user1.id,
+          created = now,
+          updated = now,
+          toPostId = None
+        )(session)
+        .get
+
+      val topicAfterPost = arenaRepository.getTopic(top1.id, user1)(session).get
+      topicAfterPost.get.postCount should be(1)
+
+    }
+  }
+
+  test("That upvote count is updated when main post in topic is upvoted") {
+    val now = NDLADate.now()
+    val user = MyNDLAUserDocument(
+      favoriteSubjects = List(),
+      userRole = UserRole.EMPLOYEE,
+      lastUpdated = now,
+      organization = "org",
+      groups = List(),
+      username = "test",
+      displayName = "Test Testesen",
+      email = "example@example.com",
+      arenaEnabled = true,
+      arenaGroups = List(),
+      shareName = true
+    )
+    val feideId  = "feideId1"
+    val feideId2 = "feideId2"
+
+    arenaRepository.withSession { session =>
+      userRepository.reserveFeideIdIfNotExists(feideId)(session).get
+      userRepository.reserveFeideIdIfNotExists(feideId2)(session).get
+      val user1 =
+        userRepository.insertUser(feideId, user.copy(username = "test1", email = "example1@example.com"))(session).get
+      val user2 =
+        userRepository.insertUser(feideId2, user.copy(username = "test2", email = "example2@example.com"))(session).get
+
+      val cat1 = arenaRepository
+        .insertCategory(
+          InsertCategory(
+            title = "Category 1",
+            description = "Category 1 description",
+            visible = true,
+            parentCategoryId = None
+          )
+        )(session)
+        .get
+
+      val top1 = arenaRepository
+        .insertTopic(
+          categoryId = cat1.id,
+          title = "Topic 1",
+          ownerId = user1.id,
+          created = now,
+          updated = now,
+          locked = false,
+          pinned = false
+        )(session)
+        .get
+
+      val topic = arenaRepository.getTopic(top1.id, user1)(session).get
+      topic.get.postCount should be(0)
+
+      val mainPost = arenaRepository
+        .postPost(
+          topicId = top1.id,
+          content = "Post 1",
+          ownerId = user2.id,
+          created = now,
+          updated = now,
+          toPostId = None
+        )(session)
+        .get
+
+      val secondPost = arenaRepository
+        .postPost(
+          topicId = top1.id,
+          content = "Post 1",
+          ownerId = user2.id,
+          created = now,
+          updated = now,
+          toPostId = None
+        )(session)
+        .get
+
+      val topicAfterPost = arenaRepository.getTopic(top1.id, user1)(session).get
+      topicAfterPost.get.postCount should be(2)
+      topicAfterPost.get.voteCount should be(0)
+
+      arenaRepository.upvotePost(mainPost.id, user2.id)(session).get
+      val topicAfterMainUpvote = arenaRepository.getTopic(top1.id, user1)(session).get
+      topicAfterMainUpvote.get.voteCount should be(1)
+
+      // Only main post of topic should count towards vote count
+      // this is how it is in nodebb
+      arenaRepository.upvotePost(secondPost.id, user2.id)(session).get
+      val topicAfterOtherUpvote = arenaRepository.getTopic(top1.id, user1)(session).get
+      topicAfterOtherUpvote.get.voteCount should be(1)
+    }
+  }
+}

--- a/myndla-api/src/test/scala/no/ndla/myndlaapi/repository/ArenaRepositoryTest.scala
+++ b/myndla-api/src/test/scala/no/ndla/myndlaapi/repository/ArenaRepositoryTest.scala
@@ -240,16 +240,22 @@ class ArenaRepositoryTest
       val topicAfterPost = arenaRepository.getTopic(top1.id, user1)(session).get
       topicAfterPost.get.postCount should be(2)
       topicAfterPost.get.voteCount should be(0)
+      val categoryTopicsAfterPost = arenaRepository.getTopicsForCategory(cat1.id, 0, 10, user1)(session).get
+      categoryTopicsAfterPost.head.voteCount should be(0)
 
       arenaRepository.upvotePost(mainPost.id, user2.id)(session).get
       val topicAfterMainUpvote = arenaRepository.getTopic(top1.id, user1)(session).get
       topicAfterMainUpvote.get.voteCount should be(1)
+      val categoryTopicsAfterMainUpvote = arenaRepository.getTopicsForCategory(cat1.id, 0, 10, user1)(session).get
+      categoryTopicsAfterMainUpvote.head.voteCount should be(1)
 
       // Only main post of topic should count towards vote count
       // this is how it is in nodebb
       arenaRepository.upvotePost(secondPost.id, user2.id)(session).get
       val topicAfterOtherUpvote = arenaRepository.getTopic(top1.id, user1)(session).get
       topicAfterOtherUpvote.get.voteCount should be(1)
+      val categoryTopicsAfterOtherUpvote = arenaRepository.getTopicsForCategory(cat1.id, 0, 10, user1)(session).get
+      categoryTopicsAfterOtherUpvote.head.voteCount should be(1)
     }
   }
 }


### PR DESCRIPTION
Forsøk på å legge til voteCount slik at typene blir riktige i GraphQL også. Nødvendige for å kunne støtte reaksjoner på TopicCard i nytt design.

KAN alternativt utvides til å også ha voteCount til categories også, men sida det ikke er noen direkte støtte for det i GraphQL (uten at vi trikser inn og summerer sjøl), er det ikke lagt inn enda.