### PR TITLE
Remove hacky schema post processing

### DIFF
--- a/common/src/main/scala/no/ndla/common/model/api/UpdateOrDelete.scala
+++ b/common/src/main/scala/no/ndla/common/model/api/UpdateOrDelete.scala
@@ -8,9 +8,8 @@
 
 package no.ndla.common.model.api
 
-import cats.implicits.catsSyntaxOptionId
 import io.circe.{Decoder, Encoder, FailedCursor, Json}
-import sttp.tapir.{FieldName, Schema, SchemaType}
+import sttp.tapir.Schema
 
 import java.util.UUID
 
@@ -30,40 +29,8 @@ final case class UpdateWith[A](value: A) extends UpdateOrDelete[A]
 object UpdateOrDelete {
   val schemaName = s"UpdateOrDeleteInnerSchema-${UUID.randomUUID()}"
 
-  def replaceSchema(schema: sttp.apispec.Schema): Option[sttp.apispec.Schema] = {
-    val updateOrDeleteSchema = schema.properties.find { case (k, _) =>
-      k == UpdateOrDelete.schemaName
-    }
-
-    updateOrDeleteSchema match {
-      case Some((_, v: sttp.apispec.Schema)) =>
-        v
-          .copy(
-            title = schema.title,
-            description = schema.description,
-            deprecated = schema.deprecated
-          )
-          .nullable
-          .some
-      case _ => None
-    }
-  }
-
-  implicit def schema[T](implicit subschema: Schema[T]): Schema[UpdateOrDelete[T]] = {
-    val st: SchemaType.SProduct[UpdateOrDelete[T]] = SchemaType.SProduct(
-      List(
-        SchemaType.SProductField[UpdateOrDelete[T], Any](
-          FieldName(schemaName),
-          subschema.as,
-          _ => throw new RuntimeException("This is a bug")
-        )
-      )
-    )
-
-    subschema.asOption
-      .as[UpdateOrDelete[T]]
-      .copy(schemaType = st)
-  }
+  implicit def schema[T](implicit subschema: Schema[T]): Schema[UpdateOrDelete[T]] =
+    subschema.nullable.asOption.as[UpdateOrDelete[T]]
 
   implicit def decodeUpdateOrDelete[A](implicit decodeA: Decoder[A]): Decoder[UpdateOrDelete[A]] =
     Decoder.withReattempt {

--- a/network/src/main/scala/no/ndla/network/tapir/SwaggerControllerConfig.scala
+++ b/network/src/main/scala/no/ndla/network/tapir/SwaggerControllerConfig.scala
@@ -11,10 +11,8 @@ package no.ndla.network.tapir
 import cats.implicits.*
 import io.circe.Json
 import no.ndla.common.configuration.HasBaseProps
-import no.ndla.common.model.api.UpdateOrDelete
-import sttp.apispec
 import sttp.apispec.openapi.{Components, Contact, Info, License}
-import sttp.apispec.{AnySchema, OAuthFlow, OAuthFlows, SchemaLike, SecurityScheme}
+import sttp.apispec.{OAuthFlow, OAuthFlows, SecurityScheme}
 import sttp.tapir.*
 import sttp.tapir.docs.openapi.{OpenAPIDocsInterpreter, OpenAPIDocsOptions}
 import sttp.tapir.server.ServerEndpoint
@@ -63,46 +61,12 @@ trait SwaggerControllerConfig {
       openIdConnectUrl = None
     )
 
-    /** NOTE: This is a hack to allow us to create nullable types in the specification. If possible this should probably
-      * be replaced by a tapir alternative when that is possible.
-      *
-      * https://github.com/softwaremill/tapir/issues/2953
-      */
-    private val schemaPostProcessingFunctions: List[apispec.Schema => Option[apispec.Schema]] = List(
-      UpdateOrDelete.replaceSchema
-    )
-
-    private def postProcessSchema(schema: SchemaLike): SchemaLike = {
-      schema match {
-        case schema: AnySchema => schema
-        case schema: apispec.Schema =>
-          val convertedSchema = schemaPostProcessingFunctions.foldLeft(None: Option[apispec.Schema]) {
-            case (None, f)                  => f(schema)
-            case (Some(convertedSchema), _) => Some(convertedSchema)
-          }
-
-          convertedSchema match {
-            case Some(value) => value
-            case None =>
-              val props = schema.properties.map {
-                case (k, v: apispec.Schema) => k -> postProcessSchema(v)
-                case (k, v)                 => k -> v
-              }
-              schema.copy(properties = props)
-          }
-      }
-    }
-
     private val docs: Json = {
       val options             = OpenAPIDocsOptions.default
       val docs                = OpenAPIDocsInterpreter(options).serverEndpointsToOpenAPI(swaggerEndpoints, info)
       val generatedComponents = docs.components.getOrElse(Components.Empty)
-      val newSchemas          = generatedComponents.schemas.map { case (k, v) => k -> postProcessSchema(v) }
-      val newComponents = generatedComponents.copy(
-        securitySchemes = ListMap("oauth2" -> Right(securityScheme)),
-        schemas = newSchemas
-      )
-      val docsWithComponents = docs.components(newComponents).asJson
+      val newComponents       = generatedComponents.copy(securitySchemes = ListMap("oauth2" -> Right(securityScheme)))
+      val docsWithComponents  = docs.components(newComponents).asJson
       docsWithComponents.asJson
     }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
     val FlywayV               = "11.4.0"
     val PostgresV             = "42.7.5"
     val Http4sV               = "0.23.30"
-    val TapirV                = "1.11.19"
+    val TapirV                = "1.11.23"
     val ApiSpecV              = "0.11.7"
     val SttpV                 = "3.9.7"
     val CirceV                = "0.14.12"


### PR DESCRIPTION
Etter tapir [v1.11.21](https://github.com/softwaremill/tapir/releases/tag/v1.11.21) så kan vi bruke `nullable` attributtet på tapir-schema'et istedenfor å hacke oss rundt det med postprossesering.