### PR TITLE
Stop updating taxonomy metadata on publish

### DIFF
--- a/draft-api/src/main/scala/no/ndla/draftapi/service/StateTransitionRules.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/service/StateTransitionRules.scala
@@ -95,11 +95,10 @@ trait StateTransitionRules {
               val h5pPaths = converterService.getEmbeddedH5PPaths(article)
               h5pApiClient.publishH5Ps(h5pPaths, user): Unit
 
-              val taxonomyT    = taxonomyApiClient.updateTaxonomyIfExists(id, article, user)
-              val taxMetadataT = taxonomyApiClient.updateTaxonomyMetadataIfExists(id, visible = true, user)
+              val taxonomyT = taxonomyApiClient.updateTaxonomyIfExists(id, article, user)
               val articleUdpT =
                 articleApiClient.updateArticle(id, article, externalIds, isImported, useSoftValidation, user)
-              val failures = Seq(taxonomyT, taxMetadataT, articleUdpT).collectFirst { case Failure(ex) =>
+              val failures = Seq(taxonomyT, articleUdpT).collectFirst { case Failure(ex) =>
                 Failure(ex)
               }
               failures.getOrElse(articleUdpT)

--- a/draft-api/src/main/scala/no/ndla/draftapi/service/StateTransitionRules.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/service/StateTransitionRules.scala
@@ -61,14 +61,7 @@ trait StateTransitionRules {
     private[service] val unpublishArticle: SideEffect =
       SideEffect.withDraftAndUser("unpublishArticle")((article: Draft, user: TokenUser) =>
         doIfArticleIsNotInUse(article.id.getOrElse(1), user) {
-          article.id match {
-            case Some(id) =>
-              val taxMetadataT = taxonomyApiClient.updateTaxonomyMetadataIfExists(id, visible = false, user)
-              val articleUpdT  = articleApiClient.unpublishArticle(article, user)
-              val failures     = Seq(taxMetadataT, articleUpdT).collectFirst { case Failure(ex) => Failure(ex) }
-              failures.getOrElse(articleUpdT)
-            case _ => Failure(NotFoundException("This is a bug, article to unpublish has no id."))
-          }
+          articleApiClient.unpublishArticle(article, user)
         }
       )
 


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/4227

Er det ikke litt uheldig egentlig?
Vil jo fremdeles publiseres så artiklene er jo fortsatt "live"?

Antar vi ikke vil ha motsatt også (at vi ikke setter visible = false på avpublisering)?