### PR TITLE
learningpath-api: Open `ids` endpoint to allow everyone to fetch

### DIFF
--- a/scalatestsuite/src/main/scala/no/ndla/scalatestsuite/BufferedLogAppender.scala
+++ b/scalatestsuite/src/main/scala/no/ndla/scalatestsuite/BufferedLogAppender.scala
@@ -17,7 +17,7 @@ import scala.collection.mutable.ListBuffer
 object Layout {
   lazy val prebuiltLayout: PatternLayout = PatternLayout
     .newBuilder()
-    .withPattern("[%level] %C.%M#%L: %msg%n")
+    .withPattern("[%level] (%X{correlationID}) %C.%M#%L: %msg%n")
     .build()
 }
 


### PR DESCRIPTION
Gjør sånn at `/learningpath-api/v2/learningpaths/ids/` kan kalles av alle.
Men dersom man ikke er eier eller har redigeringstilgang på en privat sti så blir den ikke med i resultatet.