### PR TITLE
search-api: Stop returning 500 on whitespace only queries

### DIFF
--- a/network/src/main/scala/no/ndla/network/tapir/NonEmptyString.scala
+++ b/network/src/main/scala/no/ndla/network/tapir/NonEmptyString.scala
@@ -12,20 +12,26 @@ import io.circe.{Decoder, DecodingFailure, Encoder, FailedCursor, HCursor, Json}
 import sttp.tapir.CodecFormat.TextPlain
 import sttp.tapir.{Codec, CodecFormat, DecodeResult, Schema}
 
-/** Class that cannot be constructed with an empty string (""), therefore it means that if you have one of these the
-  * underlying string is not empty
+/** Class that cannot be constructed with an empty string ("") or a whitespace only string (" "), therefore it means
+  * that if you have one of these the underlying string is not empty.
   */
 class NonEmptyString private (val underlying: String) {
   override def equals(obj: Any): Boolean = obj match {
     case other: NonEmptyString => other.underlying == underlying
+    case other: String         => other == underlying
     case _                     => false
   }
 }
 
 object NonEmptyString {
-  def apply(underlying: String): Option[NonEmptyString]        = fromString(underlying)
-  def fromOptString(s: Option[String]): Option[NonEmptyString] = s.filter(_.nonEmpty).map(f => new NonEmptyString(f))
-  def fromString(s: String): Option[NonEmptyString]            = Option.when(s.nonEmpty)(new NonEmptyString(s))
+  def apply(underlying: String): Option[NonEmptyString] = fromString(underlying)
+
+  private def validateString(underlying: String): Boolean = underlying.trim.nonEmpty
+
+  def fromOptString(s: Option[String]): Option[NonEmptyString] =
+    s.filter(validateString).map(f => new NonEmptyString(f))
+  def fromString(s: String): Option[NonEmptyString] =
+    Option.when(validateString(s))(new NonEmptyString(s))
 
   implicit val schema: Schema[NonEmptyString]            = Schema.string
   implicit val schemaOpt: Schema[Option[NonEmptyString]] = Schema.string.asOption
@@ -60,7 +66,7 @@ object NonEmptyString {
 
   implicit def circeEncoder: Encoder[NonEmptyString] = (a: NonEmptyString) => Json.fromString(a.underlying)
 
-  /** Helpers that should make working with a bit `Option[NonEmptyString]` easier */
+  /** Helpers that should make working with `Option[NonEmptyString]` a bit easier */
   implicit class NonEmptyStringImplicit(self: Option[NonEmptyString]) {
     def underlying: Option[String]                   = self.map(_.underlying)
     def underlyingOrElse(default: => String): String = self.map(_.underlying).getOrElse(default)

--- a/network/src/test/scala/no/ndla/network/tapir/NonEmptyStringTest.scala
+++ b/network/src/test/scala/no/ndla/network/tapir/NonEmptyStringTest.scala
@@ -93,4 +93,21 @@ class NonEmptyStringTest extends UnitSuite {
     failure.message should be(NonEmptyString.parseErrorMessage)
   }
 
+  test("That comparisons works as expected") {
+    val a = NonEmptyString.fromString("hei").get
+    val b = NonEmptyString.fromString("hei").get
+    val c = NonEmptyString.fromString("hallo").get
+
+    a == b should be(true)
+    a == c should be(false)
+    a == "hei" should be(true)
+    a == "hallo" should be(false)
+  }
+
+  test("That only whitespace strings are not parsed as NonEmptyString") {
+    NonEmptyString.fromString(" ") should be(None)
+    NonEmptyString.fromString("  ") should be(None)
+    NonEmptyString.fromString("   ") should be(None)
+  }
+
 }


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/4233

Fikser det ved å ikke tillate whitespace only strenger i `NonEmptyString`. Navnet på `NonEmptyString` sier ikke noe om at bare whitespace ikke er lov, men jeg _antar_ at det aldri vil være nyttig for oss så vi løser det der tror jeg :smile: 