### PR TITLE
fix(mill): typescript generation race condition

### DIFF
--- a/modules/OpenAPITSPlugin.mill
+++ b/modules/OpenAPITSPlugin.mill
@@ -5,6 +5,7 @@ import mill.api.BuildCtx
 import mill.scalalib.*
 import mill.api.Task.Simple.create
 import mill.api.daemon.Result
+import build.modules.Yarn
 
 import java.io.{BufferedWriter, File, FileWriter}
 
@@ -23,8 +24,8 @@ trait OpenAPITSPlugin extends ScalaModule {
     if (isComponent) {
       Task.Command {
         generateOpenAPIFile()
-        yarnInstall()
-        generateOpenapiTypescriptFile()
+        Yarn.worker().yarnInstall(typescriptPath.toString)
+        Yarn.worker().generateOpenapiTypescriptFile(typescriptPath.toString, moduleName)
         writeFile()
       }
     } else {
@@ -89,21 +90,4 @@ trait OpenAPITSPlugin extends ScalaModule {
       .toList
   }
 
-  private def runCommand(cmd: String) = Task.Anon {
-    println(s"Running command: $cmd")
-    import sys.process.*
-    val result = cmd.!
-    if (result != 0) {
-      throw new Exception(s"Failed to run command: $cmd")
-    }
-    println(s"Command executed successfully: $cmd")
-  }
-
-  private def yarnInstall: Task[Unit] = Task.Anon {
-    runCommand(s"yarn --cwd ${typescriptPath.toString} install")()
-  }
-
-  private def generateOpenapiTypescriptFile: Task[Unit] = Task.Anon {
-    runCommand(s"yarn --cwd ${typescriptPath.toString} generate-typescript $moduleName")()
-  }
 }

--- a/modules/package.mill
+++ b/modules/package.mill
@@ -6,6 +6,8 @@ import mill.scalalib.*
 import mill.scalalib.scalafmt.ScalafmtModule
 import mill.util.Tasks
 import os.Path
+
+import java.security.MessageDigest
 import scala.util.{Failure, Success, Try}
 import scala.io.Source
 
@@ -50,4 +52,49 @@ trait BaseModule
     override def forkArgs: T[Seq[String]] = Task { super.forkArgs() ++ testJavaOptions() }
   }
 
+}
+
+object Yarn extends mill.Module {
+  def worker: Task.Worker[YarnWorker] = Task.Worker { new YarnWorker() }
+
+  class YarnWorker {
+    private val installedPaths = scala.collection.mutable.Map.empty[String, String]
+    private val digest         = MessageDigest.getInstance("SHA-256")
+
+    private def runCommand(cmd: String): Unit = {
+      println(s"Running command: $cmd")
+      import sys.process.*
+      val result = cmd.!
+      if (result != 0) {
+        throw new Exception(s"Failed to run command: $cmd")
+      }
+      println(s"Command executed successfully: $cmd")
+    }
+
+    private def runIfLockHashMismatch(path: String)(f: => Unit): Unit = {
+      val yarnLockPath = os.Path(path) / "yarn.lock"
+      if (!os.exists(yarnLockPath)) f
+      else {
+        val lockFile    = os.read.bytes(yarnLockPath)
+        val currentHash = digest.digest(lockFile).map("%02x".format(_)).mkString
+        if (installedPaths.get(path).contains(currentHash)) {
+          println(s"Yarn install skipped for $path, lock file hash matches: $currentHash")
+        } else {
+          f
+          installedPaths(path) = currentHash
+          println(s"Yarn install completed for $path, updated lock file hash.")
+        }
+      }
+    }
+
+    def yarnInstall(path: String): Unit = synchronized {
+      runIfLockHashMismatch(path) {
+        runCommand(s"yarn --cwd $path install")
+      }
+    }
+
+    def generateOpenapiTypescriptFile(typescriptPath: String, moduleName: String): Unit = {
+      runCommand(s"yarn --cwd ${typescriptPath} generate-typescript $moduleName")
+    }
+  }
 }


### PR DESCRIPTION
Dette gjør så `yarn install` bare kjøres en gang.
En `Task.Worker` er long-living så den lever på tvers av mill-kjøringer også.
Dvs at `yarn install` bare kjøres dersom den ikke har blitt kjørt allerede (på denne `yarn.lock` filen).
Dersom du vil tvinge den til å kjøres så kan det gjøres med `mill clean`.

_tror_ dette er [problemet](https://github.com/NDLANO/backend/actions/runs/17121012442/job/48561663677) som skjer på actions ~innimellom~ hvor type generering feiler.