### PR TITLE
Make `dataSource` lazy to avoid initialization before needed

### DIFF
--- a/article-api/src/main/scala/no/ndla/articleapi/ComponentRegistry.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/ComponentRegistry.scala
@@ -83,9 +83,7 @@ class ComponentRegistry(properties: ArticleApiProperties)
   )
   override val DBUtil: DBUtility = new DBUtility
 
-  override val dataSource: HikariDataSource = DataSource.getHikariDataSource
-  DataSource.connectToDatabase()
-
+  lazy val dataSource: HikariDataSource            = DataSource.getHikariDataSource
   lazy val internController                        = new InternController
   lazy val articleControllerV2                     = new ArticleControllerV2
   lazy val healthController: TapirHealthController = new TapirHealthController

--- a/article-api/src/test/scala/no/ndla/articleapi/repository/ArticleRepositoryTest.scala
+++ b/article-api/src/test/scala/no/ndla/articleapi/repository/ArticleRepositoryTest.scala
@@ -15,7 +15,7 @@ import no.ndla.articleapi.model.domain.ArticleIds
 import no.ndla.common.model.domain.Tag
 import no.ndla.common.model.domain.article.Article
 import no.ndla.scalatestsuite.IntegrationSuite
-import scalikejdbc.{AutoSession, ConnectionPool, DataSourceConnectionPool}
+import scalikejdbc.AutoSession
 
 import java.net.Socket
 import scala.util.{Success, Try}
@@ -41,7 +41,7 @@ class ArticleRepositoryTest
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    ConnectionPool.singleton(new DataSourceConnectionPool(dataSource))
+    DataSource.connectToDatabase()
     if (serverIsListening) {
       migrator.migrate()
     }

--- a/audio-api/src/main/scala/no/ndla/audioapi/ComponentRegistry.scala
+++ b/audio-api/src/main/scala/no/ndla/audioapi/ComponentRegistry.scala
@@ -66,8 +66,7 @@ class ComponentRegistry(properties: AudioApiProperties)
     new V5__AddAgreementToAudio,
     new V6__TranslateUntranslatedAuthors
   )
-  override val dataSource: HikariDataSource = DataSource.getHikariDataSource
-  DataSource.connectToDatabase()
+  override lazy val dataSource: HikariDataSource = DataSource.getHikariDataSource
 
   lazy val s3Client           = new NdlaS3Client(props.StorageName, props.StorageRegion)
   lazy val s3TranscribeClient = new NdlaS3Client(props.TranscribeStorageName, props.TranscribeStorageRegion)

--- a/audio-api/src/main/scala/no/ndla/audioapi/repository/AudioRepository.scala
+++ b/audio-api/src/main/scala/no/ndla/audioapi/repository/AudioRepository.scala
@@ -24,8 +24,6 @@ trait AudioRepository {
   val audioRepository: AudioRepository
 
   class AudioRepository extends StrictLogging with Repository[AudioMetaInformation] {
-    ConnectionPool.singleton(new DataSourceConnectionPool(dataSource))
-
     def audioCount(implicit session: DBSession = ReadOnlyAutoSession): Long =
       sql"select count(*) from ${AudioMetaInformation.table}"
         .map(rs => rs.long("count"))

--- a/concept-api/src/main/scala/no/ndla/conceptapi/ComponentRegistry.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/ComponentRegistry.scala
@@ -67,8 +67,7 @@ class ComponentRegistry(properties: ConceptApiProperties)
     new V25__SubjectNameAsTagsPublished(props)
   )
 
-  override val dataSource: HikariDataSource = DataSource.getHikariDataSource
-  DataSource.connectToDatabase()
+  override lazy val dataSource: HikariDataSource = DataSource.getHikariDataSource
 
   lazy val draftConceptRepository     = new DraftConceptRepository
   lazy val publishedConceptRepository = new PublishedConceptRepository

--- a/concept-api/src/test/scala/no/ndla/conceptapi/TestData.scala
+++ b/concept-api/src/test/scala/no/ndla/conceptapi/TestData.scala
@@ -16,13 +16,7 @@ import no.ndla.network.tapir.auth.TokenUser
 import no.ndla.common.model.NDLADate
 import no.ndla.common.model.api.Missing
 import no.ndla.common.model.domain.concept
-import no.ndla.common.model.domain.concept.{
-  Concept,
-  ConceptContent,
-  ConceptType,
-  Status,
-  VisualElement
-}
+import no.ndla.common.model.domain.concept.{Concept, ConceptContent, ConceptType, Status, VisualElement}
 import no.ndla.mapping.License
 
 object TestData {

--- a/concept-api/src/test/scala/no/ndla/conceptapi/service/search/DraftConceptSearchServiceTest.scala
+++ b/concept-api/src/test/scala/no/ndla/conceptapi/service/search/DraftConceptSearchServiceTest.scala
@@ -162,7 +162,12 @@ class DraftConceptSearchServiceTest extends IntegrationSuite(EnableElasticsearch
     tags = Seq(Tag(Seq("stor", "klovn"), "nb")),
     status = concept.Status(current = ConceptStatus.PUBLISHED, other = Set.empty),
     responsible = Some(Responsible("test1", today)),
-    visualElement = Seq(VisualElement(s"""<$EmbedTagName data-resource="image" data-resource_id="test.image" data-url="test.url" />""", "nb"))
+    visualElement = Seq(
+      VisualElement(
+        s"""<$EmbedTagName data-resource="image" data-resource_id="test.image" data-url="test.url" />""",
+        "nb"
+      )
+    )
   )
 
   val concept10: Concept = TestData.sampleConcept.copy(
@@ -656,7 +661,7 @@ class DraftConceptSearchServiceTest extends IntegrationSuite(EnableElasticsearch
       )
 
     search.totalCount should be(2)
-    search.results.map(_.id) should be(List(9,10))
+    search.results.map(_.id) should be(List(9, 10))
   }
 
   test("that search on embedResource matches visual element") {
@@ -709,7 +714,7 @@ class DraftConceptSearchServiceTest extends IntegrationSuite(EnableElasticsearch
       )
 
     search.totalCount should be(2)
-    search.results.map(_.id) should be(List(9,10))
+    search.results.map(_.id) should be(List(9, 10))
   }
 
   test("that search on query parameter matches on concept id") {

--- a/database/src/main/scala/no/ndla/database/DBMigrator.scala
+++ b/database/src/main/scala/no/ndla/database/DBMigrator.scala
@@ -17,6 +17,8 @@ trait DBMigrator {
 
   case class DBMigrator(migrations: JavaMigration*) {
     def migrate(): Unit = {
+      DataSource.connectToDatabase()
+
       val config = Flyway
         .configure()
         .javaMigrations(migrations*)

--- a/draft-api/src/main/scala/no/ndla/draftapi/ComponentRegistry.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/ComponentRegistry.scala
@@ -98,9 +98,8 @@ class ComponentRegistry(properties: DraftApiProperties)
     new V57__MigrateSavedSearch,
     new V66__SetHideBylineForImagesNotCopyrighted
   )
-  override val dataSource: HikariDataSource = DataSource.getHikariDataSource
-  override val DBUtil: DBUtility            = new DBUtility
-  DataSource.connectToDatabase()
+  override lazy val dataSource: HikariDataSource = DataSource.getHikariDataSource
+  override val DBUtil: DBUtility                 = new DBUtility
 
   lazy val draftRepository    = new DraftRepository
   lazy val userDataRepository = new UserDataRepository

--- a/frontpage-api/src/main/scala/no/ndla/frontpageapi/ComponentRegistry.scala
+++ b/frontpage-api/src/main/scala/no/ndla/frontpageapi/ComponentRegistry.scala
@@ -39,10 +39,9 @@ class ComponentRegistry(properties: FrontpageApiProperties)
     with DBMigrator
     with ConverterService
     with SwaggerDocControllerConfig {
-  override val props: FrontpageApiProperties = properties
-  override val migrator: DBMigrator          = DBMigrator()
-  override val dataSource: HikariDataSource  = DataSource.getHikariDataSource
-  DataSource.connectToDatabase()
+  override val props: FrontpageApiProperties     = properties
+  override val migrator: DBMigrator              = DBMigrator()
+  override lazy val dataSource: HikariDataSource = DataSource.getHikariDataSource
 
   override val clock = new SystemClock
 

--- a/image-api/src/main/scala/no/ndla/imageapi/ComponentRegistry.scala
+++ b/image-api/src/main/scala/no/ndla/imageapi/ComponentRegistry.scala
@@ -72,8 +72,7 @@ class ComponentRegistry(properties: ImageApiProperties)
     new V6__AddAgreementToImages,
     new V7__TranslateUntranslatedAuthors
   )
-  override val dataSource: HikariDataSource = DataSource.getHikariDataSource
-  DataSource.connectToDatabase()
+  override lazy val dataSource: HikariDataSource = DataSource.getHikariDataSource
 
   lazy val s3Client = new NdlaS3Client(props.StorageName, props.StorageRegion)
 

--- a/image-api/src/test/scala/no/ndla/imageapi/controller/InternControllerTest.scala
+++ b/image-api/src/test/scala/no/ndla/imageapi/controller/InternControllerTest.scala
@@ -124,9 +124,9 @@ class InternControllerTest extends UnitSuite with TestEnvironment with TapirCont
 
   test("That DELETE /index removes all indexes") {
     when(imageIndexService.findAllIndexes(any[String])).thenReturn(Success(List("index1", "index2", "index3")))
-    doReturn(Success(""), Nil *).when(imageIndexService).deleteIndexWithName(Some("index1"))
-    doReturn(Success(""), Nil *).when(imageIndexService).deleteIndexWithName(Some("index2"))
-    doReturn(Success(""), Nil *).when(imageIndexService).deleteIndexWithName(Some("index3"))
+    doReturn(Success(""), Nil*).when(imageIndexService).deleteIndexWithName(Some("index1"))
+    doReturn(Success(""), Nil*).when(imageIndexService).deleteIndexWithName(Some("index2"))
+    doReturn(Success(""), Nil*).when(imageIndexService).deleteIndexWithName(Some("index3"))
     val res = simpleHttpClient
       .send(quickRequest.delete(uri"http://localhost:$serverPort/intern/index"))
     res.code.code should be(200)
@@ -139,12 +139,12 @@ class InternControllerTest extends UnitSuite with TestEnvironment with TapirCont
   }
 
   test("That DELETE /index fails if at least one index isn't found, and no indexes are deleted") {
-    doReturn(Failure(new RuntimeException("Failed to find indexes")), Nil *)
+    doReturn(Failure(new RuntimeException("Failed to find indexes")), Nil*)
       .when(imageIndexService)
       .findAllIndexes(props.SearchIndex)
-    doReturn(Success(""), Nil *).when(imageIndexService).deleteIndexWithName(Some("index1"))
-    doReturn(Success(""), Nil *).when(imageIndexService).deleteIndexWithName(Some("index2"))
-    doReturn(Success(""), Nil *).when(imageIndexService).deleteIndexWithName(Some("index3"))
+    doReturn(Success(""), Nil*).when(imageIndexService).deleteIndexWithName(Some("index1"))
+    doReturn(Success(""), Nil*).when(imageIndexService).deleteIndexWithName(Some("index2"))
+    doReturn(Success(""), Nil*).when(imageIndexService).deleteIndexWithName(Some("index3"))
     val res = simpleHttpClient
       .send(quickRequest.delete(uri"http://localhost:$serverPort/intern/index"))
     res.code.code should equal(500)
@@ -156,11 +156,11 @@ class InternControllerTest extends UnitSuite with TestEnvironment with TapirCont
     "That DELETE /index fails if at least one index couldn't be deleted, but the other indexes are deleted regardless"
   ) {
     when(imageIndexService.findAllIndexes(any[String])).thenReturn(Success(List("index1", "index2", "index3")))
-    doReturn(Success(""), Nil *).when(imageIndexService).deleteIndexWithName(Some("index1"))
-    doReturn(Failure(new RuntimeException("No index with name 'index2' exists")), Nil *)
+    doReturn(Success(""), Nil*).when(imageIndexService).deleteIndexWithName(Some("index1"))
+    doReturn(Failure(new RuntimeException("No index with name 'index2' exists")), Nil*)
       .when(imageIndexService)
       .deleteIndexWithName(Some("index2"))
-    doReturn(Success(""), Nil *).when(imageIndexService).deleteIndexWithName(Some("index3"))
+    doReturn(Success(""), Nil*).when(imageIndexService).deleteIndexWithName(Some("index3"))
     val res = simpleHttpClient
       .send(quickRequest.delete(uri"http://localhost:$serverPort/intern/index"))
     res.code.code should equal(500)

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/ComponentRegistry.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/ComponentRegistry.scala
@@ -86,8 +86,7 @@ class ComponentRegistry(properties: LearningpathApiProperties)
     new V31__ArenaDefaultEnabledOrgs,
     new V33__AiDefaultEnabledOrgs
   )
-  override val dataSource: HikariDataSource = DataSource.getHikariDataSource
-  DataSource.connectToDatabase()
+  override lazy val dataSource: HikariDataSource = DataSource.getHikariDataSource
 
   lazy val learningPathRepository = new LearningPathRepository
   lazy val readService            = new ReadService

--- a/myndla-api/src/main/scala/no/ndla/myndlaapi/ComponentRegistry.scala
+++ b/myndla-api/src/main/scala/no/ndla/myndlaapi/ComponentRegistry.scala
@@ -93,9 +93,8 @@ class ComponentRegistry(properties: MyNdlaApiProperties)
   lazy val v16__MigrateResourcePaths: V16__MigrateResourcePaths = new V16__MigrateResourcePaths
   lazy val DBUtil                                               = new DBUtility
 
-  override val migrator: DBMigrator         = DBMigrator(v16__MigrateResourcePaths)
-  override val dataSource: HikariDataSource = DataSource.getHikariDataSource
-  DataSource.connectToDatabase()
+  override val migrator: DBMigrator              = DBMigrator(v16__MigrateResourcePaths)
+  override lazy val dataSource: HikariDataSource = DataSource.getHikariDataSource
 
   val swagger = new SwaggerController(
     List(


### PR DESCRIPTION
Since we now start the applications when generating typescript we need to be able to build the component registry without connecting to a database.

This patch moves the actual database connecting to `DBMigrator` and make the `dataSource` member lazy so it isn't accessed before needed.