### PR TITLE
Gjør at validering av url i embed ikkje feiler ved lagring.

### DIFF
--- a/validation/src/main/scala/no/ndla/validation/HtmlTagRules.scala
+++ b/validation/src/main/scala/no/ndla/validation/HtmlTagRules.scala
@@ -14,7 +14,7 @@ import org.jsoup.nodes.Element
 import org.jsoup.nodes.Entities.EscapeMode
 
 import scala.io.Source
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 
 object HtmlTagRules {
 

--- a/validation/src/main/scala/no/ndla/validation/TagValidator.scala
+++ b/validation/src/main/scala/no/ndla/validation/TagValidator.scala
@@ -573,7 +573,7 @@ object TagValidator {
     if (!field.validation.required && value.isEmpty) {
       return None
     }
-    if (value.matches(domainRegex)) {
+    if (value.trim.matches(domainRegex)) {
       if (field.validation.allowedDomains.isEmpty) None
       else {
         val urlHost               = value.hostOption.map(_.toString).getOrElse("")

--- a/validation/src/main/scala/no/ndla/validation/TextValidator.scala
+++ b/validation/src/main/scala/no/ndla/validation/TextValidator.scala
@@ -76,10 +76,10 @@ object TextValidator {
       allowedTags: Set[String]
   ): Seq[ValidationMessage] = {
 
-    val whiteList = new Safelist().addTags(allowedTags.toSeq: _*)
+    val whiteList = new Safelist().addTags(allowedTags.toSeq*)
     HtmlTagRules.allLegalTags
       .filter(tag => HtmlTagRules.legalAttributesForTag(tag).nonEmpty)
-      .foreach(tag => whiteList.addAttributes(tag, HtmlTagRules.legalAttributesForTag(tag).toSeq: _*))
+      .foreach(tag => whiteList.addAttributes(tag, HtmlTagRules.legalAttributesForTag(tag).toSeq*))
 
     if (text.isEmpty) {
       Seq.empty

--- a/validation/src/test/scala/no/ndla/validation/UnitSuite.scala
+++ b/validation/src/test/scala/no/ndla/validation/UnitSuite.scala
@@ -8,7 +8,7 @@
 
 package no.ndla.validation
 
-import org.scalatest._
+import org.scalatest.*
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 


### PR DESCRIPTION
Lagring av noen artikler feiler fordi data-url har whitespace. Og siden den har fleire språkversjoner går det ikkje an å lagre den i det heile tatt. Bør sikkert kjøre trim ved lagring også.