### PR TITLE
learningpath-api: Allow everyone with permissions to copy learningpaths

### DIFF
--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/controller/LearningpathControllerV2.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/controller/LearningpathControllerV2.scala
@@ -464,17 +464,13 @@ trait LearningpathControllerV2 {
       .withRequiredMyNDLAUserOrTokenUser
       .serverLogicPure { user =>
         { case (pathId, newLearningPath) =>
-          UserInfo
-            .getWithUserIdOrAdmin(user)
-            .flatMap(userInfo =>
-              updateService
-                .newFromExistingV2(pathId, newLearningPath, userInfo)
-                .map(learningPath => {
-                  logger.info(s"COPIED LearningPath with ID =  ${learningPath.id}")
-                  val headers = DynamicHeaders.fromValue("Location", learningPath.metaUrl)
-                  (learningPath, headers)
-                })
-            )
+          updateService
+            .newFromExistingV2(pathId, newLearningPath, user)
+            .map(learningPath => {
+              logger.info(s"COPIED LearningPath with ID =  ${learningPath.id}")
+              val headers = DynamicHeaders.fromValue("Location", learningPath.metaUrl)
+              (learningPath, headers)
+            })
             .handleErrorsOrOk
         }
       }


### PR DESCRIPTION
Vet ikke hvorfor jeg la inn at man måtte være admin eller ndla-bruker for å kopiere denne tidligere, men jeg mistenker at det bare ikke var så gjennomtenkt :nerd_face: 