### PR TITLE
common: Make `OptLanguageFields` compare without `NotWanted` values

### DIFF
--- a/common/src/test/scala/no/ndla/common/model/domain/LanguageFieldsTest.scala
+++ b/common/src/test/scala/no/ndla/common/model/domain/LanguageFieldsTest.scala
@@ -86,4 +86,28 @@ class LanguageFieldsTest extends UnitTestSuite {
     result.get("en") should be(Some(NotWanted()))
   }
 
+  test("That the OptLanguageFields type compares without unwanted fields") {
+    val a = {
+      val fields = Seq(BaseWithLanguageAndValue[String]("nb", "bokmål"))
+      OptLanguageFields.fromFields(fields).withUnwanted("en")
+    }
+
+    val b = {
+      val fields = Seq(BaseWithLanguageAndValue[String]("nb", "bokmål"))
+      OptLanguageFields.fromFields(fields)
+    }
+    (a == b) should be(true)
+
+    val c = {
+      val fields = Seq(BaseWithLanguageAndValue[String]("nb", "bokmål"))
+      OptLanguageFields.fromFields(fields).withValue("nynorsk", "nn")
+    }
+
+    val d = {
+      val fields = Seq(BaseWithLanguageAndValue[String]("nb", "bokmål"))
+      OptLanguageFields.fromFields(fields)
+    }
+    (c == d) should be(false)
+  }
+
 }


### PR DESCRIPTION
Fikser en bug i draft-api hvor vi trigget status-endringer fordi man sammenlignet med `NotWanted`

Så om man hadde:

disclaimer:
  - "nb" -> "hei"
  - "en" -> "hello"
og oppdaterte til
disclaimer:
  - "nb" -> "hei"
  - "en" -> "hello"
  - "nn" -> `NotWanted`

Så ble det ansett som en endring.
