### PR TITLE
feat: delete learning step language

### DIFF
--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/ComponentRegistry.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/ComponentRegistry.scala
@@ -44,6 +44,7 @@ import no.ndla.network.NdlaClient
 import no.ndla.network.clients.MyNDLAApiClient
 import no.ndla.network.tapir.TapirApplication
 import no.ndla.search.{BaseIndexService, Elastic4sClient, SearchLanguage}
+import no.ndla.database.DBUtility
 
 class ComponentRegistry(properties: LearningpathApiProperties)
     extends BaseComponentRegistry[LearningpathApiProperties]
@@ -54,6 +55,7 @@ class ComponentRegistry(properties: LearningpathApiProperties)
     with LearningPathRepositoryComponent
     with ReadService
     with UpdateService
+    with DBUtility
     with SearchConverterServiceComponent
     with SearchService
     with SearchIndexService
@@ -90,6 +92,7 @@ class ComponentRegistry(properties: LearningpathApiProperties)
     new V33__AiDefaultEnabledOrgs
   )
   override lazy val dataSource: HikariDataSource = DataSource.getHikariDataSource
+  override val DBUtil: DBUtility                 = new DBUtility
 
   lazy val learningPathRepository = new LearningPathRepository
   lazy val readService            = new ReadService

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/model/api/ErrorHandling.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/model/api/ErrorHandling.scala
@@ -18,6 +18,7 @@ import no.ndla.network.tapir.{AllErrors, TapirErrorHandling}
 import no.ndla.search.model.domain.ElasticIndexingException
 import no.ndla.search.{IndexNotFoundException, NdlaSearchException}
 import org.postgresql.util.PSQLException
+import no.ndla.common.errors.OperationNotAllowedException
 
 trait ErrorHandling extends TapirErrorHandling {
   this: Props with Clock with DataSource =>
@@ -48,6 +49,7 @@ trait ErrorHandling extends TapirErrorHandling {
       errorBody(DATABASE_UNAVAILABLE, DATABASE_UNAVAILABLE_DESCRIPTION, 500)
     case mse: InvalidLpStatusException =>
       errorBody(MISSING_STATUS, mse.getMessage, 400)
+    case one: OperationNotAllowedException => errorBody(UNPROCESSABLE_ENTITY, one.getMessage, 422)
     case NdlaSearchException(_, Some(rf), _, _)
         if rf.error.rootCause
           .exists(x => x.`type` == "search_context_missing_exception" || x.reason == "Cannot parse scroll id") =>

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/ConverterService.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/ConverterService.scala
@@ -349,6 +349,24 @@ trait ConverterService {
       learningPath.copy(learningsteps = Some(steps), status = status, lastUpdated = clock.now())
     }
 
+    def deleteLearningStepLanguage(step: LearningStep, language: String): Try[LearningStep] = {
+      step.title.size match {
+        case 1 =>
+          Failure(
+            errors.OperationNotAllowedException(s"Cannot delete last title for step with id ${step.id.getOrElse(-1)}")
+          )
+        case _ =>
+          Success(
+            step.copy(
+              title = step.title.filterNot(_.language == language),
+              introduction = step.introduction.filterNot(_.language == language),
+              description = step.description.filterNot(_.language == language),
+              embedUrl = step.embedUrl.filterNot(_.language == language)
+            )
+          )
+      }
+    }
+
     def mergeLearningSteps(existing: LearningStep, updated: UpdatedLearningStepV2DTO): Try[LearningStep] = {
       val titles = updated.title match {
         case None        => existing.title

--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/TestEnvironment.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/TestEnvironment.scala
@@ -25,6 +25,7 @@ import no.ndla.network.tapir.TapirApplication
 import no.ndla.search.{BaseIndexService, Elastic4sClient, SearchLanguage}
 import org.mockito.Mockito.reset
 import org.scalatestplus.mockito.MockitoSugar
+import no.ndla.database.DBUtility
 
 trait TestEnvironment
     extends TapirApplication
@@ -34,6 +35,7 @@ trait TestEnvironment
     with FeideApiClient
     with ReadService
     with UpdateService
+    with DBUtility
     with SearchConverterServiceComponent
     with SearchService
     with SearchLanguage
@@ -93,6 +95,7 @@ trait TestEnvironment
   val feideApiClient: FeideApiClient                                   = mock[FeideApiClient]
   val redisClient: RedisClient                                         = mock[RedisClient]
   val myndlaApiClient: MyNDLAApiClient                                 = mock[MyNDLAApiClient]
+  val DBUtil: DBUtility                                                = mock[DBUtility]
 
   def services: List[TapirController] = List.empty
   val swagger: SwaggerController      = mock[SwaggerController]


### PR DESCRIPTION
Litt usikker på logikken for å verifisere at en har flere språkversjoner av et steg. Tok inspirasjon fra draft, der vi sjekker mengden titler. Men her klarte jeg helt fint å få to forskjellige embed-URL'er med kun én tittel.

Hvordan skal vi håndtere sletting av språkversjon av læringssti? Skal vi da også slette alle steg som har språkvarianter på det slettede språket?