### PR TITLE
network: log request information if the request results in an error

### DIFF
--- a/log4j2.yaml
+++ b/log4j2.yaml
@@ -22,7 +22,7 @@ Configuration:
   Loggers:
     Logger:
       name: "no.ndla"
-      level: info
+      level: debug
       additivity: false
       AppenderRef:
         - ref: ${env:LOG_APPENDER:-Console}


### PR DESCRIPTION
Samme tanke som i graphql-api. Forhåpentligvis litt enklere å finne ut hva som går galt når ting går galt dersom vi logger request bodies (og headers).