### PR TITLE
programatically trigger log4j shutdown hook in tests

### DIFF
--- a/log4j/test/log4j2-test.yaml
+++ b/log4j/test/log4j2-test.yaml
@@ -1,5 +1,7 @@
 Configuration:
   status: warn
+  shutdownHook: disable
+
   Loggers:
     Logger:
       name: "no.ndla"

--- a/testbase/src/main/scala/no/ndla/testbase/TestSuiteLoggingSetup.scala
+++ b/testbase/src/main/scala/no/ndla/testbase/TestSuiteLoggingSetup.scala
@@ -47,6 +47,18 @@ trait TestSuiteLoggingSetup extends AnyFunSuite with BeforeAndAfterEach with Bef
     super.afterEach()
   }
 
+  override def afterAll(): Unit = {
+    super.afterAll()
+    shutdownLogger()
+  }
+
+  private def shutdownLogger(): Unit = {
+    LoggerContext.getContext(false) match {
+      case context: LoggerContext => context.stop()
+      case _                      => println("No LoggerContext found, cannot stop logging context.")
+    }
+  }
+
   override def withFixture(test: NoArgTest): Outcome = {
     val result = super.withFixture(test)
     if (!result.isSucceeded) {


### PR DESCRIPTION
Gjør dette på samme måte som vi gjør under faktisk kjøring for å unngå en warning i testkjøringer