### PR TITLE
draft-api: Add editorial validation path

### DIFF
--- a/draft-api/src/main/scala/no/ndla/draftapi/service/ConverterService.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/service/ConverterService.scala
@@ -175,6 +175,16 @@ trait ConverterService {
     ): Option[common.draft.QualityEvaluation] =
       newQualityEvaluation.map(qe => common.draft.QualityEvaluation(grade = qe.grade, note = qe.note))
 
+    def withSortedLanguageFields(article: Draft): Draft = {
+      article.copy(
+        visualElement = article.visualElement.sorted,
+        content = article.content.sorted,
+        introduction = article.introduction.sorted,
+        metaImage = article.metaImage.sorted,
+        title = article.title.sorted
+      )
+    }
+
     private[service] def updatedCommentToDomainNullDocument(
         updatedComments: List[UpdatedComment]
     ): Try[Seq[Comment]] = {

--- a/draft-api/src/main/scala/no/ndla/draftapi/service/ConverterService.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/service/ConverterService.scala
@@ -208,7 +208,7 @@ trait ConverterService {
 
     private def toDomainRevisionMeta(revisionMeta: api.RevisionMeta): common.draft.RevisionMeta = {
       common.draft.RevisionMeta(
-        id = revisionMeta.id.map(UUID.fromString).getOrElse(UUID.randomUUID()),
+        id = revisionMeta.id.map(UUID.fromString).getOrElse(uuidUtil.randomUUID()),
         revisionDate = revisionMeta.revisionDate,
         note = revisionMeta.note,
         status = common.draft.RevisionStatus.fromStringDefault(revisionMeta.status)

--- a/draft-api/src/main/scala/no/ndla/draftapi/service/WriteService.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/service/WriteService.scala
@@ -186,7 +186,7 @@ trait WriteService {
             oldNdlaCreatedDate,
             oldNdlaUpdatedDate
           )
-          _               <- contentValidator.validateArticle(domainArticle)
+          _               <- contentValidator.validateArticle(None, domainArticle)
           insertedArticle <- Try(insertFunction(domainArticle))
           _ = indexArticle(insertedArticle, user)
           apiArticle <- converterService.toApiArticle(insertedArticle, newArticle.language)
@@ -409,7 +409,7 @@ trait WriteService {
         updatePriorityField(withStarted, oldArticle, statusWasUpdated)
 
       for {
-        _ <- contentValidator.validateArticleOnLanguage(toUpdate, language)
+        _ <- contentValidator.validateArticleOnLanguage(oldArticle, toUpdate, language)
         domainArticle <- performArticleUpdate(
           withPriority,
           externalIds,

--- a/draft-api/src/main/scala/no/ndla/draftapi/service/WriteService.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/service/WriteService.scala
@@ -445,31 +445,27 @@ trait WriteService {
       // Function that sets values we don't want to include when comparing articles to check if we should update status
       val withComparableValues =
         (article: Draft) =>
-          article.copy(
-            revision = None,
-            notes = Seq.empty,
-            editorLabels = Seq.empty,
-            created = NDLADate.MIN,
-            updated = NDLADate.MIN,
-            updatedBy = "",
-            availability = common.Availability.everyone,
-            grepCodes = Seq.empty,
-            copyright = article.copyright.map(e => e.copy(license = None)),
-            metaDescription = Seq.empty,
-            relatedContent = Seq.empty,
-            tags = Seq.empty,
-            revisionMeta = Seq.empty,
-            comments = List.empty,
-            priority = Priority.Unspecified,
-            started = false,
-            qualityEvaluation = None,
-            // LanguageField ordering shouldn't matter:
-            visualElement = article.visualElement.sorted,
-            content = article.content.sorted,
-            introduction = article.introduction.sorted,
-            metaImage = article.metaImage.sorted,
-            title = article.title.sorted
-          )
+          converterService
+            .withSortedLanguageFields(article)
+            .copy(
+              revision = None,
+              notes = Seq.empty,
+              editorLabels = Seq.empty,
+              created = NDLADate.MIN,
+              updated = NDLADate.MIN,
+              updatedBy = "",
+              availability = common.Availability.everyone,
+              grepCodes = Seq.empty,
+              copyright = article.copyright.map(e => e.copy(license = None)),
+              metaDescription = Seq.empty,
+              relatedContent = Seq.empty,
+              tags = Seq.empty,
+              revisionMeta = Seq.empty,
+              comments = List.empty,
+              priority = Priority.Unspecified,
+              started = false,
+              qualityEvaluation = None
+            )
 
       val comparableNew      = withComparableValues(changedArticle)
       val comparableExisting = withComparableValues(existingArticle)

--- a/draft-api/src/main/scala/no/ndla/draftapi/validation/ContentValidator.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/validation/ContentValidator.scala
@@ -56,8 +56,9 @@ trait ContentValidator {
     }
 
     def validateArticleOnLanguage(oldArticle: Option[Draft], article: Draft, language: Option[String]): Try[Draft] = {
-      val toValidate = language.map(getArticleOnLanguage(article, _)).getOrElse(article)
-      validateArticle(oldArticle, toValidate)
+      val toValidate    = language.map(getArticleOnLanguage(article, _)).getOrElse(article)
+      val oldToValidate = language.map(getArticleOnLanguage(article, _)).orElse(oldArticle)
+      validateArticle(oldToValidate, toValidate)
     }
 
     def validateArticleOnLanguage(article: Draft, language: Option[String]): Try[Draft] =
@@ -113,15 +114,17 @@ trait ContentValidator {
         case Some(oldArticle) =>
           val withComparableValues =
             (article: Draft) =>
-              article.copy(
-                revision = None,
-                notes = Seq.empty,
-                editorLabels = Seq.empty,
-                comments = List.empty,
-                updated = NDLADate.MIN,
-                revisionMeta = Seq.empty,
-                updatedBy = ""
-              )
+              converterService
+                .withSortedLanguageFields(article)
+                .copy(
+                  revision = None,
+                  notes = Seq.empty,
+                  editorLabels = Seq.empty,
+                  comments = List.empty,
+                  updated = NDLADate.MIN,
+                  revisionMeta = Seq.empty,
+                  updatedBy = ""
+                )
 
           withComparableValues(oldArticle) == withComparableValues(changedArticle)
       }

--- a/draft-api/src/test/scala/no/ndla/draftapi/service/WriteServiceTest.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/service/WriteServiceTest.scala
@@ -80,8 +80,12 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
       invocation.getArgument[Draft](0)
     )
     when(contentValidator.validateArticle(any[Draft])).thenReturn(Success(article))
+    when(contentValidator.validateArticle(any, any[Draft])).thenReturn(Success(article))
     when(contentValidator.validateArticleOnLanguage(any[Draft], any)).thenAnswer((i: InvocationOnMock) =>
       Success(i.getArgument[Draft](0))
+    )
+    when(contentValidator.validateArticleOnLanguage(any, any[Draft], any)).thenAnswer((i: InvocationOnMock) =>
+      Success(i.getArgument[Draft](1))
     )
     when(draftRepository.getExternalIdsFromId(any[Long])(any[DBSession])).thenReturn(List("1234"))
     when(clock.now()).thenReturn(today)
@@ -506,7 +510,7 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
     when(draftRepository.withId(any)(any)).thenReturn(Some(article))
     service.updateArticle(1, updatedArticle, List(), List(), TestData.userWithPublishAccess, None, None, None)
 
-    verify(contentValidator, times(1)).validateArticleOnLanguage(any, eqTo(Some("nb")))
+    verify(contentValidator, times(1)).validateArticleOnLanguage(any, any, eqTo(Some("nb")))
   }
 
   test("That articles are cloned with reasonable values") {
@@ -1088,6 +1092,7 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
   }
 
   test("That updateArticle should get editor notes if RevisionMeta is added or updated") {
+    when(uuidUtil.randomUUID()).thenCallRealMethod()
     val revision = api.RevisionMeta(None, NDLADate.now(), "Ny revision", RevisionStatus.NeedsRevision.entryName)
     val updatedApiArticle = TestData.blankUpdatedArticle.copy(
       revision = 1,

--- a/draft-api/src/test/scala/no/ndla/draftapi/validation/ContentValidatorTest.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/validation/ContentValidatorTest.scala
@@ -17,9 +17,10 @@ import java.util.UUID
 import scala.util.Failure
 
 class ContentValidatorTest extends UnitSuite with TestEnvironment {
-  override val contentValidator = new ContentValidator()
-  val validDocument             = """<section><h1>heisann</h1><h2>heia</h2></section>"""
-  val invalidDocument           = """<section><invalid></invalid></section>"""
+  override val contentValidator                   = new ContentValidator()
+  override val converterService: ConverterService = new ConverterService
+  val validDocument                               = """<section><h1>heisann</h1><h2>heia</h2></section>"""
+  val invalidDocument                             = """<section><invalid></invalid></section>"""
 
   val articleToValidate: Draft =
     TestData.sampleArticleWithByNcSa.copy(responsible = Some(Responsible("hei", TestData.today)))

--- a/draft-api/src/test/scala/no/ndla/draftapi/validation/ContentValidatorTest.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/validation/ContentValidatorTest.scala
@@ -8,11 +8,12 @@
 package no.ndla.draftapi.validation
 
 import no.ndla.common.errors.{ValidationException, ValidationMessage}
-import no.ndla.common.model.domain._
-import no.ndla.common.model.domain.draft.{DraftCopyright, Draft, RevisionMeta}
+import no.ndla.common.model.domain.*
+import no.ndla.common.model.domain.draft.{Comment, Draft, DraftCopyright, RevisionMeta}
 import no.ndla.draftapi.{TestData, TestEnvironment, UnitSuite}
 import no.ndla.mapping.License.CC_BY_SA
 
+import java.util.UUID
 import scala.util.Failure
 
 class ContentValidatorTest extends UnitSuite with TestEnvironment {
@@ -356,5 +357,64 @@ class ContentValidatorTest extends UnitSuite with TestEnvironment {
     val Seq(err1, err2)                     = error.errors
     err1.message.contains("The content contains illegal tags and/or attributes.") should be(true)
     err2.message should be("An article must consist of one or more <section> blocks. Illegal tag(s) are div ")
+  }
+
+  test("That validation succeeds if only editor fields are updated") {
+    val oldArticle =
+      TestData.sampleDomainArticle.copy(
+        id = Some(5),
+        revision = Some(1),
+        responsible = None,
+        revisionMeta = RevisionMeta.default
+      )
+    val article =
+      oldArticle.copy(
+        id = Some(5),
+        revision = Some(2),
+        responsible = None,
+        revisionMeta = RevisionMeta.default ++ RevisionMeta.default,
+        notes = Seq(
+          EditorNote("note1", "editor", oldArticle.status, TestData.today),
+          EditorNote("note2", "editor", oldArticle.status, TestData.today)
+        ),
+        comments = Seq(
+          Comment(UUID.randomUUID(), TestData.today, TestData.today, "Fin kommentar a gitt", true, false),
+          Comment(UUID.randomUUID(), TestData.today, TestData.today, "Fin kommentar igjen a gitt", true, false)
+        )
+      )
+
+    val result = contentValidator.validateArticleOnLanguage(Some(oldArticle), article, Some("nb"))
+    result.get should be(article)
+  }
+
+  test("That validation fails if only editor fields are updated and editor validation fails") {
+    val oldArticle =
+      TestData.sampleDomainArticle.copy(
+        id = Some(5),
+        revision = Some(1),
+        responsible = None,
+        revisionMeta = Seq.empty
+      )
+    val article =
+      oldArticle.copy(
+        id = Some(5),
+        revision = Some(2),
+        responsible = None,
+        revisionMeta = Seq.empty,
+        notes = Seq(
+          EditorNote("note1", "editor", oldArticle.status, TestData.today),
+          EditorNote("note2", "editor", oldArticle.status, TestData.today)
+        ),
+        comments = Seq(
+          Comment(UUID.randomUUID(), TestData.today, TestData.today, "Fin kommentar a gitt", true, false),
+          Comment(UUID.randomUUID(), TestData.today, TestData.today, "Fin kommentar igjen a gitt", true, false)
+        )
+      )
+
+    val result = contentValidator.validateArticleOnLanguage(Some(oldArticle), article, Some("nb"))
+    result.isFailure should be(true)
+    val Failure(validationError: ValidationException) = result
+    validationError.errors.length should be(1)
+    validationError.errors.head.message should be("An article must contain at least one planned revisiondate")
   }
 }


### PR DESCRIPTION
Introduserer en valideringspath som slår inn dersom man _bare_ har redigert editor felter (`notes`, `comments`, `revisionMeta`).
Dersom vi treffer denne pathen validerer vi bare editor feltene og ikke resten av artikkelen.

Usecasen er å ikke validere ansvarlig dersom vi bare skal oppdatere notes når vi oppdaterer kvalitetsvurdering.