### PR TITLE
allow deletion of introduction, embedUrl and description for learning steps

### DIFF
--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/model/api/UpdatedLearningStepV2DTO.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/model/api/UpdatedLearningStepV2DTO.scala
@@ -10,16 +10,17 @@ package no.ndla.learningpathapi.model.api
 
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
 import io.circe.{Decoder, Encoder}
+import no.ndla.common.model.api.UpdateOrDelete
 import sttp.tapir.Schema.annotations.description
 
 @description("Information about a new learningstep")
 case class UpdatedLearningStepV2DTO(
     @description("The revision number for this learningstep") revision: Int,
     @description("The title of the learningstep") title: Option[String],
-    @description("The introduction of the learningstep") introduction: Option[String],
+    @description("The introduction of the learningstep") introduction: UpdateOrDelete[String],
     @description("The chosen language") language: String,
-    @description("The description of the learningstep") description: Option[String],
-    @description("The embed content for the learningstep") embedUrl: Option[EmbedUrlV2DTO],
+    @description("The description of the learningstep") description: UpdateOrDelete[String],
+    @description("The embed content for the learningstep") embedUrl: UpdateOrDelete[EmbedUrlV2DTO],
     @description("Determines if the title of the step should be displayed in viewmode") showTitle: Option[Boolean],
     @description("The type of the step") `type`: Option[String],
     @description("Describes the copyright information for the learningstep") license: Option[String]

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/ConverterService.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/ConverterService.scala
@@ -357,20 +357,22 @@ trait ConverterService {
       }
 
       val introductions = updated.introduction match {
-        case None        => existing.introduction
-        case Some(value) =>
-          mergeLanguageFields(existing.introduction, Seq(Introduction(value, updated.language)))
+        case Missing           => existing.introduction
+        case Delete            => existing.introduction.filterNot(_.language == updated.language)
+        case UpdateWith(value) => mergeLanguageFields(existing.introduction, Seq(Introduction(value, updated.language)))
       }
 
       val descriptions = updated.description match {
-        case None        => existing.description
-        case Some(value) =>
+        case Missing           => existing.description
+        case Delete            => existing.description.filterNot(_.language == updated.language)
+        case UpdateWith(value) =>
           mergeLanguageFields(existing.description, Seq(Description(value, updated.language)))
       }
 
       val embedUrlsT = updated.embedUrl match {
-        case None        => Success(existing.embedUrl)
-        case Some(value) =>
+        case Missing           => Success(existing.embedUrl)
+        case Delete            => Success(existing.embedUrl.filterNot(_.language == updated.language))
+        case UpdateWith(value) =>
           converterService
             .asDomainEmbedUrl(value, updated.language)
             .map(newEmbedUrl => mergeLanguageFields(existing.embedUrl, Seq(newEmbedUrl)))

--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/UpdateServiceTest.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/UpdateServiceTest.scala
@@ -141,7 +141,17 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
     )
 
   val UPDATED_STEPV2: UpdatedLearningStepV2DTO =
-    UpdatedLearningStepV2DTO(1, Option("Tittel"), None, "nb", Some("Beskrivelse"), None, Some(false), None, None)
+    UpdatedLearningStepV2DTO(
+      1,
+      Option("Tittel"),
+      commonApi.Missing,
+      "nb",
+      commonApi.UpdateWith("Beskrivelse"),
+      commonApi.Missing,
+      Some(false),
+      None,
+      None
+    )
 
   val rubio: Author                    = Author(ContributorType.Writer, "Little Marco")
   val license: String                  = License.PublicDomain.toString
@@ -1105,7 +1115,18 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
     when(clock.now()).thenReturn(newDate)
     when(learningPathRepository.learningPathsWithIsBasedOn(any[Long])).thenReturn(List.empty)
 
-    val updatedLs = UpdatedLearningStepV2DTO(1, Some("Dårlig tittel"), None, "nb", None, None, None, None, None)
+    val updatedLs =
+      UpdatedLearningStepV2DTO(
+        1,
+        Some("Dårlig tittel"),
+        commonApi.Missing,
+        "nb",
+        commonApi.Missing,
+        commonApi.Missing,
+        None,
+        None,
+        None
+      )
     service.updateLearningStepV2(PUBLISHED_ID, STEP1.id.get, updatedLs, PUBLISHED_OWNER.toCombined)
     val updatedPath = PUBLISHED_LEARNINGPATH.copy(
       status = LearningPathStatus.UNLISTED,
@@ -1173,7 +1194,18 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
     when(clock.now()).thenReturn(newDate)
     when(learningPathRepository.learningPathsWithIsBasedOn(any[Long])).thenReturn(List.empty)
 
-    val updatedLs = UpdatedLearningStepV2DTO(1, Some("Dårlig tittel"), None, "nb", None, None, None, None, None)
+    val updatedLs =
+      UpdatedLearningStepV2DTO(
+        1,
+        Some("Dårlig tittel"),
+        commonApi.Missing,
+        "nb",
+        commonApi.Missing,
+        commonApi.Missing,
+        None,
+        None,
+        None
+      )
     service.updateLearningStepV2(PRIVATE_ID, STEP1.id.get, updatedLs, PRIVATE_OWNER.toCombined)
     val updatedPath = PRIVATE_LEARNINGPATH.copy(
       lastUpdated = newDate,
@@ -1200,7 +1232,18 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
     )
     when(clock.now()).thenReturn(newDate)
 
-    val updatedLs = UpdatedLearningStepV2DTO(1, Some("Dårlig tittel"), None, "nb", None, None, None, None, None)
+    val updatedLs =
+      UpdatedLearningStepV2DTO(
+        1,
+        Some("Dårlig tittel"),
+        commonApi.Missing,
+        "nb",
+        commonApi.Missing,
+        commonApi.Missing,
+        None,
+        None,
+        None
+      )
     service.updateLearningStepV2(
       PUBLISHED_ID,
       STEP1.id.get,
@@ -1441,7 +1484,6 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
         .get
         .coverPhoto
     }
-
   }
 
 }


### PR DESCRIPTION
Fixes https://github.com/ndlano/issues/issues/4247

Per dags dato kan vi ende opp i uheldige situasjoner der man ikke nuller ut gamle felter når en bytter type på et læringssteg. Dette fikser det, gitt at man sender inn riktige verdier.