### PR TITLE
Add default context to searchables

### DIFF
--- a/search-api/src/main/scala/no/ndla/searchapi/model/api/MultiSearchSummaryDTO.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/model/api/MultiSearchSummaryDTO.scala
@@ -27,38 +27,65 @@ object HighlightedFieldDTO {
   implicit val decoder: Decoder[HighlightedFieldDTO] = deriveDecoder
 }
 
-// format: off
 @description("Short summary of information about the resource")
 case class MultiSearchSummaryDTO(
-                                  @description("The unique id of the resource") id: Long,
-                                  @description("The title of the resource") title: TitleWithHtmlDTO,
-                                  @description("The meta description of the resource") metaDescription: MetaDescriptionDTO,
-                                  @description("The meta image for the resource") metaImage: Option[MetaImageDTO],
-                                  @description("Url pointing to the resource") url: String,
-                                  @description("Contexts of the resource") contexts: List[ApiTaxonomyContextDTO],
-                                  @description("Languages the resource exists in") supportedLanguages: Seq[String],
-                                  @description("Learning resource type") learningResourceType: LearningResourceType,
-                                  @description("Status information of the resource") status: Option[StatusDTO],
-                                  @description("Traits for the resource") traits: List[SearchTrait],
-                                  @description("Relevance score. The higher the score, the better the document matches your search criteria.") score: Float,
-                                  @description("List of objects describing matched field with matching words emphasized") highlights: List[HighlightedFieldDTO],
-                                  @description("The taxonomy paths for the resource") paths: List[String],
-                                  @description("The time and date of last update") lastUpdated: NDLADate,
-                                  @description("Describes the license of the resource") license: Option[String],
-                                  @description("A list of revisions planned for the article") revisions: Seq[RevisionMetaDTO],
-                                  @description("Responsible field") responsible: Option[DraftResponsibleDTO],
-                                  @description("Information about comments attached to the article") comments: Option[Seq[CommentDTO]],
-                                  @description("If the article should be prioritized" ) prioritized: Option[Boolean],
-                                  @description("If the article should be prioritized. Possible values are prioritized, on-hold, unspecified") priority: Option[String],
-                                  @description("A combined resource type name if a standard article, otherwise the article type name") resourceTypeName: Option[String],
-                                  @description("Name of the parent topic if exists") parentTopicName: Option[String],
-                                  @description("Name of the primary context root if exists") primaryRootName: Option[String],
-                                  @description("When the article was last published") published: Option[NDLADate],
-                                  @description("Number of times favorited in MyNDLA") favorited: Option[Long],
-                                  @description("Type of the resource") resultType: SearchType,
-                                  @description("Subject ids for the resource, if a concept") conceptSubjectIds: Option[List[String]]
+    @description("The unique id of the resource")
+    id: Long,
+    @description("The title of the resource")
+    title: TitleWithHtmlDTO,
+    @description("The meta description of the resource")
+    metaDescription: MetaDescriptionDTO,
+    @description("The meta image for the resource")
+    metaImage: Option[MetaImageDTO],
+    @description("Url pointing to the resource")
+    url: String,
+    @description("Primary context of the resource")
+    context: Option[ApiTaxonomyContextDTO],
+    @description("Contexts of the resource")
+    contexts: List[ApiTaxonomyContextDTO],
+    @description("Languages the resource exists in")
+    supportedLanguages: Seq[String],
+    @description("Learning resource type")
+    learningResourceType: LearningResourceType,
+    @description("Status information of the resource")
+    status: Option[StatusDTO],
+    @description("Traits for the resource")
+    traits: List[SearchTrait],
+    @description("Relevance score. The higher the score, the better the document matches your search criteria.")
+    score: Float,
+    @description("List of objects describing matched field with matching words emphasized")
+    highlights: List[HighlightedFieldDTO],
+    @description("The taxonomy paths for the resource")
+    paths: List[String],
+    @description("The time and date of last update")
+    lastUpdated: NDLADate,
+    @description("Describes the license of the resource")
+    license: Option[String],
+    @description("A list of revisions planned for the article")
+    revisions: Seq[RevisionMetaDTO],
+    @description("Responsible field")
+    responsible: Option[DraftResponsibleDTO],
+    @description("Information about comments attached to the article")
+    comments: Option[Seq[CommentDTO]],
+    @description("If the article should be prioritized")
+    prioritized: Option[Boolean],
+    @description("If the article should be prioritized. Possible values are prioritized, on-hold, unspecified")
+    priority: Option[String],
+    @description("A combined resource type name if a standard article, otherwise the article type name")
+    resourceTypeName: Option[String],
+    @description("Name of the parent topic if exists")
+    parentTopicName: Option[String],
+    @description("Name of the primary context root if exists")
+    primaryRootName: Option[String],
+    @description("When the article was last published")
+    published: Option[NDLADate],
+    @description("Number of times favorited in MyNDLA")
+    favorited: Option[Long],
+    @description("Type of the resource")
+    resultType: SearchType,
+    @description("Subject ids for the resource, if a concept")
+    conceptSubjectIds: Option[List[String]]
 )
-// format: on
 
 object MultiSearchSummaryDTO {
   implicit val encoder: Encoder[MultiSearchSummaryDTO] = deriveEncoder

--- a/search-api/src/main/scala/no/ndla/searchapi/model/search/SearchableArticle.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/model/search/SearchableArticle.scala
@@ -32,6 +32,7 @@ case class SearchableArticle(
     metaImage: List[ArticleMetaImage],
     defaultTitle: Option[String],
     supportedLanguages: List[String],
+    context: Option[SearchableTaxonomyContext],
     contexts: List[SearchableTaxonomyContext],
     contextids: List[String],
     grepContexts: List[SearchableGrepContext],

--- a/search-api/src/main/scala/no/ndla/searchapi/model/search/SearchableDraft.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/model/search/SearchableDraft.scala
@@ -32,6 +32,7 @@ case class SearchableDraft(
     defaultTitle: Option[String],
     supportedLanguages: List[String],
     notes: List[String],
+    context: Option[SearchableTaxonomyContext],
     contexts: List[SearchableTaxonomyContext],
     contextids: List[String],
     draftStatus: SearchableStatus,

--- a/search-api/src/main/scala/no/ndla/searchapi/model/search/SearchableLearningPath.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/model/search/SearchableLearningPath.scala
@@ -18,7 +18,7 @@ import no.ndla.searchapi.model.domain.LearningResourceType
 case class SearchableLearningPath(
     id: Long,
     title: SearchableLanguageValues,
-    content: SearchableLanguageValues, // only for suggestions to work.
+    content: SearchableLanguageValues,
     description: SearchableLanguageValues,
     coverPhotoId: Option[String],
     duration: Option[Int],
@@ -33,6 +33,7 @@ case class SearchableLearningPath(
     isBasedOn: Option[Long],
     supportedLanguages: List[String],
     authors: List[String],
+    context: Option[SearchableTaxonomyContext],
     contexts: List[SearchableTaxonomyContext],
     contextids: List[String],
     favorited: Long,

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/ArticleIndexService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/ArticleIndexService.scala
@@ -58,7 +58,8 @@ trait ArticleIndexService {
         keywordField("traits"),
         keywordField("availability"),
         keywordField("learningResourceType"),
-        getTaxonomyContextMapping,
+        getTaxonomyContextMapping("context"),
+        getTaxonomyContextMapping("contexts"),
         keywordField("contextids"),
         nestedField("embedResourcesAndIds").fields(
           keywordField("resource"),
@@ -83,6 +84,9 @@ trait ArticleIndexService {
         generateLanguageSupportedDynamicTemplates("relevance") ++
         generateLanguageSupportedDynamicTemplates("breadcrumbs") ++
         generateLanguageSupportedDynamicTemplates("name", keepRaw = true) ++
+        generateLanguageSupportedDynamicTemplates("context.root") ++
+        generateLanguageSupportedDynamicTemplates("context.relevance") ++
+        generateLanguageSupportedDynamicTemplates("context.resourceTypes.name") ++
         generateLanguageSupportedDynamicTemplates("contexts.root") ++
         generateLanguageSupportedDynamicTemplates("contexts.relevance") ++
         generateLanguageSupportedDynamicTemplates("contexts.resourceTypes.name")

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/DraftIndexService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/DraftIndexService.scala
@@ -71,7 +71,8 @@ trait DraftIndexService {
             dateField("lastUpdated")
           )
         ),
-        getTaxonomyContextMapping,
+        getTaxonomyContextMapping("context"),
+        getTaxonomyContextMapping("contexts"),
         keywordField("contextids"),
         nestedField("embedResourcesAndIds").fields(
           keywordField("resource"),
@@ -112,6 +113,10 @@ trait DraftIndexService {
         generateLanguageSupportedDynamicTemplates("parentTopicName", keepRaw = true) ++
         generateLanguageSupportedDynamicTemplates("resourceTypeName", keepRaw = true) ++
         generateLanguageSupportedDynamicTemplates("primaryRoot", keepRaw = true) ++
+        generateLanguageSupportedDynamicTemplates("context.root") ++
+        generateLanguageSupportedDynamicTemplates("context.relevance") ++
+        generateLanguageSupportedDynamicTemplates("context.resourceTypes.name") ++
+        generateLanguageSupportedDynamicTemplates("contexts.root") ++
         generateLanguageSupportedDynamicTemplates("contexts.relevance") ++
         generateLanguageSupportedDynamicTemplates("contexts.resourceTypes.name")
 

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/IndexService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/IndexService.scala
@@ -291,8 +291,8 @@ trait IndexService {
       })
     }
 
-    protected def getTaxonomyContextMapping: NestedField = {
-      nestedField("contexts").fields(
+    protected def getTaxonomyContextMapping(fieldName: String): NestedField = {
+      nestedField(fieldName).fields(
         keywordField("publicId"),
         keywordField("contextId"),
         keywordField("path"),

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/LearningPathIndexService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/LearningPathIndexService.scala
@@ -78,7 +78,8 @@ trait LearningPathIndexService {
         ),
         intField("isBasedOn"),
         keywordField("supportedLanguages"),
-        getTaxonomyContextMapping,
+        getTaxonomyContextMapping("context"),
+        getTaxonomyContextMapping("contexts"),
         keywordField("contextids"),
         nestedField("embedResourcesAndIds").fields(
           keywordField("resource"),
@@ -94,6 +95,9 @@ trait LearningPathIndexService {
         generateLanguageSupportedDynamicTemplates("relevance") ++
         generateLanguageSupportedDynamicTemplates("breadcrumbs") ++
         generateLanguageSupportedDynamicTemplates("name", keepRaw = true) ++
+        generateLanguageSupportedDynamicTemplates("context.root") ++
+        generateLanguageSupportedDynamicTemplates("context.relevance") ++
+        generateLanguageSupportedDynamicTemplates("context.resourceTypes.name") ++
         generateLanguageSupportedDynamicTemplates("contexts.root") ++
         generateLanguageSupportedDynamicTemplates("contexts.relevance") ++
         generateLanguageSupportedDynamicTemplates("contexts.resourceTypes.name")

--- a/search-api/src/test/scala/no/ndla/searchapi/TestData.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/TestData.scala
@@ -1817,7 +1817,6 @@ object TestData {
   )
   val searchableDraft: SearchableDraft = SearchableDraft(
     id = 100,
-    draftStatus = SearchableStatus(DraftStatus.PLANNED.toString, Seq(DraftStatus.IN_PROGRESS.toString)),
     title = searchableTitles,
     content = searchableContents,
     visualElement = searchableVisualElements,
@@ -1831,8 +1830,10 @@ object TestData {
     defaultTitle = Some("Christian Tut"),
     supportedLanguages = List("en", "nb", "nn"),
     notes = List("Note1", "note2"),
+    None,
     contexts = searchableTaxonomyContexts,
     contextids = searchableTaxonomyContexts.map(_.contextId),
+    draftStatus = SearchableStatus(DraftStatus.PLANNED.toString, Seq(DraftStatus.IN_PROGRESS.toString)),
     users = List("ndalId54321", "ndalId12345"),
     previousVersionsNotes = List("OldNote"),
     grepContexts = List(),
@@ -1857,10 +1858,10 @@ object TestData {
       )
     ),
     priority = Priority.Unspecified,
-    parentTopicName = searchableTitles,
     defaultParentTopicName = searchableTitles.defaultValue,
-    primaryRoot = searchableTitles,
+    parentTopicName = searchableTitles,
     defaultRoot = searchableTitles.defaultValue,
+    primaryRoot = searchableTitles,
     resourceTypeName = searchableTitles,
     defaultResourceTypeName = searchableTitles.defaultValue,
     published = TestData.today,

--- a/search-api/src/test/scala/no/ndla/searchapi/model/search/SearchableArticleTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/model/search/SearchableArticleTest.scala
@@ -77,6 +77,7 @@ class SearchableArticleTest extends UnitSuite with TestEnvironment {
       metaImage = metaImages,
       defaultTitle = Some("Christian Tut"),
       supportedLanguages = List("en", "nb", "nn"),
+      context = searchableTaxonomyContexts.headOption,
       contexts = searchableTaxonomyContexts,
       contextids = searchableTaxonomyContexts.map(_.contextId),
       grepContexts =
@@ -155,6 +156,7 @@ class SearchableArticleTest extends UnitSuite with TestEnvironment {
       metaImage = metaImages,
       defaultTitle = Some("Christian Tut"),
       supportedLanguages = List("en", "nb", "nn"),
+      context = Some(singleSearchableTaxonomyContext),
       contexts = List(singleSearchableTaxonomyContext),
       contextids = List(singleSearchableTaxonomyContext.contextId),
       grepContexts =
@@ -170,9 +172,8 @@ class SearchableArticleTest extends UnitSuite with TestEnvironment {
     val json         = CirceUtil.toJsonString(original)
     val deserialized = CirceUtil.unsafeParseAs[SearchableArticle](json)
 
-    val expected = original.copy(
-      contexts = List(singleSearchableTaxonomyContext)
-    )
+    val expected =
+      original.copy(context = Some(singleSearchableTaxonomyContext), contexts = List(singleSearchableTaxonomyContext))
 
     deserialized should be(expected)
   }

--- a/search-api/src/test/scala/no/ndla/searchapi/model/search/SearchableDraftTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/model/search/SearchableDraftTest.scala
@@ -84,7 +84,6 @@ class SearchableDraftTest extends UnitSuite with TestEnvironment {
 
     val original = SearchableDraft(
       id = 100,
-      draftStatus = SearchableStatus(DraftStatus.PLANNED.toString, Seq(DraftStatus.IN_PROGRESS.toString)),
       title = titles,
       content = contents,
       visualElement = visualElements,
@@ -98,8 +97,10 @@ class SearchableDraftTest extends UnitSuite with TestEnvironment {
       defaultTitle = Some("Christian Tut"),
       supportedLanguages = List("en", "nb", "nn"),
       notes = List("Note1", "note2"),
+      context = searchableTaxonomyContexts.headOption,
       contexts = searchableTaxonomyContexts,
       contextids = searchableTaxonomyContexts.map(_.contextId),
+      draftStatus = SearchableStatus(DraftStatus.PLANNED.toString, Seq(DraftStatus.IN_PROGRESS.toString)),
       users = List("ndalId54321", "ndalId12345"),
       previousVersionsNotes = List("OldNote"),
       grepContexts =
@@ -125,10 +126,10 @@ class SearchableDraftTest extends UnitSuite with TestEnvironment {
         )
       ),
       priority = Priority.Unspecified,
-      parentTopicName = titles,
       defaultParentTopicName = titles.defaultValue,
-      primaryRoot = titles,
+      parentTopicName = titles,
       defaultRoot = titles.defaultValue,
+      primaryRoot = titles,
       resourceTypeName = titles,
       defaultResourceTypeName = titles.defaultValue,
       published = TestData.today,

--- a/search-api/src/test/scala/no/ndla/searchapi/model/search/SearchableLearningPathTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/model/search/SearchableLearningPathTest.scala
@@ -56,6 +56,7 @@ class SearchableLearningPathTest extends UnitSuite with TestEnvironment {
       defaultTitle = Some("Christian Tut"),
       tags = tags,
       learningsteps = learningsteps,
+      license = "by-sa",
       copyright = CopyrightDTO(
         LicenseDTO("by-sa", Some("bysasaa"), None),
         Seq(AuthorDTO("Supplier", "Jonas"), AuthorDTO("Originator", "Kakemonsteret"))
@@ -63,9 +64,9 @@ class SearchableLearningPathTest extends UnitSuite with TestEnvironment {
       isBasedOn = Some(1001),
       supportedLanguages = List("nb", "en", "nn"),
       authors = List("Yap"),
+      context = searchableTaxonomyContexts.headOption,
       contexts = searchableTaxonomyContexts,
       contextids = searchableTaxonomyContexts.map(_.contextId),
-      license = "by-sa",
       favorited = 0,
       learningResourceType = LearningResourceType.LearningPath
     )

--- a/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceAtomicTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceAtomicTest.scala
@@ -905,30 +905,30 @@ class MultiDraftSearchServiceAtomicTest
           case 1 =>
             TestData.searchableDraft.copy(
               id = 1,
-              parentTopicName = SearchableLanguageValues.from("nb" -> "Apekatt emne"),
               defaultParentTopicName = Some("Apekatt emne"),
-              primaryRoot = SearchableLanguageValues.from("nb" -> "Capekatt rot"),
+              parentTopicName = SearchableLanguageValues.from("nb" -> "Apekatt emne"),
               defaultRoot = Some("Capekatt rot"),
+              primaryRoot = SearchableLanguageValues.from("nb" -> "Capekatt rot"),
               resourceTypeName = SearchableLanguageValues.from("nb" -> "Bapekatt ressurs"),
               defaultResourceTypeName = Some("Bapekatt ressurs")
             )
           case 2 =>
             TestData.searchableDraft.copy(
               id = 2,
-              parentTopicName = SearchableLanguageValues.from("nb" -> "Bpekatt emne"),
               defaultParentTopicName = Some("Bpekatt emne"),
-              primaryRoot = SearchableLanguageValues.from("nb" -> "Apekatt rot"),
+              parentTopicName = SearchableLanguageValues.from("nb" -> "Bpekatt emne"),
               defaultRoot = Some("Apekatt rot"),
+              primaryRoot = SearchableLanguageValues.from("nb" -> "Apekatt rot"),
               resourceTypeName = SearchableLanguageValues.from("nb" -> "Capekatt ressurs"),
               defaultResourceTypeName = Some("Capekatt ressurs")
             )
           case 3 =>
             TestData.searchableDraft.copy(
               id = 3,
-              parentTopicName = SearchableLanguageValues.from("nb" -> "Cpekatt emne"),
               defaultParentTopicName = Some("Cpekatt emne"),
-              primaryRoot = SearchableLanguageValues.from("nb" -> "Bapekatt rot"),
+              parentTopicName = SearchableLanguageValues.from("nb" -> "Cpekatt emne"),
               defaultRoot = Some("Bapekatt rot"),
+              primaryRoot = SearchableLanguageValues.from("nb" -> "Bapekatt rot"),
               resourceTypeName = SearchableLanguageValues.from("nb" -> "Apekatt ressurs"),
               defaultResourceTypeName = Some("Apekatt ressurs")
             )


### PR DESCRIPTION
Trengs for at aggregeringer på ressurstype ikkje skal gi alt for masse treff. Dette setter en primærkontekst på søkeobjektet, slik at det går an å aggregere på context.resourceTypes.id og kun få en per treff.