### PR TITLE
Only disconnect copies when path is deleted

### DIFF
--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/model/domain/LearningPath.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/model/domain/LearningPath.scala
@@ -60,6 +60,10 @@ case class LearningPath(
     status == LearningPathStatus.PUBLISHED
   }
 
+  def isDeleted: Boolean = {
+    status == LearningPathStatus.DELETED
+  }
+
   def canSetStatus(status: LearningPathStatus.Value, user: TokenUser): Try[LearningPath] = {
     if (status == LearningPathStatus.PUBLISHED && !user.canPublish) {
       Failure(AccessDeniedException("You need to be a publisher to publish learningpaths."))

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/UpdateService.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/UpdateService.scala
@@ -140,7 +140,7 @@ trait UpdateService {
 
       if (learningPath.isPublished) {
         searchApiClient.indexLearningPathDocument(learningPath, user): Unit
-      } else if (learningPath.status == LearningPathStatus.DELETED) {
+      } else if (learningPath.isDeleted) {
         deleteIsBasedOnReference(learningPath): Unit
       }
 

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/UpdateService.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/UpdateService.scala
@@ -140,7 +140,7 @@ trait UpdateService {
 
       if (learningPath.isPublished) {
         searchApiClient.indexLearningPathDocument(learningPath, user): Unit
-      } else {
+      } else if (learningPath.status == LearningPathStatus.DELETED) {
         deleteIsBasedOnReference(learningPath): Unit
       }
 

--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/UpdateServiceTest.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/UpdateServiceTest.scala
@@ -524,7 +524,6 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
         .get
         .status
     }
-    verify(learningPathRepository, times(1)).learningPathsWithIsBasedOn(any[Long])
     verify(learningPathRepository, times(1)).update(any[domain.LearningPath])(any)
     verify(searchIndexService, times(1)).indexDocument(any[domain.LearningPath])
   }
@@ -542,7 +541,6 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
         .get
         .status
     }
-    verify(learningPathRepository, times(1)).learningPathsWithIsBasedOn(any[Long])
     verify(learningPathRepository, times(1)).update(any[domain.LearningPath])(any)
     verify(searchIndexService, times(1)).indexDocument(any[domain.LearningPath])
   }


### PR DESCRIPTION
Vi sletter koblinger til stier som har blitt kopiert dersom status endres bort fra publisert. Men det vil sei at dersom en sti endres og repubiseres så mistes koblinga for kopiene. Eg synes det gir mest meining om koblinga slettes først dersom original sti slettes, altså får status Deleted.

Grunnen til at eg fant dette var mange stier som var oppdatert i vår sjølv om eiger ikkje hadde logga på på fire år.