### PR TITLE
mill+docker: _actually_ expand `JAVA_OPTS` during startup

### DIFF
--- a/modules/DockerComponent.mill
+++ b/modules/DockerComponent.mill
@@ -10,7 +10,19 @@ trait DockerComponent extends ScalaModule, DockerModule {
     def tags: T[Seq[String]]            = List(s"ndla/$moduleName:$versionTag")
     def baseImage                       = "eclipse-temurin:21-alpine"
     def envVars: T[Map[String, String]] = Map("LOG_APPENDER" -> "Docker")
-    def jvmOptions: T[Seq[String]]      = Task { super.jvmOptions() ++ Seq("$JAVA_OPTS") }
+
+    // Customize entrypoint so we can expand JAVA_OPTS from environment variables
+    override def dockerfile: T[String] = Task {
+      val oldFile       = super.dockerfile()
+      val jarName       = assembly().path.last
+      val cmd           = List("java") ++ jvmOptions() ++ List("$JAVA_OPTS", "-jar", s"/$jarName")
+      val newEntryPoint = s"ENTRYPOINT ${cmd.mkString(" ")}"
+
+      oldFile.linesIterator.toList match {
+        case init :+ _ => (init :+ newEntryPoint).mkString("\n")
+        case _         => throw new RuntimeException("Bad dockerfile generated. Look at DockerComponent.mill")
+      }
+    }
   }
 
   override def assemblyRules: Seq[Assembly.Rule] = {


### PR DESCRIPTION
Dette krevde en liten hack siden https://mill-build.org/mill/contrib/docker.html ikke hadde noen native støtte for å endre _bare_ entrypointet så da tar jeg bare å redigerer den siste linja i dockerfile'n.

By default så bruker de sånn syntax: `ENTRYPOINT ["java", ...]` og det støtter ikke shell expansion 🤷 


Vi kunne sikkert også i teorien tatt i bruk disse `JAVA_TOOL_OPTIONS` variablene som noen jvm'er støtter, men det virker litt som det ikke oppfordres til det.