### PR TITLE
Fix unstable typescript generation of `GrepResultDTO`

### DIFF
--- a/.github/workflows/typescript-generate.yml
+++ b/.github/workflows/typescript-generate.yml
@@ -4,7 +4,7 @@ on:
     inputs: { }
   push:
     branches:
-      - masteretannetnavnbecauseloop
+      - master
 env:
   AWS_ACCESS_KEY_ID: ${{ secrets.CI_AWS_CLIENT_ID }}
   AWS_DEFAULT_REGION: eu-west-1

--- a/search-api/src/test/scala/no/ndla/searchapi/model/api/grep/GrepResultDTOTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/model/api/grep/GrepResultDTOTest.scala
@@ -1,0 +1,30 @@
+/*
+ * Part of NDLA backend.search-api.test
+ * Copyright (C) 2025 NDLA
+ *
+ * See LICENSE
+ *
+ */
+
+package no.ndla.searchapi.model.api.grep
+
+import no.ndla.searchapi.UnitSuite
+import scala.reflect.runtime.universe.*
+
+class GrepResultDTOTest extends UnitSuite {
+
+  test("test that GrepResultDTO has typescript generation for all subclasses") {
+    val rtm        = runtimeMirror(getClass.getClassLoader)
+    val subclasses = rtm.staticClass("no.ndla.searchapi.model.api.grep.GrepResultDTO").knownDirectSubclasses
+    subclasses.size should be(5)
+    subclasses.foreach { subclass =>
+      val generatedType = GrepResultDTO.typescriptUnionTypes.find(_.name == s"I${subclass.name}")
+      if (generatedType.isEmpty)
+        fail(
+          s"Missing typescript type for ${subclass.name}. Please update `no.ndla.searchapi.model.api.grep.GrepResultDTO.typescriptUnionTypes`"
+        )
+    }
+
+  }
+
+}

--- a/typescript/types-backend/search-api.ts
+++ b/typescript/types-backend/search-api.ts
@@ -1,6 +1,6 @@
 // DO NOT EDIT: generated file by scala-tsi
 
-export type GrepResultDTO = (IGrepKompetansemaalSettDTO | IGrepKjerneelementDTO | IGrepLaererplanDTO | IGrepTverrfagligTemaDTO | IGrepKompetansemaalDTO)
+export type GrepResultDTO = (IGrepKjerneelementDTO | IGrepKompetansemaalDTO | IGrepKompetansemaalSettDTO | IGrepLaererplanDTO | IGrepTverrfagligTemaDTO)
 
 export type GrepSort = ("-relevance" | "relevance" | "-title" | "title" | "-code" | "code")
 


### PR DESCRIPTION
Virker som scala-tsi sin generering av sealed typer ikke er stabil som gjør at vi lager en evig loop med actions.
Tror dette vil bli stabilt nå, ved å generere unionen selv fremfor å lene oss på scala-tsi sin macro.