### PR TITLE
docker: use json args entrypoint

### DIFF
--- a/modules/DockerComponent.mill
+++ b/modules/DockerComponent.mill
@@ -13,10 +13,11 @@ trait DockerComponent extends ScalaModule, DockerModule {
 
     // Customize entrypoint so we can expand JAVA_OPTS from environment variables
     override def dockerfile: T[String] = Task {
-      val oldFile       = super.dockerfile()
-      val jarName       = assembly().path.last
-      val cmd           = List("java") ++ jvmOptions() ++ List("$JAVA_OPTS", "-jar", s"/$jarName")
-      val newEntryPoint = s"ENTRYPOINT ${cmd.mkString(" ")}"
+      val oldFile              = super.dockerfile()
+      val jarName              = assembly().path.last
+      val cmd                  = List("exec", "java") ++ jvmOptions() ++ List("$JAVA_OPTS", "-jar", s"/$jarName")
+      val quotedEntryPointArgs = Seq("sh", "-c", cmd.mkString(" ")).map(arg => s"\"$arg\"").mkString(", ")
+      val newEntryPoint        = s"ENTRYPOINT [$quotedEntryPointArgs]"
 
       oldFile.linesIterator.toList match {
         case init :+ _ => (init :+ newEntryPoint).mkString("\n")


### PR DESCRIPTION
Vi har fått warning på at vi har bruk den shell syntax'en lenge, så kanskje vi faktisk heller skal gå for en løsning om ikke lager warnings 🤓 

Den gamle fungerer nok fint så lenge vi er på det docker imaget vi er, men jeg tenker vi kan like greit bruke json versjonen og være eksplisitte for å slippe en warning.