### PR TITLE
stop logging rollback exceptions as errors by default

### DIFF
--- a/article-api/src/main/scala/no/ndla/articleapi/MainClass.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/MainClass.scala
@@ -27,9 +27,6 @@ class MainClass(override val props: ArticleApiProperties) extends NdlaTapirMain[
   }
 
   override def beforeStart(): Unit = {
-    logger.info("Starting the db migration...")
-    val startDBMillis = System.currentTimeMillis()
     componentRegistry.migrator.migrate()
-    logger.info(s"Done db migration, took ${System.currentTimeMillis() - startDBMillis}ms")
   }
 }

--- a/audio-api/src/main/scala/no/ndla/audioapi/MainClass.scala
+++ b/audio-api/src/main/scala/no/ndla/audioapi/MainClass.scala
@@ -26,9 +26,6 @@ class MainClass(val props: AudioApiProperties) extends NdlaTapirMain[ComponentRe
   }
 
   def beforeStart(): Unit = {
-    logger.info("Starting DB Migration")
-    val dBstartMillis = System.currentTimeMillis()
     componentRegistry.migrator.migrate()
-    logger.info(s"Done DB Migration took ${System.currentTimeMillis() - dBstartMillis} ms")
   }
 }

--- a/common/src/main/scala/no/ndla/common/logging/package.scala
+++ b/common/src/main/scala/no/ndla/common/logging/package.scala
@@ -13,7 +13,11 @@ import com.typesafe.scalalogging.StrictLogging
 import scala.concurrent.duration.*
 
 package object logging extends StrictLogging {
-  def logTaskTime[T](taskName: String, warnLimit: Duration = Duration.Zero)(task: => T): T = {
+  def logTaskTime[T](taskName: String, warnLimit: Duration = Duration.Zero, logTaskStart: Boolean = false)(
+      task: => T
+  ): T = {
+    if (logTaskStart) logger.info(s"Task '$taskName' started...")
+
     val start  = System.nanoTime()
     val result = task
     val end    = System.nanoTime()
@@ -21,9 +25,9 @@ package object logging extends StrictLogging {
     val taskDuration = Duration.fromNanos(end - start).toMillis.millis
 
     if (warnLimit != Duration.Zero && taskDuration >= warnLimit) {
-      logger.warn(s"Task $taskName took $taskDuration")
+      logger.warn(s"Task '$taskName' took $taskDuration")
     } else {
-      logger.info(s"Task $taskName took $taskDuration")
+      logger.info(s"Task '$taskName' took $taskDuration")
     }
     result
   }

--- a/concept-api/src/main/scala/no/ndla/conceptapi/MainClass.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/MainClass.scala
@@ -26,9 +26,6 @@ class MainClass(override val props: ConceptApiProperties) extends NdlaTapirMain[
   }
 
   override def beforeStart(): Unit = {
-    logger.info("Starting the db migration...")
-    val startDBMillis = System.currentTimeMillis()
     componentRegistry.migrator.migrate()
-    logger.info(s"Done db migration, took ${System.currentTimeMillis() - startDBMillis}ms")
   }
 }

--- a/database/src/main/scala/no/ndla/database/DBUtility.scala
+++ b/database/src/main/scala/no/ndla/database/DBUtility.scala
@@ -30,7 +30,7 @@ trait DBUtility {
         }
       } catch {
         case rbex: RollbackException =>
-          logger.error("Rolling back transaction due to failure", rbex)
+          logger.info("Rolling back transaction due to failure", rbex)
           Failure(rbex.ex)
       }
     }

--- a/draft-api/src/main/scala/no/ndla/draftapi/MainClass.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/MainClass.scala
@@ -26,9 +26,6 @@ class MainClass(override val props: DraftApiProperties) extends NdlaTapirMain[Co
   }
 
   override def beforeStart(): Unit = {
-    logger.info("Starting the db migration...")
-    val startDBMillis = System.currentTimeMillis()
     componentRegistry.migrator.migrate()
-    logger.info(s"Done db migration, took ${System.currentTimeMillis() - startDBMillis}ms")
   }
 }

--- a/frontpage-api/src/main/scala/no/ndla/frontpageapi/MainClass.scala
+++ b/frontpage-api/src/main/scala/no/ndla/frontpageapi/MainClass.scala
@@ -15,10 +15,7 @@ class MainClass(override val props: FrontpageApiProperties) extends NdlaTapirMai
   val componentRegistry = new ComponentRegistry(props)
 
   override def beforeStart(): Unit = {
-    logger.info("Starting DB Migration")
-    val dBstartMillis = System.currentTimeMillis()
     componentRegistry.migrator.migrate()
-    logger.info(s"Done DB Migration took ${System.currentTimeMillis() - dBstartMillis} ms")
   }
 
   private def warmupRequest = (path: String) => Warmup.warmupRequest(props.ApplicationPort, path, Map.empty)

--- a/image-api/src/main/scala/no/ndla/imageapi/MainClass.scala
+++ b/image-api/src/main/scala/no/ndla/imageapi/MainClass.scala
@@ -27,11 +27,7 @@ class MainClass(override val props: ImageApiProperties) extends NdlaTapirMain[Co
   }
 
   override def beforeStart(): Unit = {
-    logger.info("Starting DB Migration")
-    val DbStartMillis = System.currentTimeMillis()
     componentRegistry.migrator.migrate()
-    logger.info(s"Done DB Migration took ${System.currentTimeMillis() - DbStartMillis} ms")
-
     componentRegistry.imageSearchService.createEmptyIndexIfNoIndexesExist()
     componentRegistry.tagSearchService.createEmptyIndexIfNoIndexesExist()
   }

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/MainClass.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/MainClass.scala
@@ -26,9 +26,6 @@ class MainClass(override val props: LearningpathApiProperties) extends NdlaTapir
   }
 
   override def beforeStart(): Unit = {
-    logger.info("Starting the db migration...")
-    val startDBMillis = System.currentTimeMillis()
     componentRegistry.migrator.migrate()
-    logger.info(s"Done db migration, took ${System.currentTimeMillis() - startDBMillis}ms")
   }
 }

--- a/myndla-api/src/main/scala/no/ndla/myndlaapi/MainClass.scala
+++ b/myndla-api/src/main/scala/no/ndla/myndlaapi/MainClass.scala
@@ -24,9 +24,6 @@ class MainClass(override val props: MyNdlaApiProperties) extends NdlaTapirMain[C
   }
 
   override def beforeStart(): Unit = {
-    logger.info("Starting the db migration...")
-    val startDBMillis = System.currentTimeMillis()
     componentRegistry.migrator.migrate()
-    logger.info(s"Done db migration, took ${System.currentTimeMillis() - startDBMillis}ms")
   }
 }


### PR DESCRIPTION
Merket at disse ble logget som feil da jeg prøvde å klone en mappe som ikke fantes.
Tenker at feilloggingen burde skje i error handleren i controlleren fremfor i denne funksjonen dersom det er noe faktisk galt 😄 (Og det skjer jo egentlig allerede, så dette tilførte bare støy).

La også på logging for utførte migreringer sånn at det er litt enklere å se hva som faktisk skjer når migreringer kjører.

