### PR TITLE
Update validation: Allow target and rel attributes on anchor

### DIFF
--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/db/migration/V44__AddTargetAndRelToAnchors.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/db/migration/V44__AddTargetAndRelToAnchors.scala
@@ -1,0 +1,68 @@
+/*
+ * Part of NDLA learningpath-api
+ * Copyright (C) 2025 NDLA
+ *
+ * See LICENSE
+ *
+ */
+
+package no.ndla.learningpathapi.db.migration
+
+import io.circe.parser
+import io.circe.generic.auto.*
+import io.circe.syntax.EncoderOps
+import no.ndla.database.DocumentMigration
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Entities.EscapeMode
+
+class V44__AddTargetAndRelToAnchors extends DocumentMigration {
+  override val tableName: String  = "learningsteps"
+  override val columnName: String = "document"
+
+  override def convertColumn(value: String): String = {
+    val oldDocument = parser.parse(value).toTry.get
+    val description = oldDocument.hcursor
+      .downField("description")
+      .as[Option[List[OldDescription]]]
+      .toTry
+      .get
+      .getOrElse(List.empty)
+
+    val newDescription = description.map(d => convertDescription(d))
+
+    val newDocument = oldDocument.hcursor
+      .withFocus {
+        _.mapObject { obj =>
+          obj
+            .remove("description")
+            .add("description", newDescription.asJson)
+        }
+      }
+
+    newDocument.top.get.noSpaces
+  }
+
+  def convertHtml(str: String): String = {
+    val document = Jsoup.parseBodyFragment(str)
+    document
+      .outputSettings()
+      .escapeMode(EscapeMode.xhtml)
+      .prettyPrint(false)
+      .indentAmount(0)
+
+    document
+      .select("a")
+      .forEach(anchor => {
+        anchor.attr("target", "_blank"): Unit
+        anchor.attr("rel", "noopener noreferrer"): Unit
+      })
+    document.select("body").first().html()
+  }
+
+  private def convertDescription(description: OldDescription): OldDescription = {
+    val convertedHtmlDescription = convertHtml(description.description)
+    description.copy(description = convertedHtmlDescription)
+  }
+}
+
+case class OldDescription(description: String, language: String)

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/validation/TextValidator.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/validation/TextValidator.scala
@@ -38,7 +38,7 @@ trait TextValidator {
       if (text.isEmpty) {
         Some(ValidationMessage(fieldPath, FieldEmpty))
       } else {
-        if (Jsoup.isValid(text, Safelist.basic().addTags("section"))) {
+        if (Jsoup.isValid(text, Safelist.basic().addTags("section").addAttributes("a", "target", "rel"))) {
           None
         } else {
           Some(ValidationMessage(fieldPath, IllegalContentInBasicText))

--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/db/migration/V44__AddTargetAndRelToAnchorsTest.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/db/migration/V44__AddTargetAndRelToAnchorsTest.scala
@@ -1,0 +1,62 @@
+/*
+ * Part of NDLA learningpath-api
+ * Copyright (C) 2025 NDLA
+ *
+ * See LICENSE
+ *
+ */
+
+package no.ndla.learningpathapi.db.migration
+
+import io.circe.parser
+import no.ndla.learningpathapi.{TestEnvironment, UnitSuite}
+
+class V44__AddTargetAndRelToAnchorsTest extends UnitSuite with TestEnvironment {
+
+  test("that urls are converted to anchors with target and rel") {
+    val migration = new V44__AddTargetAndRelToAnchors
+    val oldDocument =
+      """
+        |{
+        |  "description": [
+        |    {
+        |      "description": "Læringssti om <a href=\"https://example.com\">temaet</a> geologiske prosesser.",
+        |      "language": "nb"
+        |    }
+        |  ]
+        |}
+        |""".stripMargin
+
+    val expectedDocument =
+      """
+        |{
+        |  "description": [
+        |    {
+        |      "description": "Læringssti om <a href=\"https://example.com\" target=\"_blank\" rel=\"noopener noreferrer\">temaet</a> geologiske prosesser.",
+        |      "language": "nb"
+        |    }
+        |  ]
+        |}
+        |""".stripMargin
+    val expected = parser.parse(expectedDocument).toTry.get
+    migration.convertColumn(oldDocument) should be(expected.noSpaces)
+  }
+
+  test("that no html descriptions are left alone") {
+    val migration = new V44__AddTargetAndRelToAnchors
+    val oldDocument =
+      """
+        |{
+        |  "description": [
+        |    {
+        |      "description": "Læringssti om temaet geologiske prosesser.",
+        |      "language": "nb"
+        |    }
+        |  ]
+        |}
+        |""".stripMargin
+
+    val expected = parser.parse(oldDocument).toTry.get
+    migration.convertColumn(oldDocument) should be(expected.noSpaces)
+  }
+}

--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/validation/TextValidatorTest.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/validation/TextValidatorTest.scala
@@ -32,7 +32,7 @@ class TextValidatorTest extends UnitSuite with TestEnvironment {
   test("That TextValidator allows links in html") {
     allowedHtmlValidator.validate(
       "path1",
-      """<p>This is plain text with a <a href="https://ndla.no">link</a></p>"""
+      """<p>This is plain text with a <a href="https://ndla.no" target="_blank" rel="noopener noreferrer">link</a></p>"""
     ) should equal(None)
   }
 


### PR DESCRIPTION
Her trengs det også en migrering som legger på `target="_blank"` og `rel="noopener noreferrer"` på anchor tags i description på læringsstisteg @jnatten  😇 