### PR TITLE
Fix log4j sbt reference

### DIFF
--- a/project/Module.scala
+++ b/project/Module.scala
@@ -54,8 +54,8 @@ trait Module {
     javaOptions ++= reflectiveAccessOptions,
     tpolecatScalacOptions ++= scalacOptions,
     tpolecatExcludeOptions ++= excludeOptions,
-    Compile / unmanagedResources += file("log4j2.yaml"),
-    Test / unmanagedResources += file("log4j2-test.yaml"),
+    Compile / unmanagedResources += (ThisBuild / baseDirectory).value / "log4j2.yaml",
+    Test / unmanagedResources += (ThisBuild / baseDirectory).value / "log4j2-test.yaml",
     Test / tpolecatExcludeOptions ++= testExcludeOptions,
     Test / parallelExecution := false,
     resolvers ++= scala.util.Properties


### PR DESCRIPTION
Dette gjorde at bloop kræsja (som brukes av metals), så om noen ville prøve seg på metals så ble det en fryktelig dårlig opplevelse.

(Ikke se på klokkeslettet på denne PR'en)