### PR TITLE
chore: support data-variant on divs and blockquotes

### DIFF
--- a/validation/src/main/resources/html-rules.json
+++ b/validation/src/main/resources/html-rules.json
@@ -21,6 +21,13 @@
         }
       ]
     },
+    "blockquote": {
+      "fields": [
+        {
+          "name": "data-variant"
+        }
+      ]
+    },
     "colgroup": {
       "fields": [
         {
@@ -63,6 +70,9 @@
         },
         {
           "name": "data-parallax-cell"
+        },
+        {
+          "name": "data-variant"
         }
       ]
     },

--- a/validation/src/main/scala/no/ndla/validation/TagRules.scala
+++ b/validation/src/main/scala/no/ndla/validation/TagRules.scala
@@ -300,6 +300,7 @@ object TagAttribute extends Enum[TagAttribute] with CirceEnum[TagAttribute] {
   case object DataUpperLeftY          extends TagAttribute("data-upper-left-y")
   case object DataUrl                 extends TagAttribute("data-url")
   case object DataUrlText             extends TagAttribute("data-url-text")
+  case object DataVariant             extends TagAttribute("data-variant")
   case object DataVideoId             extends TagAttribute("data-videoid")
   case object DataWidth               extends TagAttribute("data-width")
   case object DataYear                extends TagAttribute("data-year")


### PR DESCRIPTION
Skal brukes til å vise fargede versjoner av `FramedContent` og `blockquote` basert på artikkeltype (hvis man velger at de skal være farget).