### PR TITLE
Only set hideByline if not already set

### DIFF
--- a/article-api/src/main/scala/no/ndla/articleapi/db/migrationwithdependencies/V55__SetHideBylineForImagesNotCopyrighted.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/db/migrationwithdependencies/V55__SetHideBylineForImagesNotCopyrighted.scala
@@ -19,10 +19,7 @@ trait V55__SetHideBylineForImagesNotCopyrighted {
       doc
         .select("ndlaembed[data-resource='image']")
         .forEach(embed => {
-          val noHideByline = !embed.hasAttr("data-hide-byline")
-          if (noHideByline) {
-            ids += embed.attr("data-resource_id")
-          }
+          ids += embed.attr("data-resource_id")
         })
       if (ids.result().isEmpty) {
         return doc
@@ -31,10 +28,16 @@ trait V55__SetHideBylineForImagesNotCopyrighted {
       doc
         .select("ndlaembed[data-resource='image']")
         .forEach(embed => {
-          val imageId = embed.attr("data-resource_id")
-          val image   = images.find(i => i.id == imageId)
-          embed
-            .attr("data-hide-byline", s"${image.exists(i => !i.copyright.license.license.equals("COPYRIGHTED"))}"): Unit
+          val noHideByline = !embed.hasAttr("data-hide-byline")
+          if (noHideByline) {
+            val imageId = embed.attr("data-resource_id")
+            val image   = images.find(i => i.id == imageId)
+            embed
+              .attr(
+                "data-hide-byline",
+                s"${image.exists(i => !i.copyright.license.license.equals("COPYRIGHTED"))}"
+              ): Unit
+          }
         })
       doc
     }

--- a/draft-api/src/main/scala/no/ndla/draftapi/db/migrationwithdependencies/V66__SetHideBylineForImagesNotCopyrighted.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/db/migrationwithdependencies/V66__SetHideBylineForImagesNotCopyrighted.scala
@@ -31,10 +31,7 @@ trait V66__SetHideBylineForImagesNotCopyrighted {
       doc
         .select("ndlaembed[data-resource='image']")
         .forEach(embed => {
-          val noHideByline = !embed.hasAttr("data-hide-byline")
-          if (noHideByline) {
-            ids += embed.attr("data-resource_id")
-          }
+          ids += embed.attr("data-resource_id")
         })
       if (ids.result().isEmpty) {
         return doc

--- a/draft-api/src/main/scala/no/ndla/draftapi/db/migrationwithdependencies/V66__SetHideBylineForImagesNotCopyrighted.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/db/migrationwithdependencies/V66__SetHideBylineForImagesNotCopyrighted.scala
@@ -43,10 +43,16 @@ trait V66__SetHideBylineForImagesNotCopyrighted {
       doc
         .select("ndlaembed[data-resource='image']")
         .forEach(embed => {
-          val imageId = embed.attr("data-resource_id")
-          val image   = images.find(i => i.id == imageId)
-          embed
-            .attr("data-hide-byline", s"${image.exists(i => !i.copyright.license.license.equals("COPYRIGHTED"))}"): Unit
+          val noHideByline = !embed.hasAttr("data-hide-byline")
+          if (noHideByline) {
+            val imageId = embed.attr("data-resource_id")
+            val image   = images.find(i => i.id == imageId)
+            embed
+              .attr(
+                "data-hide-byline",
+                s"${image.exists(i => !i.copyright.license.license.equals("COPYRIGHTED"))}"
+              ): Unit
+          }
         })
       doc
     }


### PR DESCRIPTION
Dette fikser en logisk feil i forrige versjon av migreringa. Det som skjedde då var at om hidebyline var satt så blei ikkje bildeid sendt til imageid, noko som førte til at hidebyline blei satt til false for bilder som var satt inn med hidebyline=true fordi images.find ikkje har bildet som sjekkes. 
Dette henter litt fleire bilder fra image-api, men oppdaterer kun dei som ikkje har verdien satt allerede.