### PR TITLE
Only subject roots can be truly primary

### DIFF
--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
@@ -543,7 +543,7 @@ trait SearchConverterService {
           .getOrElse(Seq.empty)
       )
 
-      val primaryContext           = taxonomyContexts.find(_.isPrimary)
+      val primaryContext           = taxonomyContexts.find(tc => tc.isPrimary && tc.rootId.startsWith("urn:subject:"))
       val primaryRoot              = primaryContext.map(_.root).getOrElse(SearchableLanguageValues.empty)
       val sortableResourceTypeName = getSortableResourceTypeName(draft, taxonomyContexts)
 


### PR DESCRIPTION
I arbeidslista i ed har programområder sneke seg inn i lista over primærfag:
![image](https://github.com/user-attachments/assets/9e814ad4-6525-46e7-928a-1474c87c5b39)

Dette fikser det slik at kun fag-kontekster kan være rot/primærkontekst.