### PR TITLE
network: Use `def` to avoid racecondition `null`

### DIFF
--- a/network/src/main/scala/no/ndla/network/model/CombinedUser.scala
+++ b/network/src/main/scala/no/ndla/network/model/CombinedUser.scala
@@ -14,7 +14,7 @@ import no.ndla.network.tapir.auth.TokenUser
 sealed trait CombinedUser {
   val tokenUser: Option[TokenUser]
   val myndlaUser: Option[MyNDLAUserDTO]
-  val isMyNDLAUser: Boolean = myndlaUser.isDefined && tokenUser.isEmpty
+  def isMyNDLAUser: Boolean = myndlaUser.isDefined && tokenUser.isEmpty
 }
 
 case class OptionalCombinedUser(tokenUser: Option[TokenUser], myndlaUser: Option[MyNDLAUserDTO]) extends CombinedUser


### PR DESCRIPTION
Since the constructor of the sealed trait runs before the child constructor the fields are `null` when the `isMyNDLAUser` field is calculated.

Lets fix this by making it a function instead of a calculated value.