### PR TITLE
Convert `disclaimer` to new `OptLanguageFields` type

### DIFF
--- a/article-api/src/main/scala/no/ndla/articleapi/db/HtmlMigration.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/db/HtmlMigration.scala
@@ -28,7 +28,7 @@ abstract class HtmlMigration extends DocumentMigration {
     jsoupDocumentToString(converted)
   }
 
-  protected def convertColumn(document: String): String = {
+  def convertColumn(document: String): String = {
     val oldArticle = parser.parse(document).flatMap(_.as[Article]).toTry.get
     val convertedContent = oldArticle.content.map(c => {
       val converted = convertContent(c.content, c.language)

--- a/article-api/src/main/scala/no/ndla/articleapi/db/migration/V56__DisclaimerToLanguageFields.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/db/migration/V56__DisclaimerToLanguageFields.scala
@@ -1,0 +1,17 @@
+/*
+ * Part of NDLA article-api
+ * Copyright (C) 2025 NDLA
+ *
+ * See LICENSE
+ *
+ */
+
+package no.ndla.articleapi.db.migration
+
+import no.ndla.database.LanguageFieldMigration
+
+class V56__DisclaimerToLanguageFields extends LanguageFieldMigration {
+  override val columnName: String = "document"
+  override val tableName: String  = "contentdata"
+  override val fieldName: String  = "disclaimer"
+}

--- a/article-api/src/main/scala/no/ndla/articleapi/service/ConverterService.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/service/ConverterService.scala
@@ -260,8 +260,8 @@ trait ConverterService {
         val metaImage = findByLanguageOrBestEffort(article.metaImage, language).map(toApiArticleMetaImage)
         val copyright = toApiCopyright(article.copyright)
         val disclaimer = article.disclaimer
-          .flatMap(d => findByLanguageOrBestEffort(d, language))
-          .map(d => DisclaimerDTO(d.disclaimer, d.language))
+          .findByLanguageOrBestEffort(language)
+          .map(DisclaimerDTO.fromLanguageValue)
 
         Success(
           api.ArticleV2DTO(

--- a/article-api/src/test/scala/no/ndla/articleapi/TestData.scala
+++ b/article-api/src/test/scala/no/ndla/articleapi/TestData.scala
@@ -15,6 +15,7 @@ import no.ndla.common.model
 import no.ndla.common.model.NDLADate
 import no.ndla.common.model.domain.article.{Article, Copyright}
 import no.ndla.common.model.domain.*
+import no.ndla.common.model.domain.language.OptLanguageFields
 import no.ndla.mapping.License
 
 trait TestData {
@@ -155,7 +156,7 @@ trait TestData {
       relatedContent = Seq.empty,
       revisionDate = Some(NDLADate.now().withNano(0)),
       slug = None,
-      disclaimer = None
+      disclaimer = OptLanguageFields.empty
     )
 
     val sampleDomainArticle: Article = Article(
@@ -181,7 +182,7 @@ trait TestData {
       relatedContent = Seq.empty,
       revisionDate = None,
       slug = None,
-      disclaimer = None
+      disclaimer = OptLanguageFields.empty
     )
 
     val sampleDomainArticle2: Article = Article(
@@ -207,7 +208,7 @@ trait TestData {
       relatedContent = Seq.empty,
       revisionDate = None,
       slug = None,
-      disclaimer = None
+      disclaimer = OptLanguageFields.empty
     )
 
     val sampleArticleWithByNcSa: Article      = sampleArticleWithPublicDomain.copy(copyright = byNcSaCopyright)
@@ -245,7 +246,7 @@ trait TestData {
       relatedContent = Seq.empty,
       revisionDate = None,
       slug = None,
-      disclaimer = None
+      disclaimer = OptLanguageFields.empty
     )
 
     val apiArticleWithHtmlFaultV2: api.ArticleV2DTO = api.ArticleV2DTO(
@@ -316,7 +317,7 @@ trait TestData {
         relatedContent = Seq.empty,
         revisionDate = None,
         slug = None,
-        disclaimer = None
+        disclaimer = OptLanguageFields.empty
       )
     }
 

--- a/article-api/src/test/scala/no/ndla/articleapi/db/migration/V55__DisclaimerToLanguageFieldsTest.scala
+++ b/article-api/src/test/scala/no/ndla/articleapi/db/migration/V55__DisclaimerToLanguageFieldsTest.scala
@@ -1,0 +1,37 @@
+/*
+ * Part of NDLA article-api
+ * Copyright (C) 2024 NDLA
+ *
+ * See LICENSE
+ */
+
+package no.ndla.articleapi.db.migration
+
+import no.ndla.articleapi.{TestEnvironment, UnitSuite}
+
+class V55__DisclaimerToLanguageFieldsTest extends UnitSuite with TestEnvironment {
+  test("That old disclaimers are migrated to new language fields") {
+    val oldDocument =
+      """{"disclaimer":[{"disclaimer":"Dette er bokmål","language":"nb"},{"disclaimer":"Dette er nynorsk","language":"nn"}]}"""
+    val expectedResult = """{"disclaimer":{"nb":"Dette er bokmål","nn":"Dette er nynorsk"}}"""
+    val migration      = new V56__DisclaimerToLanguageFields
+    val result         = migration.convertColumn(oldDocument)
+    result should be(expectedResult)
+  }
+
+  test("That no old disclaimers are migrated to new language fields") {
+    val oldDocument    = """{}"""
+    val expectedResult = """{"disclaimer":{}}"""
+    val migration      = new V56__DisclaimerToLanguageFields
+    val result         = migration.convertColumn(oldDocument)
+    result should be(expectedResult)
+  }
+
+  test("That null disclaimers are migrated to new language fields") {
+    val oldDocument    = """{"disclaimer":null}"""
+    val expectedResult = """{"disclaimer":{}}"""
+    val migration      = new V56__DisclaimerToLanguageFields
+    val result         = migration.convertColumn(oldDocument)
+    result should be(expectedResult)
+  }
+}

--- a/article-api/src/test/scala/no/ndla/articleapi/validation/ContentValidatorTest.scala
+++ b/article-api/src/test/scala/no/ndla/articleapi/validation/ContentValidatorTest.scala
@@ -15,13 +15,13 @@ import no.ndla.common.model.domain.{
   ArticleMetaImage,
   Author,
   Description,
-  Disclaimer,
   Introduction,
   RequiredLibrary,
   Tag,
   Title
 }
 import no.ndla.common.model.domain.article.Copyright
+import no.ndla.common.model.domain.language.OptLanguageFields
 import no.ndla.mapping.License.{CC_BY_SA, NA}
 
 import scala.util.Failure
@@ -83,7 +83,7 @@ class ContentValidatorTest extends UnitSuite with TestEnvironment {
   test("validateArticle should throw an error if disclaimer contains illegal HTML tags") {
     val article = TestData.sampleArticleWithByNcSa.copy(
       content = Seq(ArticleContent(validDocument, "nb")),
-      disclaimer = Some(Seq(Disclaimer("<p><hallo>hei</hallo></p>", "nb")))
+      disclaimer = OptLanguageFields.withValue("<p><hallo>hei</hallo></p>", "nb")
     )
 
     val Failure(error: ValidationException) = contentValidator.validateArticle(article, false)
@@ -98,14 +98,7 @@ class ContentValidatorTest extends UnitSuite with TestEnvironment {
   test("validateArticle should not throw an error if disclaimer contains legal HTML tags") {
     val article = TestData.sampleArticleWithByNcSa.copy(
       content = Seq(ArticleContent(validDocument, "nb")),
-      disclaimer = Some(
-        Seq(
-          Disclaimer(
-            validDisclaimer,
-            "nb"
-          )
-        )
-      )
+      disclaimer = OptLanguageFields.withValue(validDisclaimer, "nb")
     )
     contentValidator.validateArticle(article, false).isSuccess should be(true)
   }
@@ -113,7 +106,7 @@ class ContentValidatorTest extends UnitSuite with TestEnvironment {
   test("validateArticle should not throw an error if disclaimer contains plain text") {
     val article = TestData.sampleArticleWithByNcSa.copy(
       content = Seq(ArticleContent(validDocument, "nb")),
-      disclaimer = Some(Seq(Disclaimer("disclaimer", "nb")))
+      disclaimer = OptLanguageFields.withValue("disclaimer", "nb")
     )
     contentValidator.validateArticle(article, false).isSuccess should be(true)
   }

--- a/audio-api/src/test/scala/no/ndla/audioapi/service/WriteServiceTest.scala
+++ b/audio-api/src/test/scala/no/ndla/audioapi/service/WriteServiceTest.scala
@@ -404,7 +404,7 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
 
     val result = writeService.updateAudio(1, updatedAudioMeta, Some(mock[UploadedFile]), testUser)
     result.isFailure should be(true)
-    result.failed.get.getMessage should equal(new ValidationException(errors = Seq()).getMessage)
+    result.failed.get.getMessage should equal(new ValidationException(errors = Seq(validationMessage)).getMessage)
   }
 
   test("that updateAudio returns Failure when audio upload fails") {

--- a/common/src/main/scala/no/ndla/common/errors/ValidationException.scala
+++ b/common/src/main/scala/no/ndla/common/errors/ValidationException.scala
@@ -8,11 +8,18 @@
 
 package no.ndla.common.errors
 
+import no.ndla.common.errors.ValidationException.formatError
+
 case class ValidationException(
     message: String = "Validation Error",
     errors: Seq[ValidationMessage]
-) extends RuntimeException(message)
+) extends RuntimeException(formatError(message, errors))
 
 object ValidationException {
   def apply(path: String, msg: String) = new ValidationException(errors = Seq(ValidationMessage(path, msg)))
+
+  def formatError(message: String, errors: Seq[ValidationMessage]): String = {
+    if (errors.nonEmpty) s"$message:\n${errors.map(e => s"\t${e.field}: ${e.message}").mkString("\n")}"
+    else message
+  }
 }

--- a/common/src/main/scala/no/ndla/common/model/api/DisclaimerDTO.scala
+++ b/common/src/main/scala/no/ndla/common/model/api/DisclaimerDTO.scala
@@ -10,6 +10,7 @@ package no.ndla.common.model.api
 
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
 import io.circe.{Decoder, Encoder}
+import no.ndla.language.model.WithLanguageAndValue
 import sttp.tapir.Schema.annotations.description
 
 case class DisclaimerDTO(
@@ -18,6 +19,8 @@ case class DisclaimerDTO(
 )
 
 object DisclaimerDTO {
+  def fromLanguageValue(lv: WithLanguageAndValue[String]): DisclaimerDTO = DisclaimerDTO(lv.value, lv.language)
+
   implicit def encoder: Encoder[DisclaimerDTO] = deriveEncoder
   implicit def decoder: Decoder[DisclaimerDTO] = deriveDecoder
 }

--- a/common/src/main/scala/no/ndla/common/model/domain/article/Article.scala
+++ b/common/src/main/scala/no/ndla/common/model/domain/article/Article.scala
@@ -11,8 +11,9 @@ package no.ndla.common.model.domain.article
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
 import io.circe.{Decoder, Encoder}
 import no.ndla.common.model.{NDLADate, RelatedContentLink}
-import no.ndla.common.model.domain._
-import no.ndla.common.implicits._
+import no.ndla.common.model.domain.*
+import no.ndla.common.implicits.*
+import no.ndla.common.model.domain.language.OptLanguageFields
 
 case class Article(
     id: Option[Long],
@@ -37,7 +38,7 @@ case class Article(
     relatedContent: Seq[RelatedContent],
     revisionDate: Option[NDLADate],
     slug: Option[String],
-    disclaimer: Option[Seq[Disclaimer]]
+    disclaimer: OptLanguageFields[String]
 ) extends Content
 
 object Article {

--- a/common/src/main/scala/no/ndla/common/model/domain/draft/Draft.scala
+++ b/common/src/main/scala/no/ndla/common/model/domain/draft/Draft.scala
@@ -51,7 +51,16 @@ case class Draft(
 ) extends Content {
 
   def supportedLanguages: Seq[String] =
-    getSupportedLanguages(title, visualElement, introduction, metaDescription, tags, content, metaImage)
+    getSupportedLanguages(
+      title,
+      visualElement,
+      introduction,
+      metaDescription,
+      tags,
+      content,
+      metaImage,
+      disclaimer.getWithLanguageFields
+    )
 }
 
 object Draft {

--- a/common/src/main/scala/no/ndla/common/model/domain/draft/Draft.scala
+++ b/common/src/main/scala/no/ndla/common/model/domain/draft/Draft.scala
@@ -9,9 +9,10 @@ package no.ndla.common.model.domain.draft
 
 import io.circe.{Decoder, Encoder}
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
-import no.ndla.common.implicits._
+import no.ndla.common.implicits.*
 import no.ndla.common.model.{NDLADate, RelatedContentLink}
-import no.ndla.common.model.domain._
+import no.ndla.common.model.domain.*
+import no.ndla.common.model.domain.language.OptLanguageFields
 import no.ndla.language.Language.getSupportedLanguages
 
 case class Draft(
@@ -46,7 +47,7 @@ case class Draft(
     priority: Priority,
     started: Boolean,
     qualityEvaluation: Option[QualityEvaluation],
-    disclaimer: Option[Seq[Disclaimer]]
+    disclaimer: OptLanguageFields[String]
 ) extends Content {
 
   def supportedLanguages: Seq[String] =

--- a/common/src/main/scala/no/ndla/common/model/domain/language/LanguageFields.scala
+++ b/common/src/main/scala/no/ndla/common/model/domain/language/LanguageFields.scala
@@ -1,0 +1,40 @@
+/*
+ * Part of NDLA backend.common.main
+ * Copyright (C) 2025 NDLA
+ *
+ * See LICENSE
+ *
+ */
+
+package no.ndla.common.model.domain.language
+
+import io.circe.*
+import io.circe.syntax.EncoderOps
+import no.ndla.language.Language
+import no.ndla.language.model.{BaseWithLanguageAndValue, WithLanguageAndValue}
+
+case class LanguageFields[T: Encoder: Decoder](internal: Map[String, T]) {
+  def getWithLanguageFields: Seq[WithLanguageAndValue[T]] = internal.map { case (language, value) =>
+    BaseWithLanguageAndValue(language, value)
+  }.toSeq
+  def get(language: String): Option[WithLanguageAndValue[T]] =
+    internal.get(language).map(BaseWithLanguageAndValue(language, _))
+  def findByLanguageOrBestEffort(language: String): Option[WithLanguageAndValue[T]] =
+    Language.findByLanguageOrBestEffort(getWithLanguageFields, language)
+}
+
+object LanguageFields {
+  def empty[T: Encoder: Decoder]: LanguageFields[T] = LanguageFields(Map.empty)
+  def fromFields[T](
+      fields: Seq[WithLanguageAndValue[T]]
+  )(implicit encoder: Encoder[T], decoder: Decoder[T]): LanguageFields[T] = {
+    val underlyingMap = fields.map(f => f.language -> f.value).toMap
+    LanguageFields(underlyingMap)
+  }
+
+  implicit def encoder[T: Encoder]: Encoder[LanguageFields[T]] = Encoder.instance { lf => lf.internal.asJson }
+  implicit def decoder[T: Decoder: Encoder]: Decoder[LanguageFields[T]] = Decoder.instance { json =>
+    json.as[Map[String, T]].map { m => LanguageFields(m) }
+
+  }
+}

--- a/common/src/main/scala/no/ndla/common/model/domain/language/LanguageFields.scala
+++ b/common/src/main/scala/no/ndla/common/model/domain/language/LanguageFields.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA backend.common.main
+ * Part of NDLA common
  * Copyright (C) 2025 NDLA
  *
  * See LICENSE
@@ -13,7 +13,7 @@ import io.circe.syntax.EncoderOps
 import no.ndla.language.Language
 import no.ndla.language.model.{BaseWithLanguageAndValue, WithLanguageAndValue}
 
-case class LanguageFields[T: Encoder: Decoder](internal: Map[String, T]) {
+case class LanguageFields[T](internal: Map[String, T]) {
   def getWithLanguageFields: Seq[WithLanguageAndValue[T]] = internal.map { case (language, value) =>
     BaseWithLanguageAndValue(language, value)
   }.toSeq
@@ -24,16 +24,14 @@ case class LanguageFields[T: Encoder: Decoder](internal: Map[String, T]) {
 }
 
 object LanguageFields {
-  def empty[T: Encoder: Decoder]: LanguageFields[T] = LanguageFields(Map.empty)
-  def fromFields[T](
-      fields: Seq[WithLanguageAndValue[T]]
-  )(implicit encoder: Encoder[T], decoder: Decoder[T]): LanguageFields[T] = {
+  def empty[T]: LanguageFields[T] = LanguageFields(Map.empty)
+  def fromFields[T](fields: Seq[WithLanguageAndValue[T]]): LanguageFields[T] = {
     val underlyingMap = fields.map(f => f.language -> f.value).toMap
     LanguageFields(underlyingMap)
   }
 
   implicit def encoder[T: Encoder]: Encoder[LanguageFields[T]] = Encoder.instance { lf => lf.internal.asJson }
-  implicit def decoder[T: Decoder: Encoder]: Decoder[LanguageFields[T]] = Decoder.instance { json =>
+  implicit def decoder[T: Decoder]: Decoder[LanguageFields[T]] = Decoder.instance { json =>
     json.as[Map[String, T]].map { m => LanguageFields(m) }
 
   }

--- a/common/src/main/scala/no/ndla/common/model/domain/language/OptLanguageFields.scala
+++ b/common/src/main/scala/no/ndla/common/model/domain/language/OptLanguageFields.scala
@@ -67,6 +67,11 @@ case class OptLanguageFields[T: Encoder: Decoder](
     val updated: Map[String, Either[NotWantedKeyT, Option[T]]] = internal.updated(language, Right(Some(value)))
     OptLanguageFields(updated)
   }
+
+  def dropLanguage(language: String): OptLanguageFields[T] = {
+    val newInternal = internal.removed(language)
+    OptLanguageFields(newInternal)
+  }
 }
 
 object OptLanguageFields {

--- a/common/src/main/scala/no/ndla/common/model/domain/language/OptLanguageFields.scala
+++ b/common/src/main/scala/no/ndla/common/model/domain/language/OptLanguageFields.scala
@@ -1,0 +1,70 @@
+/*
+ * Part of NDLA backend.common.main
+ * Copyright (C) 2025 NDLA
+ *
+ * See LICENSE
+ *
+ */
+
+package no.ndla.common.model.domain.language
+
+import io.circe.syntax.EncoderOps
+import io.circe.{Decoder, Encoder, Json}
+import no.ndla.common.model.domain.language.OptionalLanguageValue.{NotWantedKey, NotWantedKeyT}
+import no.ndla.language.model.WithLanguageAndValue
+
+case class OptLanguageFields[T: Encoder: Decoder](
+    internal: Map[String, Either[NotWantedKeyT, Option[T]]]
+) {
+  def get(language: String): Option[OptionalLanguageValue[T]] = {
+    val res = internal.get(language)
+    res match {
+      case None                     => None
+      case Some(Right(Some(value))) => Some(Exists(value))
+      case Some(Right(None))        => None
+      case Some(Left(_))            => Some(NotWanted())
+    }
+  }
+
+  def withUnwanted(language: String): OptLanguageFields[T] = {
+    val updated: Map[String, Either[NotWantedKeyT, Option[T]]] = internal.updated(language, Left(NotWantedKey))
+    OptLanguageFields(updated)
+  }
+}
+
+object OptLanguageFields {
+
+  def fromFields[T](
+      fields: Seq[WithLanguageAndValue[T]]
+  )(implicit encoder: Encoder[T], decoder: Decoder[T]): OptLanguageFields[T] = {
+    val underlyingMap = fields.map(f => f.language -> Right(Some(f.value))).toMap
+    OptLanguageFields(underlyingMap)
+  }
+
+  implicit def eitherEncoder[T](implicit e: Encoder[T]): Encoder[Either[NotWantedKeyT, Option[T]]] = Encoder.instance {
+    case Right(value) => value.asJson
+    case Left(_)      => Json.obj(NotWantedKey -> Json.True)
+  }
+
+  implicit def eitherDecoder[T](implicit d: Decoder[T]): Decoder[Either[NotWantedKeyT, Option[T]]] = Decoder.instance {
+    cursor =>
+      val x              = cursor.downField(NotWantedKey)
+      val notWantedField = x.as[Option[Boolean]]
+      notWantedField match {
+        case Right(Some(true)) =>
+          Right(Left(NotWantedKey))
+        case _ =>
+          cursor.as[Option[T]].map(Right(_))
+      }
+  }
+
+  implicit def encoder[T: Encoder]: Encoder[OptLanguageFields[T]] = Encoder.instance { lf =>
+    lf.internal.asJson
+  }
+
+  implicit def decoder[T: Decoder: Encoder]: Decoder[OptLanguageFields[T]] = Decoder.instance { json =>
+    json.as[Map[String, Either[NotWantedKeyT, Option[T]]]].map { m =>
+      OptLanguageFields(m)
+    }
+  }
+}

--- a/common/src/main/scala/no/ndla/common/model/domain/language/OptLanguageFields.scala
+++ b/common/src/main/scala/no/ndla/common/model/domain/language/OptLanguageFields.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA backend.common.main
+ * Part of NDLA common
  * Copyright (C) 2025 NDLA
  *
  * See LICENSE
@@ -11,11 +11,14 @@ package no.ndla.common.model.domain.language
 import io.circe.syntax.EncoderOps
 import io.circe.{Decoder, Encoder, Json}
 import no.ndla.common.model.domain.language.OptionalLanguageValue.{NotWantedKey, NotWantedKeyT}
-import no.ndla.language.model.WithLanguageAndValue
+import no.ndla.language.Language
+import no.ndla.language.model.{BaseWithLanguageAndValue, WithLanguageAndValue}
+import sttp.tapir.Schema
 
 case class OptLanguageFields[T: Encoder: Decoder](
     internal: Map[String, Either[NotWantedKeyT, Option[T]]]
 ) {
+
   def get(language: String): Option[OptionalLanguageValue[T]] = {
     val res = internal.get(language)
     res match {
@@ -26,13 +29,81 @@ case class OptLanguageFields[T: Encoder: Decoder](
     }
   }
 
+  def map[R](f: WithLanguageAndValue[Option[T]] => R): Seq[R] = internal.map { case (language, value) =>
+    value match {
+      case Right(Some(value)) => f(BaseWithLanguageAndValue(language, Some(value)))
+      case _                  => f(BaseWithLanguageAndValue(language, None))
+    }
+  }.toSeq
+
+  def mapExisting[R](f: WithLanguageAndValue[T] => R): Seq[R] = internal.flatMap { case (language, value) =>
+    value match {
+      case Right(Some(value)) => Some(f(BaseWithLanguageAndValue(language, value)))
+      case _                  => None
+    }
+  }.toSeq
+
+  def getWithLanguageFields: Seq[WithLanguageAndValue[T]] = internal.flatMap { case (language, value) =>
+    value match {
+      case Right(Some(value)) => Some(BaseWithLanguageAndValue(language, value))
+      case _                  => None
+    }
+  }.toSeq
+
+  def findByLanguageOrBestEffort(language: String): Option[WithLanguageAndValue[T]] = {
+    get(language) match {
+      case Some(Exists(value)) => Some(BaseWithLanguageAndValue(language, value))
+      case Some(NotWanted())   => None
+      case None                => Language.findByLanguageOrBestEffort(getWithLanguageFields, language)
+    }
+  }
+
   def withUnwanted(language: String): OptLanguageFields[T] = {
     val updated: Map[String, Either[NotWantedKeyT, Option[T]]] = internal.updated(language, Left(NotWantedKey))
+    OptLanguageFields(updated)
+  }
+
+  def withValue(value: T, language: String): OptLanguageFields[T] = {
+    val updated: Map[String, Either[NotWantedKeyT, Option[T]]] = internal.updated(language, Right(Some(value)))
     OptLanguageFields(updated)
   }
 }
 
 object OptLanguageFields {
+  implicit val s1: Schema[OptLanguageFields[String]] = Schema.any
+
+  def withUnwanted[T: Encoder: Decoder](language: String): OptLanguageFields[T] = {
+    val underlyingMap = Map(language -> Left(NotWantedKey))
+    OptLanguageFields(underlyingMap)
+  }
+
+  def withValue[T: Encoder: Decoder](value: T, language: String): OptLanguageFields[T] = {
+    val underlyingMap = Map(language -> Right(Some(value)))
+    OptLanguageFields(underlyingMap)
+  }
+
+  implicit class optStringLanguageFields(s: OptLanguageFields[String]) {
+    def withOptValue(value: Option[String], language: String): OptLanguageFields[String] = {
+      value match {
+        case Some("") => s.withUnwanted(language)
+        case Some(v)  => s.withValue(v, language)
+        case None     => this.s
+      }
+    }
+
+    def withOptValue(value: Option[String], language: Option[String]): OptLanguageFields[String] = language match {
+      case None       => this.s
+      case Some(lang) => this.withOptValue(value, lang)
+    }
+  }
+
+  def fromMaybeString(value: Option[String], language: String): OptLanguageFields[String] = {
+    value match {
+      case Some("") => withUnwanted(language)
+      case Some(v)  => withValue(v, language)
+      case None     => empty
+    }
+  }
 
   def fromFields[T](
       fields: Seq[WithLanguageAndValue[T]]
@@ -40,6 +111,8 @@ object OptLanguageFields {
     val underlyingMap = fields.map(f => f.language -> Right(Some(f.value))).toMap
     OptLanguageFields(underlyingMap)
   }
+
+  def empty[T: Encoder: Decoder]: OptLanguageFields[T] = OptLanguageFields(Map.empty)
 
   implicit def eitherEncoder[T](implicit e: Encoder[T]): Encoder[Either[NotWantedKeyT, Option[T]]] = Encoder.instance {
     case Right(value) => value.asJson

--- a/common/src/main/scala/no/ndla/common/model/domain/language/OptionalLanguageValue.scala
+++ b/common/src/main/scala/no/ndla/common/model/domain/language/OptionalLanguageValue.scala
@@ -10,20 +10,22 @@ package no.ndla.common.model.domain.language
 
 import io.circe.syntax.EncoderOps
 import io.circe.{Decoder, Encoder, HCursor, Json}
+import sttp.tapir.Schema
 
 sealed trait OptionalLanguageValue[T]
-case class Exists[T: Encoder: Decoder](value: T) extends OptionalLanguageValue[T]
-case class NotWanted[T]()                        extends OptionalLanguageValue[T]
+case class Exists[T](value: T) extends OptionalLanguageValue[T]
+case class NotWanted[T]()      extends OptionalLanguageValue[T]
 
 object OptionalLanguageValue {
   type NotWantedKeyT = "__notwanted__"
-  final val NotWantedKey = "__notwanted__"
+  final val NotWantedKey: NotWantedKeyT               = "__notwanted__"
+  implicit val NotWantedSchema: Schema[NotWantedKeyT] = Schema.string
   implicit def encoder[T](implicit valueEncoder: Encoder[T]): Encoder[OptionalLanguageValue[T]] = Encoder.instance {
     case Exists(value) => Json.obj("value" -> value.asJson)
     case NotWanted()   => Json.obj(NotWantedKey -> Json.True)
   }
 
-  implicit def decoder[T: Encoder: Decoder]: Decoder[OptionalLanguageValue[T]] =
+  implicit def decoder[T: Decoder]: Decoder[OptionalLanguageValue[T]] =
     (c: HCursor) => {
       c.downField(NotWantedKey).as[Option[Boolean]].flatMap {
         case Some(true) => Right(NotWanted())

--- a/common/src/main/scala/no/ndla/common/model/domain/language/OptionalLanguageValue.scala
+++ b/common/src/main/scala/no/ndla/common/model/domain/language/OptionalLanguageValue.scala
@@ -1,0 +1,36 @@
+/*
+ * Part of NDLA common
+ * Copyright (C) 2025 NDLA
+ *
+ * See LICENSE
+ *
+ */
+
+package no.ndla.common.model.domain.language
+
+import io.circe.syntax.EncoderOps
+import io.circe.{Decoder, Encoder, HCursor, Json}
+
+sealed trait OptionalLanguageValue[T]
+case class Exists[T: Encoder: Decoder](value: T) extends OptionalLanguageValue[T]
+case class NotWanted[T]()                        extends OptionalLanguageValue[T]
+
+object OptionalLanguageValue {
+  type NotWantedKeyT = "__notwanted__"
+  final val NotWantedKey = "__notwanted__"
+  implicit def encoder[T](implicit valueEncoder: Encoder[T]): Encoder[OptionalLanguageValue[T]] = Encoder.instance {
+    case Exists(value) => Json.obj("value" -> value.asJson)
+    case NotWanted()   => Json.obj(NotWantedKey -> Json.True)
+  }
+
+  implicit def decoder[T: Encoder: Decoder]: Decoder[OptionalLanguageValue[T]] =
+    (c: HCursor) => {
+      c.downField(NotWantedKey).as[Option[Boolean]].flatMap {
+        case Some(true) => Right(NotWanted())
+        case _ =>
+          val field  = c.downField("value")
+          val parsed = field.as[T]
+          parsed.map(value => Exists(value))
+      }
+    }
+}

--- a/common/src/test/scala/no/ndla/common/model/domain/LanguageFieldsTest.scala
+++ b/common/src/test/scala/no/ndla/common/model/domain/LanguageFieldsTest.scala
@@ -1,0 +1,81 @@
+/*
+ * Part of NDLA common
+ * Copyright (C) 2025 NDLA
+ *
+ * See LICENSE
+ *
+ */
+
+package no.ndla.common.model.domain
+
+import no.ndla.common.CirceUtil
+import no.ndla.common.model.domain.language.*
+import no.ndla.language.model.BaseWithLanguageAndValue
+import no.ndla.scalatestsuite.UnitTestSuite
+
+class LanguageFieldsTest extends UnitTestSuite {
+
+  test("That language fields serialize and deserialize as expected") {
+    import io.circe.syntax.*
+    val fields = Seq(
+      BaseWithLanguageAndValue("nb", "bokmål"),
+      BaseWithLanguageAndValue("nn", "nynorsk"),
+      BaseWithLanguageAndValue("en", "english")
+    )
+
+    val languageFields = LanguageFields.fromFields(fields)
+    val jsonString     = languageFields.asJson.noSpaces
+    val result         = CirceUtil.unsafeParseAs[LanguageFields[String]](jsonString)
+
+    result should be(languageFields)
+  }
+
+  test("That language fields are found by language or best effort according to language priority") {
+    val fields = Seq(
+      BaseWithLanguageAndValue("nb", "bokmål"),
+      BaseWithLanguageAndValue("nn", "nynorsk"),
+      BaseWithLanguageAndValue("en", "english")
+    )
+
+    val languageFields = LanguageFields.fromFields(fields)
+
+    languageFields.findByLanguageOrBestEffort("nb") should be(Some(BaseWithLanguageAndValue("nb", "bokmål")))
+    languageFields.findByLanguageOrBestEffort("sma") should be(Some(BaseWithLanguageAndValue("nb", "bokmål")))
+    languageFields.findByLanguageOrBestEffort("nn") should be(Some(BaseWithLanguageAndValue("nn", "nynorsk")))
+  }
+
+  test("That the LanguageFields type is able to differentiate between a missing and not needed field") {
+
+    val fields = Seq(
+      BaseWithLanguageAndValue[OptionalLanguageValue[String]]("nb", Exists("bokmål")),
+      BaseWithLanguageAndValue[OptionalLanguageValue[String]]("nn", NotWanted())
+    )
+
+    val languageFields = LanguageFields.fromFields(fields)
+    val jsonString     = CirceUtil.toJsonString(languageFields)
+
+    val result = CirceUtil.unsafeParseAs[LanguageFields[OptionalLanguageValue[String]]](jsonString)
+    result should be(languageFields)
+
+    result.get("nb") should be(Some(BaseWithLanguageAndValue("nb", Exists("bokmål"))))
+    result.get("nn") should be(Some(BaseWithLanguageAndValue("nn", NotWanted())))
+  }
+
+  test("That the OptLanguageFields type is able to differentiate between a missing and not needed field") {
+
+    val fields = Seq(
+      BaseWithLanguageAndValue[String]("nb", "bokmål")
+    )
+
+    val languageFields = OptLanguageFields.fromFields(fields).withUnwanted("en")
+    val jsonString     = CirceUtil.toJsonString(languageFields)
+
+    val result = CirceUtil.unsafeParseAs[OptLanguageFields[String]](jsonString)
+    result should be(languageFields)
+
+    result.get("nb") should be(Some(Exists("bokmål")))
+    result.get("nn") should be(None)
+    result.get("en") should be(Some(NotWanted()))
+  }
+
+}

--- a/database/src/main/scala/no/ndla/database/DocumentMigration.scala
+++ b/database/src/main/scala/no/ndla/database/DocumentMigration.scala
@@ -32,5 +32,5 @@ abstract class DocumentMigration extends TableMigration[DocumentRow] {
       .update()
   }
 
-  protected def convertColumn(value: String): String
+  def convertColumn(value: String): String
 }

--- a/database/src/main/scala/no/ndla/database/LanguageFieldMigration.scala
+++ b/database/src/main/scala/no/ndla/database/LanguageFieldMigration.scala
@@ -1,0 +1,41 @@
+/*
+ * Part of NDLA database
+ * Copyright (C) 2025 NDLA
+ *
+ * See LICENSE
+ *
+ */
+
+package no.ndla.database
+
+import io.circe.{Json, parser}
+
+abstract class LanguageFieldMigration extends DocumentMigration {
+  protected def fieldName: String
+  protected def oldSubfieldName: String = fieldName
+
+  private def convertOldLanguageField(fields: Vector[Json]): Json = {
+    fields.foldLeft(Json.obj()) { (acc, disclaimer) =>
+      val language = disclaimer.hcursor.downField("language").as[String].toTry.get
+      val text     = disclaimer.hcursor.downField(oldSubfieldName).as[String].toTry.get
+      acc.mapObject(_.add(language, Json.fromString(text)))
+    }
+  }
+
+  private def addEmptyLanguageField(obj: Json): String = {
+    obj.withObject(_.add(fieldName, Json.obj()).toJson).noSpaces
+  }
+
+  override def convertColumn(document: String): String = {
+    val oldArticle = parser.parse(document).toTry.get
+    oldArticle.hcursor.downField(fieldName).focus match {
+      case None                => addEmptyLanguageField(oldArticle)
+      case Some(f) if f.isNull => addEmptyLanguageField(oldArticle)
+      case Some(disclaimers) =>
+        val disclaimerVector = disclaimers.asArray.get
+        val converted        = convertOldLanguageField(disclaimerVector)
+        val newArticle       = oldArticle.withObject(_.remove(fieldName).add(fieldName, converted).toJson)
+        newArticle.noSpaces
+    }
+  }
+}

--- a/draft-api/src/main/scala/no/ndla/draftapi/db/HtmlMigration.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/db/HtmlMigration.scala
@@ -28,7 +28,7 @@ abstract class HtmlMigration extends DocumentMigration {
     jsoupDocumentToString(converted)
   }
 
-  protected def convertColumn(document: String): String = {
+  def convertColumn(document: String): String = {
     val oldArticle = parser.parse(document).flatMap(_.as[Draft]).toTry.get
     val convertedContent = oldArticle.content.map(c => {
       val converted = convertContent(c.content, c.language)

--- a/draft-api/src/main/scala/no/ndla/draftapi/db/migration/V67__DisclaimerToLanguageFields.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/db/migration/V67__DisclaimerToLanguageFields.scala
@@ -1,0 +1,17 @@
+/*
+ * Part of NDLA article-api
+ * Copyright (C) 2025 NDLA
+ *
+ * See LICENSE
+ *
+ */
+
+package no.ndla.draftapi.db.migration
+
+import no.ndla.database.LanguageFieldMigration
+
+class V67__DisclaimerToLanguageFields extends LanguageFieldMigration {
+  override val columnName: String = "document"
+  override val tableName: String  = "articledata"
+  override val fieldName: String  = "disclaimer"
+}

--- a/draft-api/src/main/scala/no/ndla/draftapi/service/ConverterService.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/service/ConverterService.scala
@@ -558,6 +558,7 @@ trait ConverterService {
       val tags                = article.tags.filter(_.language != language)
       val metaImage           = article.metaImage.filter(_.language != language)
       val visualElement       = article.visualElement.filter(_.language != language)
+      val disclaimers         = article.disclaimer.dropLanguage(language)
       newNotes(Seq(s"Slettet språkvariant '$language'."), userInfo, article.status) match {
         case Failure(ex) => Failure(ex)
         case Success(newEditorNotes) =>
@@ -570,7 +571,8 @@ trait ConverterService {
               tags = tags,
               metaImage = metaImage,
               visualElement = visualElement,
-              notes = article.notes ++ newEditorNotes
+              notes = article.notes ++ newEditorNotes,
+              disclaimer = disclaimers
             )
           )
       }

--- a/draft-api/src/test/scala/no/ndla/draftapi/TestData.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/TestData.scala
@@ -13,6 +13,7 @@ import no.ndla.common.model.api.{DraftCopyrightDTO, Missing}
 import no.ndla.common.model.domain.Priority
 import no.ndla.common.model.domain.draft.Draft
 import no.ndla.common.model.domain.draft.DraftStatus.*
+import no.ndla.common.model.domain.language.OptLanguageFields
 import no.ndla.common.model.{NDLADate, api as commonApi, domain as common}
 import no.ndla.draftapi.integration.{LearningPath, Title}
 import no.ndla.draftapi.model.api.*
@@ -322,7 +323,7 @@ object TestData {
     Priority.Unspecified,
     false,
     None,
-    None
+    disclaimer = OptLanguageFields.empty
   )
 
   val sampleArticleWithPublicDomain: Draft = Draft(
@@ -357,7 +358,7 @@ object TestData {
     Priority.Unspecified,
     false,
     None,
-    None
+    disclaimer = OptLanguageFields.empty
   )
 
   val sampleDomainArticle: Draft = Draft(
@@ -394,7 +395,7 @@ object TestData {
     Priority.Unspecified,
     false,
     None,
-    None
+    disclaimer = OptLanguageFields.empty
   )
 
   val newArticle: NewArticleDTO = api.NewArticleDTO(
@@ -485,7 +486,7 @@ object TestData {
     priority = Priority.Unspecified,
     started = false,
     qualityEvaluation = None,
-    disclaimer = None
+    disclaimer = OptLanguageFields.empty
   )
 
   val apiArticleWithHtmlFaultV2: api.ArticleDTO = api.ArticleDTO(

--- a/draft-api/src/test/scala/no/ndla/draftapi/service/ConverterServiceTest.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/service/ConverterServiceTest.scala
@@ -14,6 +14,7 @@ import no.ndla.common.model.api.{Delete, Missing, UpdateWith}
 import no.ndla.common.model.domain.*
 import no.ndla.common.model.domain.draft.DraftStatus.*
 import no.ndla.common.model.domain.draft.{Comment, Draft, DraftCopyright, DraftStatus}
+import no.ndla.common.model.domain.language.OptLanguageFields
 import no.ndla.common.model.{NDLADate, api as commonApi}
 import no.ndla.draftapi.model.api
 import no.ndla.draftapi.model.api.{NewCommentDTO, UpdatedCommentDTO}
@@ -333,7 +334,7 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
       priority = Priority.Unspecified,
       started = false,
       qualityEvaluation = None,
-      disclaimer = Some(Seq(Disclaimer("Disclaimer test", "nb")))
+      disclaimer = OptLanguageFields.withValue("Disclaimer test", "nb")
     )
 
     val updatedNothing = TestData.blankUpdatedArticle.copy(
@@ -381,7 +382,7 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
       priority = Priority.Unspecified,
       started = false,
       qualityEvaluation = None,
-      disclaimer = Some(Seq(Disclaimer("Disclaimer test", "nb")))
+      disclaimer = OptLanguageFields.withValue("Disclaimer test", "nb")
     )
 
     val expectedArticle = Draft(
@@ -416,7 +417,7 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
       priority = Priority.Unspecified,
       started = false,
       qualityEvaluation = None,
-      disclaimer = Some(Seq(Disclaimer("NyDisclaimer test", "nb")))
+      disclaimer = OptLanguageFields.withValue("NyDisclaimer test", "nb")
     )
 
     val updatedEverything = TestData.blankUpdatedArticle.copy(
@@ -482,7 +483,7 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
       priority = Priority.Unspecified,
       started = false,
       qualityEvaluation = None,
-      disclaimer = None
+      disclaimer = OptLanguageFields.empty
     )
 
     val expectedArticle = Draft(
@@ -525,7 +526,7 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
       priority = Priority.Unspecified,
       started = false,
       qualityEvaluation = None,
-      disclaimer = None
+      disclaimer = OptLanguageFields.empty
     )
 
     val updatedEverything = TestData.blankUpdatedArticle.copy(
@@ -1127,7 +1128,7 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
       priority = Priority.Unspecified,
       started = false,
       qualityEvaluation = None,
-      disclaimer = Some(Seq(Disclaimer("articleDisclaimer", "nb")))
+      disclaimer = OptLanguageFields.withValue("articleDisclaimer", "nb")
     )
     val article = common.model.domain.article.Article(
       id = Some(articleId),
@@ -1153,7 +1154,7 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
       relatedContent = Seq.empty,
       revisionDate = None,
       slug = Some("kjempe-slug"),
-      disclaimer = Some(Seq(Disclaimer("articleDisclaimer", "nb")))
+      disclaimer = OptLanguageFields.withValue("articleDisclaimer", "nb")
     )
 
     val result = service.toArticleApiArticle(draft)

--- a/draft-api/src/test/scala/no/ndla/draftapi/service/StateTransitionRulesTest.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/service/StateTransitionRulesTest.scala
@@ -11,6 +11,7 @@ import no.ndla.common.errors.{ValidationException, ValidationMessage}
 import no.ndla.common.model.domain.{Priority, Responsible, Status}
 import no.ndla.common.model.domain.draft.Draft
 import no.ndla.common.model.domain.draft.DraftStatus.*
+import no.ndla.common.model.domain.language.OptLanguageFields
 import no.ndla.common.model.{NDLADate, domain as common}
 import no.ndla.draftapi.integration.{SearchHit, Title}
 import no.ndla.draftapi.model.domain.StateTransition
@@ -356,7 +357,7 @@ class StateTransitionRulesTest extends UnitSuite with TestEnvironment {
       priority = Priority.Unspecified,
       started = false,
       qualityEvaluation = None,
-      disclaimer = None
+      disclaimer = OptLanguageFields.empty
     )
     val article = common.article.Article(
       id = Some(articleId),
@@ -381,7 +382,7 @@ class StateTransitionRulesTest extends UnitSuite with TestEnvironment {
       relatedContent = Seq.empty,
       revisionDate = None,
       slug = None,
-      disclaimer = None
+      disclaimer = OptLanguageFields.empty
     )
     val status = common.Status(END_CONTROL, Set.empty)
 
@@ -479,7 +480,7 @@ class StateTransitionRulesTest extends UnitSuite with TestEnvironment {
       priority = Priority.Unspecified,
       started = false,
       qualityEvaluation = None,
-      disclaimer = None
+      disclaimer = OptLanguageFields.empty
     )
     val status            = common.Status(PLANNED, Set.empty)
     val transitionsToTest = StateTransitionRules.StateTransitions.filter(_.to == PUBLISHED)
@@ -536,7 +537,7 @@ class StateTransitionRulesTest extends UnitSuite with TestEnvironment {
       priority = Priority.Unspecified,
       started = false,
       qualityEvaluation = None,
-      disclaimer = None
+      disclaimer = OptLanguageFields.empty
     )
     val status            = common.Status(PLANNED, Set.empty)
     val transitionsToTest = StateTransitionRules.StateTransitions.filter(_.to == ARCHIVED)
@@ -597,7 +598,7 @@ class StateTransitionRulesTest extends UnitSuite with TestEnvironment {
       priority = Priority.Unspecified,
       started = false,
       qualityEvaluation = None,
-      disclaimer = None
+      disclaimer = OptLanguageFields.empty
     )
     val status            = common.Status(PLANNED, Set.empty)
     val transitionsToTest = StateTransitionRules.StateTransitions.filter(_.to == UNPUBLISHED)
@@ -659,7 +660,7 @@ class StateTransitionRulesTest extends UnitSuite with TestEnvironment {
       priority = Priority.Unspecified,
       started = false,
       qualityEvaluation = None,
-      disclaimer = None
+      disclaimer = OptLanguageFields.empty
     )
     val status                            = common.Status(PUBLISHED, Set.empty)
     val transitionToTest: StateTransition = PUBLISHED -> IN_PROGRESS

--- a/draft-api/src/test/scala/no/ndla/draftapi/validation/ContentValidatorTest.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/validation/ContentValidatorTest.scala
@@ -10,6 +10,7 @@ package no.ndla.draftapi.validation
 import no.ndla.common.errors.{ValidationException, ValidationMessage}
 import no.ndla.common.model.domain.*
 import no.ndla.common.model.domain.draft.{Comment, Draft, DraftCopyright, RevisionMeta}
+import no.ndla.common.model.domain.language.OptLanguageFields
 import no.ndla.draftapi.{TestData, TestEnvironment, UnitSuite}
 import no.ndla.mapping.License.CC_BY_SA
 
@@ -63,21 +64,20 @@ class ContentValidatorTest extends UnitSuite with TestEnvironment {
   test("validateArticle should throw an error if disclaimer contains illegal HTML tags") {
     val article = articleToValidate.copy(
       content = Seq(ArticleContent(validDocument, "nb")),
-      disclaimer = Some(Seq(Disclaimer("<p><hallo>hei</hallo></p>", "nb")))
+      disclaimer = OptLanguageFields.withValue("<p><hallo>hei</hallo></p>", "nb")
     )
     val Failure(error: ValidationException) = contentValidator.validateArticle(article)
-    error should be(
-      ValidationException(
-        "disclaimer",
-        "The content contains illegal tags and/or attributes. Allowed HTML tags are: h3, msgroup, a, article, sub, sup, mtext, msrow, tbody, mtd, pre, thead, figcaption, mover, msup, semantics, ol, span, mroot, munder, h4, mscarries, dt, nav, mtr, ndlaembed, li, br, mrow, merror, mphantom, u, audio, ul, maligngroup, mfenced, annotation, div, strong, section, i, mspace, malignmark, mfrac, code, h2, td, aside, em, mstack, button, dl, th, tfoot, math, tr, b, blockquote, msline, col, annotation-xml, mstyle, caption, mpadded, mo, mlongdiv, msubsup, p, munderover, maction, menclose, h1, details, mmultiscripts, msqrt, mscarry, mstac, mi, mglyph, mlabeledtr, mtable, mprescripts, summary, mn, msub, ms, table, colgroup, dd"
-      )
+    val expected = ValidationException(
+      "disclaimer.nb",
+      "The content contains illegal tags and/or attributes. Allowed HTML tags are: h3, msgroup, a, article, sub, sup, mtext, msrow, tbody, mtd, pre, thead, figcaption, mover, msup, semantics, ol, span, mroot, munder, h4, mscarries, dt, nav, mtr, ndlaembed, li, br, mrow, merror, mphantom, u, audio, ul, maligngroup, mfenced, annotation, div, strong, section, i, mspace, malignmark, mfrac, code, h2, td, aside, em, mstack, button, dl, th, tfoot, math, tr, b, blockquote, msline, col, annotation-xml, mstyle, caption, mpadded, mo, mlongdiv, msubsup, p, munderover, maction, menclose, h1, details, mmultiscripts, msqrt, mscarry, mstac, mi, mglyph, mlabeledtr, mtable, mprescripts, summary, mn, msub, ms, table, colgroup, dd"
     )
+    error should be(expected)
   }
 
   test("validateArticle should not throw an error if disclaimer contains legal HTML tags") {
     val article = articleToValidate.copy(
       content = Seq(ArticleContent(validDocument, "nb")),
-      disclaimer = Some(Seq(Disclaimer(validDisclaimer, "nb")))
+      disclaimer = OptLanguageFields.withValue(validDisclaimer, "nb")
     )
     contentValidator.validateArticle(article).isSuccess should be(true)
 

--- a/integration-tests/src/test/scala/no/ndla/integrationtests/draftapi/articleapi/ArticleApiClientTest.scala
+++ b/integration-tests/src/test/scala/no/ndla/integrationtests/draftapi/articleapi/ArticleApiClientTest.scala
@@ -10,6 +10,7 @@ package no.ndla.integrationtests.draftapi.articleapi
 import no.ndla.articleapi.ArticleApiProperties
 import no.ndla.common.model.domain.Priority
 import no.ndla.common.model.domain.draft.Draft
+import no.ndla.common.model.domain.language.OptLanguageFields
 import no.ndla.common.model.{NDLADate, domain as common}
 import no.ndla.draftapi.model.api.ContentIdDTO
 import no.ndla.integrationtests.UnitSuite
@@ -126,7 +127,7 @@ class ArticleApiClientTest
     priority = Priority.Unspecified,
     started = false,
     qualityEvaluation = None,
-    disclaimer = None
+    disclaimer = OptLanguageFields.empty
   )
 
   val exampleToken =

--- a/language/src/main/scala/no/ndla/language/model/LanguageField.scala
+++ b/language/src/main/scala/no/ndla/language/model/LanguageField.scala
@@ -1,6 +1,6 @@
 package no.ndla.language.model
 
-trait LanguageField[T] extends WithLanguage {
+trait LanguageField[T] extends WithLanguageAndValue[T] {
   def value: T
   def isEmpty: Boolean
 }

--- a/language/src/main/scala/no/ndla/language/model/WithLanguageAndValue.scala
+++ b/language/src/main/scala/no/ndla/language/model/WithLanguageAndValue.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA backend.language.main
+ * Part of NDLA language
  * Copyright (C) 2025 NDLA
  *
  * See LICENSE

--- a/language/src/main/scala/no/ndla/language/model/WithLanguageAndValue.scala
+++ b/language/src/main/scala/no/ndla/language/model/WithLanguageAndValue.scala
@@ -1,0 +1,19 @@
+/*
+ * Part of NDLA backend.language.main
+ * Copyright (C) 2025 NDLA
+ *
+ * See LICENSE
+ *
+ */
+
+package no.ndla.language.model
+
+trait WithLanguageAndValue[T] extends WithLanguage {
+  def language: String
+  def value: T
+}
+
+case class BaseWithLanguageAndValue[T](
+    language: String,
+    value: T
+) extends WithLanguageAndValue[T]

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/db/migration/V39__MadeAvailableForThePublished.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/db/migration/V39__MadeAvailableForThePublished.scala
@@ -17,7 +17,7 @@ class V39__MadeAvailableForThePublished extends DocumentMigration {
   override val columnName: String = "document"
   override val tableName: String  = "learningpaths"
 
-  protected def convertColumn(document: String): String = {
+  def convertColumn(document: String): String = {
     val oldLp = CirceUtil.unsafeParseAs[LearningPath](document)
     val madeAvailable = oldLp.status match {
       case UNLISTED | PUBLISHED => Some(oldLp.lastUpdated)

--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/ConverterServiceTest.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/ConverterServiceTest.scala
@@ -427,7 +427,7 @@ class ConverterServiceTest extends UnitSuite with UnitTestEnvironment {
   }
 
   test("asEmbedUrl throws error if an not allowed value for embedType is used") {
-    assertResult("Validation Error") {
+    assertResult("Validation Error:\n\tembedType: 'test' is not a valid embed type.") {
       intercept[ValidationException] {
         service.asEmbedUrlV2(api.EmbedUrlV2DTO("http://test.no/2/oembed/", "test"), "nb")
       }.getMessage

--- a/project/languagelib.scala
+++ b/project/languagelib.scala
@@ -9,7 +9,8 @@ object languagelib extends Module {
   lazy val dependencies: Seq[ModuleID] = withLogging(
     Seq(
       "org.scalatest" %% "scalatest" % ScalaTestV % "test"
-    )
+    ),
+    tapirHttp4sCirce
   )
 
   override lazy val settings: Seq[Def.Setting[?]] = Seq(

--- a/search-api/src/main/scala/no/ndla/searchapi/controller/parameters/GetSearchQueryParams.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/controller/parameters/GetSearchQueryParams.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA backend.search-api.main
+ * Part of NDLA search-api
  * Copyright (C) 2024 NDLA
  *
  * See LICENSE

--- a/search-api/src/test/scala/no/ndla/searchapi/TestData.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/TestData.scala
@@ -38,6 +38,7 @@ import no.ndla.common.model.domain.concept.{
   WordClass
 }
 import no.ndla.common.model.domain.draft.{Draft, DraftCopyright, DraftStatus, RevisionMeta, RevisionStatus}
+import no.ndla.common.model.domain.language.OptLanguageFields
 import no.ndla.common.model.domain.learningpath.{
   LearningPath,
   LearningPathStatus,
@@ -56,9 +57,9 @@ import no.ndla.searchapi.model.grep.{
   GrepKjerneelement,
   GrepKompetansemaal,
   GrepLaererplan,
+  GrepTextObj,
   GrepTitle,
-  GrepTverrfagligTema,
-  GrepTextObj
+  GrepTverrfagligTema
 }
 import no.ndla.searchapi.model.search.*
 import no.ndla.searchapi.model.search.settings.{MultiDraftSearchSettings, SearchSettings}
@@ -211,7 +212,7 @@ object TestData {
     Seq.empty,
     None,
     slug = None,
-    None
+    disclaimer = OptLanguageFields.empty
   )
 
   val sampleDomainArticle: Article = Article(
@@ -237,7 +238,7 @@ object TestData {
     Seq.empty,
     None,
     slug = None,
-    None
+    disclaimer = OptLanguageFields.empty
   )
 
   val sampleDomainArticle2: Article = Article(
@@ -263,7 +264,7 @@ object TestData {
     Seq.empty,
     None,
     slug = None,
-    None
+    disclaimer = OptLanguageFields.empty
   )
 
   val sampleArticleWithByNcSa: Article =
@@ -544,9 +545,9 @@ object TestData {
     conceptIds = Seq.empty,
     availability = Availability.everyone,
     relatedContent = Seq.empty,
-    None,
+    revisionDate = None,
     slug = None,
-    None
+    disclaimer = OptLanguageFields.empty
   )
 
   val emptyDomainDraft: Draft = Draft(
@@ -581,7 +582,7 @@ object TestData {
     priority = Priority.Unspecified,
     started = false,
     qualityEvaluation = None,
-    None
+    disclaimer = OptLanguageFields.empty
   )
 
   val draftStatus: Status         = Status(DraftStatus.PLANNED, Set.empty)
@@ -644,7 +645,7 @@ object TestData {
     priority = Priority.Unspecified,
     started = false,
     qualityEvaluation = None,
-    disclaimer = None
+    disclaimer = OptLanguageFields.empty
   )
 
   val sampleDraftWithByNcSa: Draft      = sampleDraftWithPublicDomain.copy(copyright = Some(draftByNcSaCopyright))

--- a/search-api/src/test/scala/no/ndla/searchapi/model/api/grep/GrepResultDTOTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/model/api/grep/GrepResultDTOTest.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA backend.search-api.test
+ * Part of NDLA search-api
  * Copyright (C) 2025 NDLA
  *
  * See LICENSE


### PR DESCRIPTION
Denne PR'en er større enn den trenger å være for å fikse problemet, men jeg tror språktypene kan bli enklere å jobbe med i fremtiden!
Min drøm er at alle språktypene våre kan konverteres til denne (Evt `LanguageFields` typen som er veldig lik).

Sånn det funker:
`LanguageFields` (Opt og ikke) serialiseres til et objekt istedenfor en liste.
Feks:
```json
{ "nb": "Dette er en bokmål disclaimer", "nn": "Dette er ein nynorsk disclaimer" }
```

Den som heter `OptLanguageFields` lar deg også definere at et språk ikke skal ha en variant.
Feks lar det oss gjøre at disclaimer kan ha en bokmål versjon, og nynorsk versjonen fallbacker til bokmål, mens engelsk har ingenting og returnerer heller ingen fallback.

