### PR TITLE
Converts size attribute for image embeds

### DIFF
--- a/article-api/src/main/scala/no/ndla/articleapi/db/migration/V53__StripHideBylineFromSize.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/db/migration/V53__StripHideBylineFromSize.scala
@@ -1,0 +1,32 @@
+/*
+ * Part of NDLA article-api
+ * Copyright (C) 2024 NDLA
+ *
+ * See LICENSE
+ */
+
+package no.ndla.articleapi.db.migration
+
+import no.ndla.articleapi.db.HtmlMigration
+import org.jsoup.nodes.Element
+
+class V53__StripHideBylineFromSize extends HtmlMigration {
+
+  override val convertVisualElement: Boolean = false
+  override def convertHtml(doc: Element, language: String): Element = {
+    doc
+      .select("ndlaembed[data-resource='image']")
+      .forEach(embed => {
+        val hasSize = embed.hasAttr("data-size")
+        if (hasSize) {
+          if (embed.attr("data-size").endsWith("-hide-byline")) {
+            embed.attr("data-size", embed.attr("data-size").substring(0, embed.attr("data-size").indexOf("-"))): Unit
+          }
+          if (embed.attr("data-size").equals("fullbredde") || embed.attr("data-size").equals("fullwidth")) {
+            embed.attr("data-size", "full"): Unit
+          }
+        }
+      })
+    doc
+  }
+}

--- a/article-api/src/main/scala/no/ndla/articleapi/db/migration/V53__StripHideBylineFromSize.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/db/migration/V53__StripHideBylineFromSize.scala
@@ -12,14 +12,14 @@ import org.jsoup.nodes.Element
 
 class V53__StripHideBylineFromSize extends HtmlMigration {
 
-  override val convertVisualElement: Boolean = false
+  override val convertVisualElement: Boolean = true
   override def convertHtml(doc: Element, language: String): Element = {
     doc
       .select("ndlaembed[data-resource='image']")
       .forEach(embed => {
         val hasSize = embed.hasAttr("data-size")
         if (hasSize) {
-          if (embed.attr("data-size").endsWith("-hide-byline")) {
+          if (embed.attr("data-size").contains("-")) {
             embed.attr("data-size", embed.attr("data-size").substring(0, embed.attr("data-size").indexOf("-"))): Unit
           }
           if (embed.attr("data-size").equals("fullbredde") || embed.attr("data-size").equals("fullwidth")) {

--- a/article-api/src/test/scala/no/ndla/articleapi/db/migration/V53__StripHideBylineFromSizeTest.scala
+++ b/article-api/src/test/scala/no/ndla/articleapi/db/migration/V53__StripHideBylineFromSizeTest.scala
@@ -28,6 +28,11 @@ class V53__StripHideBylineFromSizeTest extends UnitSuite with TestEnvironment {
     ) should be(medium): Unit
 
     migration.convertContent(
+      """<section><ndlaembed data-resource="image" data-resource_id="123" data-alt="Alt" data-caption="Caption" data-size="full---" data-hide-byline="true" data-url="https://api.test.ndla.no/image-api/v2/images/123"></ndlaembed></section>""",
+      "nb"
+    ) should be(full): Unit
+
+    migration.convertContent(
       """<section><ndlaembed data-resource="image" data-resource_id="123" data-alt="Alt" data-caption="Caption" data-size="full---hide-byline" data-hide-byline="true" data-url="https://api.test.ndla.no/image-api/v2/images/123"></ndlaembed></section>""",
       "nb"
     ) should be(full): Unit

--- a/article-api/src/test/scala/no/ndla/articleapi/db/migration/V53__StripHideBylineFromSizeTest.scala
+++ b/article-api/src/test/scala/no/ndla/articleapi/db/migration/V53__StripHideBylineFromSizeTest.scala
@@ -1,0 +1,67 @@
+/*
+ * Part of NDLA article-api
+ * Copyright (C) 2024 NDLA
+ *
+ * See LICENSE
+ */
+
+package no.ndla.articleapi.db.migration
+
+import no.ndla.articleapi.{TestEnvironment, UnitSuite}
+
+class V53__StripHideBylineFromSizeTest extends UnitSuite with TestEnvironment {
+  test("That hide-byline is stripped from size") {
+    val migration = new V53__StripHideBylineFromSize
+    val full =
+      """<section><ndlaembed data-resource="image" data-resource_id="123" data-alt="Alt" data-caption="Caption" data-size="full" data-hide-byline="true" data-url="https://api.test.ndla.no/image-api/v2/images/123"></ndlaembed></section>"""
+    val medium =
+      """<section><ndlaembed data-resource="image" data-resource_id="123" data-alt="Alt" data-caption="Caption" data-size="medium" data-hide-byline="true" data-url="https://api.test.ndla.no/image-api/v2/images/123"></ndlaembed></section>"""
+
+    migration.convertContent(
+      """<section><ndlaembed data-resource="image" data-resource_id="123" data-alt="Alt" data-caption="Caption" data-size="full-hide-byline" data-hide-byline="true" data-url="https://api.test.ndla.no/image-api/v2/images/123"></ndlaembed></section>""",
+      "nb"
+    ) should be(full): Unit
+
+    migration.convertContent(
+      """<section><ndlaembed data-resource="image" data-resource_id="123" data-alt="Alt" data-caption="Caption" data-size="medium-hide-byline" data-hide-byline="true" data-url="https://api.test.ndla.no/image-api/v2/images/123"></ndlaembed></section>""",
+      "nb"
+    ) should be(medium): Unit
+
+    migration.convertContent(
+      """<section><ndlaembed data-resource="image" data-resource_id="123" data-alt="Alt" data-caption="Caption" data-size="full---hide-byline" data-hide-byline="true" data-url="https://api.test.ndla.no/image-api/v2/images/123"></ndlaembed></section>""",
+      "nb"
+    ) should be(full): Unit
+
+    migration.convertContent(
+      """<section><ndlaembed data-resource="image" data-resource_id="123" data-alt="Alt" data-caption="Caption" data-size="full-hide-byline--hide-byline" data-hide-byline="true" data-url="https://api.test.ndla.no/image-api/v2/images/123"></ndlaembed></section>""",
+      "nb"
+    ) should be(full): Unit
+
+    migration.convertContent(
+      """<section><ndlaembed data-resource="image" data-resource_id="123" data-alt="Alt" data-caption="Caption" data-size="medium-hide-byline--hide-byline" data-hide-byline="true" data-url="https://api.test.ndla.no/image-api/v2/images/123"></ndlaembed></section>""",
+      "nb"
+    ) should be(medium): Unit
+
+    migration.convertContent(
+      """<section><ndlaembed data-resource="image" data-resource_id="123" data-alt="Alt" data-caption="Caption" data-size="full---------hide-byline" data-hide-byline="true" data-url="https://api.test.ndla.no/image-api/v2/images/123"></ndlaembed></section>""",
+      "nb"
+    ) should be(full): Unit
+
+    migration.convertContent(
+      """<section><ndlaembed data-resource="image" data-resource_id="123" data-alt="Alt" data-caption="Caption" data-size="fullwidth-hide-byline" data-hide-byline="true" data-url="https://api.test.ndla.no/image-api/v2/images/123"></ndlaembed></section>""",
+      "nb"
+    ) should be(full): Unit
+
+    migration.convertContent(
+      """<section><ndlaembed data-resource="image" data-resource_id="123" data-alt="Alt" data-caption="Caption" data-size="fullwidth" data-hide-byline="true" data-url="https://api.test.ndla.no/image-api/v2/images/123"></ndlaembed></section>""",
+      "nb"
+    ) should be(full): Unit
+
+    migration.convertContent(
+      """<section><ndlaembed data-resource="image" data-resource_id="123" data-alt="Alt" data-caption="Caption" data-size="fullbredde" data-hide-byline="true" data-url="https://api.test.ndla.no/image-api/v2/images/123"></ndlaembed></section>""",
+      "nb"
+    ) should be(full): Unit
+
+  }
+
+}

--- a/draft-api/src/main/scala/no/ndla/draftapi/db/migration/V64__StripHideBylineFromSize.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/db/migration/V64__StripHideBylineFromSize.scala
@@ -11,14 +11,14 @@ import no.ndla.draftapi.db.HtmlMigration
 import org.jsoup.nodes.Element
 
 class V64__StripHideBylineFromSize extends HtmlMigration {
-  override val convertVisualElement: Boolean = false
+  override val convertVisualElement: Boolean = true
   override def convertHtml(doc: Element, language: String): Element = {
     doc
       .select("ndlaembed[data-resource='image']")
       .forEach(embed => {
         val hasSize = embed.hasAttr("data-size")
         if (hasSize) {
-          if (embed.attr("data-size").endsWith("-hide-byline")) {
+          if (embed.attr("data-size").contains("-")) {
             embed.attr("data-size", embed.attr("data-size").substring(0, embed.attr("data-size").indexOf("-"))): Unit
           }
           if (embed.attr("data-size").equals("fullbredde") || embed.attr("data-size").equals("fullwidth")) {

--- a/draft-api/src/main/scala/no/ndla/draftapi/db/migration/V64__StripHideBylineFromSize.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/db/migration/V64__StripHideBylineFromSize.scala
@@ -1,0 +1,31 @@
+/*
+ * Part of NDLA draft-api
+ * Copyright (C) 2024 NDLA
+ *
+ * See LICENSE
+ */
+
+package no.ndla.draftapi.db.migration
+
+import no.ndla.draftapi.db.HtmlMigration
+import org.jsoup.nodes.Element
+
+class V64__StripHideBylineFromSize extends HtmlMigration {
+  override val convertVisualElement: Boolean = false
+  override def convertHtml(doc: Element, language: String): Element = {
+    doc
+      .select("ndlaembed[data-resource='image']")
+      .forEach(embed => {
+        val hasSize = embed.hasAttr("data-size")
+        if (hasSize) {
+          if (embed.attr("data-size").endsWith("-hide-byline")) {
+            embed.attr("data-size", embed.attr("data-size").substring(0, embed.attr("data-size").indexOf("-"))): Unit
+          }
+          if (embed.attr("data-size").equals("fullbredde") || embed.attr("data-size").equals("fullwidth")) {
+            embed.attr("data-size", "full"): Unit
+          }
+        }
+      })
+    doc
+  }
+}

--- a/draft-api/src/test/scala/no/ndla/draftapi/db/migration/V64__StripHideBylineFromSizeTest.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/db/migration/V64__StripHideBylineFromSizeTest.scala
@@ -1,0 +1,65 @@
+/*
+ * Part of NDLA draft-api
+ * Copyright (C) 2024 NDLA
+ *
+ * See LICENSE
+ */
+
+package no.ndla.draftapi.db.migration
+
+import no.ndla.draftapi.{TestEnvironment, UnitSuite}
+
+class V64__StripHideBylineFromSizeTest extends UnitSuite with TestEnvironment {
+  test("That hide-byline is stripped from size") {
+    val migration = new V64__StripHideBylineFromSize
+    val full =
+      """<section><ndlaembed data-resource="image" data-resource_id="123" data-alt="Alt" data-caption="Caption" data-size="full" data-hide-byline="true" data-url="https://api.test.ndla.no/image-api/v2/images/123"></ndlaembed></section>"""
+    val medium =
+      """<section><ndlaembed data-resource="image" data-resource_id="123" data-alt="Alt" data-caption="Caption" data-size="medium" data-hide-byline="true" data-url="https://api.test.ndla.no/image-api/v2/images/123"></ndlaembed></section>"""
+
+    migration.convertContent(
+      """<section><ndlaembed data-resource="image" data-resource_id="123" data-alt="Alt" data-caption="Caption" data-size="full-hide-byline" data-hide-byline="true" data-url="https://api.test.ndla.no/image-api/v2/images/123"></ndlaembed></section>""",
+      "nb"
+    ) should be(full): Unit
+
+    migration.convertContent(
+      """<section><ndlaembed data-resource="image" data-resource_id="123" data-alt="Alt" data-caption="Caption" data-size="medium-hide-byline" data-hide-byline="true" data-url="https://api.test.ndla.no/image-api/v2/images/123"></ndlaembed></section>""",
+      "nb"
+    ) should be(medium): Unit
+
+    migration.convertContent(
+      """<section><ndlaembed data-resource="image" data-resource_id="123" data-alt="Alt" data-caption="Caption" data-size="full---hide-byline" data-hide-byline="true" data-url="https://api.test.ndla.no/image-api/v2/images/123"></ndlaembed></section>""",
+      "nb"
+    ) should be(full): Unit
+
+    migration.convertContent(
+      """<section><ndlaembed data-resource="image" data-resource_id="123" data-alt="Alt" data-caption="Caption" data-size="full-hide-byline--hide-byline" data-hide-byline="true" data-url="https://api.test.ndla.no/image-api/v2/images/123"></ndlaembed></section>""",
+      "nb"
+    ) should be(full): Unit
+
+    migration.convertContent(
+      """<section><ndlaembed data-resource="image" data-resource_id="123" data-alt="Alt" data-caption="Caption" data-size="medium-hide-byline--hide-byline" data-hide-byline="true" data-url="https://api.test.ndla.no/image-api/v2/images/123"></ndlaembed></section>""",
+      "nb"
+    ) should be(medium): Unit
+
+    migration.convertContent(
+      """<section><ndlaembed data-resource="image" data-resource_id="123" data-alt="Alt" data-caption="Caption" data-size="full---------hide-byline" data-hide-byline="true" data-url="https://api.test.ndla.no/image-api/v2/images/123"></ndlaembed></section>""",
+      "nb"
+    ) should be(full): Unit
+
+    migration.convertContent(
+      """<section><ndlaembed data-resource="image" data-resource_id="123" data-alt="Alt" data-caption="Caption" data-size="fullwidth-hide-byline" data-hide-byline="true" data-url="https://api.test.ndla.no/image-api/v2/images/123"></ndlaembed></section>""",
+      "nb"
+    ) should be(full): Unit
+
+    migration.convertContent(
+      """<section><ndlaembed data-resource="image" data-resource_id="123" data-alt="Alt" data-caption="Caption" data-size="fullwidth" data-hide-byline="true" data-url="https://api.test.ndla.no/image-api/v2/images/123"></ndlaembed></section>""",
+      "nb"
+    ) should be(full): Unit
+
+    migration.convertContent(
+      """<section><ndlaembed data-resource="image" data-resource_id="123" data-alt="Alt" data-caption="Caption" data-size="fullbredde" data-hide-byline="true" data-url="https://api.test.ndla.no/image-api/v2/images/123"></ndlaembed></section>""",
+      "nb"
+    ) should be(full): Unit
+  }
+}


### PR DESCRIPTION
Rydder opp i gamle verdier for size. I prod har vi disse variantene:
```
  - ""
  - "full-----hide-byline"
  - "full-hide-byline--hide-byline"
  - "full-------hide-byline"
  - "full"
  - "full---hide-byline"
  - "fullbredde"
  - "full--"
  - "full-hide-byline"
  - "fullwidth"
  - "medium"
  - "full--------hide-byline"
  - "full-"
  - "full------hide-byline"
  - "fullwidth-hide-byline"
  - "medium--hide-byline"
  - "full--hide-byline"
  - "full---"
  - "xsmall"
  - "full----hide-byline"
  - "medium-hide-byline--hide-byline"
  - "small"
  - "medium-hide-byline"

``` 