### PR TITLE
search-api: Begin indexing programme contexts

### DIFF
--- a/search-api/src/main/scala/no/ndla/searchapi/integration/TaxonomyApiClient.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/integration/TaxonomyApiClient.scala
@@ -53,11 +53,10 @@ trait TaxonomyApiClient {
         s"$TaxonomyApiEndpoint/nodes/search",
         headers = getVersionHashHeader(shouldUsePublishedTax),
         Seq(
-          "pageSize"         -> "500",
-          "nodeType"         -> NodeType.RESOURCE.toString,
-          "includeContexts"  -> "true",
-          "filterProgrammes" -> "true",
-          "isVisible"        -> getIsVisibleParam(shouldUsePublishedTax)
+          "pageSize"        -> "500",
+          "nodeType"        -> NodeType.RESOURCE.toString,
+          "includeContexts" -> "true",
+          "isVisible"       -> getIsVisibleParam(shouldUsePublishedTax)
         )
       )
 
@@ -133,7 +132,7 @@ trait TaxonomyApiClient {
       def fetchPage(p: Seq[(String, String)]): Try[PaginationPage[T]] =
         get[PaginationPage[T]](url, headers, p)
 
-      val pageSize   = params.toMap.get("pageSize").get.toInt
+      val pageSize   = params.toMap.getOrElse("pageSize", "100").toInt
       val pageParams = params :+ ("page" -> "1")
       fetchPage(pageParams).flatMap(firstPage => {
         val numPages  = Math.ceil(firstPage.totalCount.toDouble / pageSize.toDouble).toInt

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
@@ -678,7 +678,10 @@ trait SearchConverterService {
         language: String,
         filterInactive: Boolean
     ): List[ApiTaxonomyContextDTO] = {
-      val filtered = if (filterInactive) contexts.filter(c => c.isActive) else contexts
+      val filtered = contexts.filter { c =>
+        // Filter inactive if required, and also don't show programme contexts
+        (!filterInactive || c.isActive) && !c.rootId.startsWith("urn:programme:")
+      }
       filtered.sortBy(!_.isPrimary).map(c => searchableContextToApiContext(c, language))
     }
 


### PR DESCRIPTION
https://trello.com/c/5oir3xYY/1343-legge-til-filter-p%C3%A5-utdanningsprogram-s%C3%B8keside

Indekserer programme kontekster, men filtrerer de ut på vei ut av apiet.
Dette gjør at `subjects` filtered fungerer med programme id'er.

Dette gjør at indekseringsprosessen bruker en god del mer minne [så vi må øke `Xmx` på cronjob'en](https://github.com/NDLANO/deploy/pull/1091).