### PR TITLE
search-api: Use a case class for query parameters for GET `/search-api/v1/search`

### DIFF
--- a/concept-api/src/main/scala/no/ndla/conceptapi/service/search/SearchService.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/service/search/SearchService.scala
@@ -94,7 +94,7 @@ trait SearchService {
 
           resultArray.map(result => {
             val matchedLanguage = language match {
-              case AllLanguages | "*" =>
+              case AllLanguages =>
                 searchConverterService.getLanguageFromHit(result).getOrElse(language)
               case _ => language
             }

--- a/draft-api/src/main/scala/no/ndla/draftapi/service/search/SearchService.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/service/search/SearchService.scala
@@ -35,7 +35,7 @@ trait SearchService {
 
           resultArray.map(result => {
             val matchedLanguage = language match {
-              case Language.AllLanguages | "*" =>
+              case Language.AllLanguages =>
                 searchConverterService.getLanguageFromHit(result).getOrElse(language)
               case _ => language
             }
@@ -73,12 +73,12 @@ trait SearchService {
       sort match {
         case Sort.ByTitleAsc =>
           language match {
-            case "*" | Language.AllLanguages => fieldSort("defaultTitle").order(SortOrder.Asc).missing("_last")
+            case Language.AllLanguages => fieldSort("defaultTitle").order(SortOrder.Asc).missing("_last")
             case _ => fieldSort(s"title.$sortLanguage.raw").order(SortOrder.Asc).missing("_last").unmappedType("long")
           }
         case Sort.ByTitleDesc =>
           language match {
-            case "*" | Language.AllLanguages => fieldSort("defaultTitle").order(SortOrder.Desc).missing("_last")
+            case Language.AllLanguages => fieldSort("defaultTitle").order(SortOrder.Desc).missing("_last")
             case _ => fieldSort(s"title.$sortLanguage.raw").order(SortOrder.Desc).missing("_last").unmappedType("long")
           }
         case Sort.ByRelevanceAsc    => fieldSort("_score").order(SortOrder.Asc)

--- a/language/src/main/scala/no/ndla/language/Language.scala
+++ b/language/src/main/scala/no/ndla/language/Language.scala
@@ -6,7 +6,7 @@ object Language {
   val DefaultLanguage              = "nb"
   val UnknownLanguage: LanguageTag = LanguageTag("und")
   val NoLanguage                   = ""
-  val AllLanguages                 = "*"
+  final val AllLanguages           = "*"
   val Nynorsk                      = "nynorsk"
 
   val languagePriority: Seq[String] = Seq(

--- a/search-api/src/main/scala/no/ndla/searchapi/ComponentRegistry.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/ComponentRegistry.scala
@@ -15,6 +15,7 @@ import no.ndla.network.NdlaClient
 import no.ndla.network.clients.{FeideApiClient, MyNDLAApiClient, RedisClient}
 import no.ndla.network.tapir.TapirApplication
 import no.ndla.search.{BaseIndexService, Elastic4sClient}
+import no.ndla.searchapi.controller.parameters.GetSearchQueryParams
 import no.ndla.searchapi.controller.{InternController, SearchController, SwaggerDocControllerConfig}
 import no.ndla.searchapi.integration.*
 import no.ndla.searchapi.model.api.ErrorHandling
@@ -47,6 +48,7 @@ class ComponentRegistry(properties: SearchApiProperties)
     with MyNDLAApiClient
     with SearchService
     with SearchController
+    with GetSearchQueryParams
     with FeideApiClient
     with RedisClient
     with InternController

--- a/search-api/src/main/scala/no/ndla/searchapi/SearchApiProperties.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/SearchApiProperties.scala
@@ -54,7 +54,7 @@ class SearchApiProperties extends BaseProps with StrictLogging {
     case _                       => Failure(new IllegalArgumentException(s"Unknown index name: $indexName"))
   }
 
-  def DefaultPageSize                            = 10
+  final val DefaultPageSize                      = 10
   def MaxPageSize                                = 10000
   def IndexBulkSize: Int                         = propOrElse("INDEX_BULK_SIZE", "100").toInt
   def ElasticSearchIndexMaxResultWindow          = 10000

--- a/search-api/src/main/scala/no/ndla/searchapi/controller/parameters/GetSearchQueryParams.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/controller/parameters/GetSearchQueryParams.scala
@@ -107,9 +107,10 @@ trait GetSearchQueryParams {
       .derived[GetSearchQueryParams]
       .validate {
         Validator.custom {
-          case q if q.page < 1                         => Invalid("page must be greater than 0")
-          case q if q.pageSize < 1 || q.pageSize > 100 => Invalid("page-size must be between 1 and 100")
-          case _                                       => Valid
+          case q if q.page < 1 => Invalid("page must be greater than 0")
+          case q if q.pageSize < 1 || q.pageSize > props.MaxPageSize =>
+            Invalid(s"page-size must be between 1 and ${props.MaxPageSize}")
+          case _ => Valid
         }
       }
   }

--- a/search-api/src/main/scala/no/ndla/searchapi/controller/parameters/GetSearchQueryParams.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/controller/parameters/GetSearchQueryParams.scala
@@ -1,0 +1,116 @@
+/*
+ * Part of NDLA backend.search-api.main
+ * Copyright (C) 2024 NDLA
+ *
+ * See LICENSE
+ *
+ */
+
+package no.ndla.searchapi.controller.parameters
+
+import no.ndla.common.model.api.CommaSeparatedList.CommaSeparatedList
+import no.ndla.language.Language
+import no.ndla.network.tapir.NonEmptyString
+import no.ndla.searchapi.Props
+import sttp.tapir.*
+import sttp.tapir.EndpointIO.annotations.query
+import sttp.tapir.Schema.annotations.{default, description}
+import sttp.tapir.ValidationResult.{Invalid, Valid}
+
+trait GetSearchQueryParams {
+  this: Props =>
+
+  case class GetSearchQueryParams(
+      @query("page")
+      @description("The page number of the search hits to display.")
+      @default(1)
+      page: Int,
+      @query("page-size")
+      @description("The number of search hits to display for each page.")
+      @default(props.DefaultPageSize)
+      pageSize: Int,
+      @query("article-types")
+      @description("A comma separated list of article-types the search should be filtered by.")
+      articleTypes: CommaSeparatedList[String],
+      @query("context-types")
+      @description("A comma separated list of types the learning resources should be filtered by.")
+      contextTypes: CommaSeparatedList[String],
+      @query("language")
+      @description("The ISO 639-1 language code describing language.")
+      @default(Language.AllLanguages)
+      language: String,
+      @query("ids")
+      @description(
+        "Return only learning resources that have one of the provided ids. To provide multiple ids, separate by comma (,)."
+      )
+      learningResourceIds: CommaSeparatedList[Long],
+      @query("resource-types")
+      @description(
+        "Return only learning resources with specific taxonomy type(s), e.g. 'urn:resourcetype:learningpath'. To provide multiple types, separate by comma (,)."
+      )
+      resourceTypes: CommaSeparatedList[String],
+      @query("license")
+      @description("Return only results with provided license.")
+      license: Option[String],
+      @query("query")
+      @description("Return only results with content matching the specified query.")
+      @default(None)
+      queryParam: Option[NonEmptyString],
+      @query("sort")
+      @description("Sort the search results by the specified field.")
+      sort: Option[String],
+      @query("fallback")
+      @default(false)
+      @description("Fallback to existing language if language is specified.")
+      fallback: Boolean,
+      @query("subjects")
+      @description("A comma separated list of subjects the learning resources should be filtered by.")
+      subjects: CommaSeparatedList[String],
+      @query("language-filter")
+      @description("A comma separated list of ISO 639-1 language codes that the learning resource can be available in.")
+      languageFilter: CommaSeparatedList[String],
+      @query("relevance")
+      @description(
+        "A comma separated list of relevances the learning resources should be filtered by. If subjects are specified the learning resource must have specified relevances in relation to a specified subject. If levels are specified the learning resource must have specified relevances in relation to a specified level."
+      )
+      relevanceFilter: CommaSeparatedList[String],
+      @query("search-context")
+      @description("A unique string obtained from a search you want to keep scrolling in.")
+      scrollId: Option[String],
+      @query("grep-codes")
+      @description("A comma separated list of codes from GREP API the resources should be filtered by.")
+      grepCodes: CommaSeparatedList[String],
+      @query("aggregate-paths")
+      @description("List of index-paths that should be term-aggregated and returned in result.")
+      aggregatePaths: CommaSeparatedList[String],
+      @query("embed-resource")
+      @description(
+        "Return only results with embed data-resource the specified resource. Can specify multiple with a comma separated list to filter for one of the embed types."
+      )
+      embedResource: CommaSeparatedList[String],
+      @query("embed-id")
+      @description("Return only results with embed data-resource_id, data-videoid or data-url with the specified id.")
+      embedId: Option[String],
+      @query("filter-inactive")
+      @description("Filter out inactive taxonomy contexts.")
+      @default(false)
+      filterInactive: Boolean,
+      @query("traits")
+      @description("A comma separated list of traits the resources should be filtered by.")
+      traits: CommaSeparatedList[String]
+  )
+
+  object GetSearchQueryParams {
+    implicit val schema: Schema[GetSearchQueryParams]            = Schema.derived[GetSearchQueryParams]
+    implicit val schemaOpt: Schema[Option[GetSearchQueryParams]] = schema.asOption
+    def input = EndpointInput
+      .derived[GetSearchQueryParams]
+      .validate {
+        Validator.custom {
+          case q if q.page < 1                         => Invalid("page must be greater than 0")
+          case q if q.pageSize < 1 || q.pageSize > 100 => Invalid("page-size must be between 1 and 100")
+          case _                                       => Valid
+        }
+      }
+  }
+}

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/SearchService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/SearchService.scala
@@ -150,7 +150,7 @@ trait SearchService {
 
           resultArray.traverse(result => {
             val matchedLanguage = language match {
-              case Language.AllLanguages | "*" =>
+              case Language.AllLanguages =>
                 searchConverterService.getLanguageFromHit(result).getOrElse(language)
               case _ => language
             }

--- a/search-api/src/test/scala/no/ndla/searchapi/TestEnvironment.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/TestEnvironment.scala
@@ -14,6 +14,7 @@ import no.ndla.network.NdlaClient
 import no.ndla.network.clients.{FeideApiClient, MyNDLAApiClient, RedisClient}
 import no.ndla.network.tapir.TapirApplication
 import no.ndla.search.{BaseIndexService, Elastic4sClient}
+import no.ndla.searchapi.controller.parameters.GetSearchQueryParams
 import no.ndla.searchapi.controller.{InternController, SearchController}
 import no.ndla.searchapi.integration.*
 import no.ndla.searchapi.model.api.ErrorHandling
@@ -46,6 +47,7 @@ trait TestEnvironment
     with MyNDLAApiClient
     with SearchService
     with SearchController
+    with GetSearchQueryParams
     with GrepSearchService
     with LearningPathIndexService
     with InternController


### PR DESCRIPTION
Etter mye røring så har jeg skjønt hvordan vi kan gjøre dette, og det ble ikke _sååå_ krise engang.
Dette bør la oss ha mer enn 22 query parametere i fremtiden :nerd_face: 
