### PR TITLE
Graceful shutdowns

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,4 +28,4 @@ jobs:
           DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
           RELEASE_ROLE: ${{ secrets.CI_RELEASE_ROLE }}
       - name: Unit tests
-        run: sbt {{ inputs.subproject }}/test
+        run: sbt ${{ inputs.subproject }}/test

--- a/common/src/main/scala/no/ndla/common/Warmup.scala
+++ b/common/src/main/scala/no/ndla/common/Warmup.scala
@@ -14,8 +14,8 @@ import sttp.client3.quick._
 import scala.concurrent.duration.DurationInt
 
 trait Warmup {
-  var isWarmedUp: Boolean = false
-  def setWarmedUp(): Unit = this.isWarmedUp = true
+  @volatile var isWarmedUp: Boolean = false
+  def setWarmedUp(): Unit           = this.isWarmedUp = true
 }
 
 object Warmup extends StrictLogging {

--- a/common/src/main/scala/no/ndla/common/configuration/BaseProps.scala
+++ b/common/src/main/scala/no/ndla/common/configuration/BaseProps.scala
@@ -13,6 +13,7 @@ import sttp.client3.UriContext
 import sttp.model.Uri
 
 import scala.collection.mutable
+import scala.concurrent.duration.{Duration, DurationInt}
 import scala.util.Properties.{propOrElse, propOrNone}
 import scala.util.{Failure, Success, Try}
 
@@ -144,5 +145,7 @@ trait BaseProps extends StrictLogging {
     uri"https://cms.api.brightcove.com/v1/accounts/$accountId/videos/$videoId/sources"
 
   def DisableLicense: Boolean = booleanPropOrElse("DISABLE_LICENSE", default = false)
+
+  def ReadinessProbeDetectionTimeoutSeconds: Duration = intPropOrDefault("READINESS_PROBE_DETECTION_SECONDS", 7).seconds
 
 }

--- a/log4j2.yaml
+++ b/log4j2.yaml
@@ -1,5 +1,6 @@
 Configuration:
   status: warn
+  shutdownHook: disable
 
   Appenders:
     Console:

--- a/network/src/main/scala/no/ndla/network/tapir/NdlaTapirMain.scala
+++ b/network/src/main/scala/no/ndla/network/tapir/NdlaTapirMain.scala
@@ -10,10 +10,14 @@ package no.ndla.network.tapir
 
 import no.ndla.common.Environment.setPropsFromEnv
 import no.ndla.common.configuration.BaseProps
+import no.ndla.common.logging.logTaskTime
+import org.apache.logging.log4j.core.LoggerContext
 import org.apache.logging.log4j.jul.Log4jBridgeHandler
 import org.log4s.{Logger, getLogger}
+import sttp.tapir.server.jdkhttp.HttpServer
 
 import scala.concurrent.Future
+import scala.concurrent.duration.{Duration, DurationInt}
 import scala.io.Source
 import scala.util.Try
 
@@ -24,6 +28,7 @@ trait NdlaTapirMain[T <: TapirApplication] {
   val componentRegistry: T
   def warmup(): Unit
   def beforeStart(): Unit
+  var server: Option[HttpServer] = None
 
   private def logCopyrightHeader(): Unit = {
     if (!props.DisableLicense) {
@@ -32,7 +37,10 @@ trait NdlaTapirMain[T <: TapirApplication] {
   }
 
   def startServer(name: String, port: Int)(warmupFunc: => Unit): Unit = {
-    componentRegistry.Routes.startJdkServer(name, port)(warmupFunc)
+    val server = componentRegistry.Routes.startJdkServerAsync(name, port)(warmupFunc)
+    this.server = Some(server)
+    // NOTE: Since JdkHttpServer does not block, we need to block the main thread to keep the application alive
+    synchronized { wait() }
   }
 
   private def performWarmup(): Unit = if (!props.disableWarmup) {
@@ -52,15 +60,57 @@ trait NdlaTapirMain[T <: TapirApplication] {
     componentRegistry.healthController.setWarmedUp()
   }
 
-  def runServer(): Try[Unit] = {
+  private def waitForActiveRequests(timeout: Duration): Unit = {
+    val startTime      = System.currentTimeMillis()
+    val activeRequests = componentRegistry.Routes.activeRequests.get()
+    logTaskTime(s"Waiting for $activeRequests active requests to finish...", timeout, logTaskStart = true) {
+      while (componentRegistry.Routes.activeRequests.get() > 0) {
+        if (System.currentTimeMillis() - startTime > timeout.toMillis) {
+          logger.warn(s"Timeout of $timeout reached while waiting for active requests to finish.")
+          return
+        }
+        Thread.sleep(100)
+      }
+    }
+  }
+
+  private val gracefulShutdownTimeout = 30.seconds
+  private def setupShutdownHook(): Unit = sys.addShutdownHook {
+    logger.info("Shutting down gracefully...")
+    componentRegistry.healthController.setShuttingDown()
+    this.server match {
+      case Some(server) =>
+        val gracePeriod = props.ReadinessProbeDetectionTimeoutSeconds
+        logger.info(s"Waiting $gracePeriod for shutdown to be detected before stopping...")
+        Thread.sleep(gracePeriod.toMillis)
+        logger.info("Grace period finished, stopping server after requests are processed...")
+        waitForActiveRequests(gracefulShutdownTimeout)
+        server.stop(0)
+      case None =>
+        logger.error("Got shutdown signal, but no server is running, this seems weird.")
+    }
+    shutdownLogger()
+  }: Unit
+
+  /** We require shutting down logger context manually since we implement our own shutdown hook that logs for longer
+    * than the default logger shutdown handler will allow
+    */
+  private def shutdownLogger(): Unit = {
+    LoggerContext.getContext(false) match {
+      case context: LoggerContext => context.stop()
+      case _                      => println("No LoggerContext found, cannot stop logging context.")
+    }
+  }
+
+  private def runServer(): Try[Unit] = {
     logCopyrightHeader()
+    setupShutdownHook()
     Try(startServer(props.ApplicationName, props.ApplicationPort) {
       beforeStart()
       performWarmup()
     }).recover { ex =>
       logger.error(ex)("Failed to start server, exiting...")
     }
-
   }
 
   def run(args: Array[String]): Try[Unit] = {

--- a/network/src/main/scala/no/ndla/network/tapir/TapirHealthController.scala
+++ b/network/src/main/scala/no/ndla/network/tapir/TapirHealthController.scala
@@ -18,12 +18,16 @@ trait TapirHealthController {
   this: TapirController =>
   val healthController: TapirHealthController
   class TapirHealthController extends Warmup with TapirController {
-    override val enableSwagger: Boolean = false
-    val prefix: EndpointInput[Unit]     = "health"
+    @volatile private var isShuttingDown: Boolean = false
+    override val enableSwagger: Boolean           = false
+    val prefix: EndpointInput[Unit]               = "health"
+
+    def setShuttingDown(): Unit = { isShuttingDown = true }
 
     private def checkLiveness(): Either[String, String] = Right("Healthy")
     protected def checkReadiness(): Either[String, String] = {
-      if (isWarmedUp) Right("Ready")
+      if (isShuttingDown) Left("Service is shutting down")
+      else if (isWarmedUp) Right("Ready")
       else Left("Service is not ready")
     }
 


### PR DESCRIPTION
Implementerer graceful shutdowns.
Dvs at applikasjonene ikke vil stoppe med en gang de får en sigterm som tidligere, men vil feile readiness proben sin og deretter vente til alle aktive requests er ferdig å prosessere.
Dette vil i teorien gjøre at vi ikke vil avlive requests som pågår som gjør at utbytting av kubernetes noder og nedskaleringer vil lage mindre (sannsynligvis ingen) "hikke".

Tror dette er en god ide, kanskje ektra god etter vi oppgraderer ECK operatoren så elasticsearch også gjør noe lignende 😄