### PR TITLE
Add grepkodes for nodes.

### DIFF
--- a/search-api/src/main/scala/no/ndla/searchapi/model/grep/GrepBundle.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/model/grep/GrepBundle.scala
@@ -11,7 +11,7 @@ package no.ndla.searchapi.model.grep
 case class GrepBundle(
     kjerneelementer: List[GrepKjerneelement],
     kompetansemaal: List[GrepKompetansemaal],
-    kompetansemaalsett: List[GrepElement],
+    kompetansemaalsett: List[GrepKompetansemaalSett],
     tverrfagligeTemaer: List[GrepElement],
     laereplaner: List[GrepLaererplan]
 ) {
@@ -26,4 +26,6 @@ case class GrepBundle(
   val grepContextByCode: Map[String, GrepElement] =
     Map.from(grepContext.map(elem => elem.kode -> elem))
 
+  val grepKompetansemaalSettByCode: Map[String, GrepKompetansemaalSett] =
+    Map.from(kompetansemaalsett.map(elem => elem.kode -> elem))
 }

--- a/search-api/src/main/scala/no/ndla/searchapi/model/grep/GrepBundle.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/model/grep/GrepBundle.scala
@@ -26,6 +26,4 @@ case class GrepBundle(
   val grepContextByCode: Map[String, GrepElement] =
     Map.from(grepContext.map(elem => elem.kode -> elem))
 
-  val grepKompetansemaalSettByCode: Map[String, GrepKompetansemaalSett] =
-    Map.from(kompetansemaalsett.map(elem => elem.kode -> elem))
 }

--- a/search-api/src/main/scala/no/ndla/searchapi/model/grep/GrepElement.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/model/grep/GrepElement.scala
@@ -16,6 +16,9 @@ import io.circe.syntax.EncoderOps
 sealed trait GrepElement {
   val kode: String
   def getTitle: Seq[GrepTitle]
+  def getTitleValue(language: String): Option[String] = {
+    getTitle.find(title => title.spraak == language).map(title => title.verdi)
+  }
 }
 object GrepElement {
   implicit val decoder: Decoder[GrepElement] =

--- a/search-api/src/main/scala/no/ndla/searchapi/model/search/SearchableNode.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/model/search/SearchableNode.scala
@@ -21,7 +21,8 @@ case class SearchableNode(
     nodeType: NodeType,
     subjectPage: Option[SearchableSubjectPage],
     context: Option[SearchableTaxonomyContext],
-    contexts: List[SearchableTaxonomyContext]
+    contexts: List[SearchableTaxonomyContext],
+    grepContexts: List[SearchableGrepContext]
 )
 
 object SearchableNode {

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/MultiSearchService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/MultiSearchService.scala
@@ -249,10 +249,15 @@ trait MultiSearchService {
     private def getNodeSearchFilters(settings: SearchSettings): List[Query] = {
       val nodeTypeFilter       = getNodeTypeFilter(settings.nodeTypeFilter)
       val contextSubjectFilter = subjectFilter(settings.subjects, settings.filterInactive)
+      val grepCodesFilter =
+        if (settings.grepCodes.nonEmpty)
+          Some(termsQuery("grepContexts.code", settings.grepCodes))
+        else None
 
       List(
         nodeTypeFilter,
-        contextSubjectFilter
+        contextSubjectFilter,
+        grepCodesFilter
       ).flatten
     }
 

--- a/search-api/src/test/scala/no/ndla/searchapi/service/search/SearchConverterServiceTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/service/search/SearchConverterServiceTest.scala
@@ -19,9 +19,11 @@ import no.ndla.searchapi.model.grep.{
   BelongsToObj,
   GrepKjerneelement,
   GrepKompetansemaal,
+  GrepKompetansemaalSett,
+  GrepTextObj,
   GrepTitle,
   GrepTverrfagligTema,
-  GrepTextObj
+  ReferenceObj
 }
 import no.ndla.searchapi.model.search.{SearchableArticle, SearchableGrepContext}
 import no.ndla.searchapi.model.taxonomy.*
@@ -657,6 +659,50 @@ class SearchConverterServiceTest extends UnitSuite with TestEnvironment {
         )
       )
     )
+  }
+
+  test("That asSearchableNode converts grepContexts correctly based on grepBundle if node has KV grepCode") {
+    val node = TestData.subject_1.copy(metadata = Some(Metadata(Seq("KV123"), visible = true, Map.empty)))
+    val grepBundle = TestData.emptyGrepBundle.copy(
+      kompetansemaalsett = List(
+        GrepKompetansemaalSett(
+          "KV123",
+          GrepTextObj(List(GrepTitle("default", "tittel123"))),
+          BelongsToObj("LP123", "Dette er LP123"),
+          List(
+            ReferenceObj("KM123", "Tittel KM123"),
+            ReferenceObj("KM234", "Tittel KM234")
+          )
+        )
+      ),
+      kompetansemaal = List(
+        GrepKompetansemaal(
+          "KM123",
+          GrepTextObj(List(GrepTitle("default", "tittel123"))),
+          BelongsToObj("LP123", "Dette er LP123"),
+          BelongsToObj("KV123", "Dette er KV123"),
+          List(),
+          List(),
+          None
+        ),
+        GrepKompetansemaal(
+          "KM234",
+          GrepTextObj(List(GrepTitle("default", "tittel234"))),
+          BelongsToObj("LP123", "Dette er LP123"),
+          BelongsToObj("KV123", "Dette er KV123"),
+          List(),
+          List(),
+          None
+        )
+      )
+    )
+    val grepContexts = List(
+      SearchableGrepContext("KM123", Some("tittel123")),
+      SearchableGrepContext("KM234", Some("tittel234"))
+    )
+    val Success(searchableNode) =
+      searchConverterService.asSearchableNode(node, None, IndexingBundle(Some(grepBundle), Some(emptyBundle), None))
+    searchableNode.grepContexts should equal(grepContexts)
   }
 
   private def verifyTitles(searchableArticle: SearchableArticle): Unit = {

--- a/search-api/src/test/scala/no/ndla/searchapi/service/search/SearchConverterServiceTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/service/search/SearchConverterServiceTest.scala
@@ -698,7 +698,8 @@ class SearchConverterServiceTest extends UnitSuite with TestEnvironment {
     )
     val grepContexts = List(
       SearchableGrepContext("KM123", Some("tittel123")),
-      SearchableGrepContext("KM234", Some("tittel234"))
+      SearchableGrepContext("KM234", Some("tittel234")),
+      SearchableGrepContext("KV123", Some("tittel123"))
     )
     val Success(searchableNode) =
       searchConverterService.asSearchableNode(node, None, IndexingBundle(Some(grepBundle), Some(emptyBundle), None))


### PR DESCRIPTION
Oversetter grepkode for kompetansemålsett til å ta med verdier for tilhørende kompetansemål. Dette gjør at du kan få treff på fag kun dersom et kompetansemål er i settet som er satt på faget.