### PR TITLE
fix: props eager loading, but lazy failing

### DIFF
--- a/article-api/src/main/scala/no/ndla/articleapi/controller/ControllerErrorHandling.scala
+++ b/article-api/src/main/scala/no/ndla/articleapi/controller/ControllerErrorHandling.scala
@@ -16,7 +16,7 @@ import no.ndla.network.tapir.{AllErrors, ErrorBody, ErrorHandling, ErrorHelpers,
 import no.ndla.search.{IndexNotFoundException, NdlaSearchException}
 import org.postgresql.util.PSQLException
 
-class ControllerErrorHandling(using dataSource: DataSource, errorHelpers: ErrorHelpers, clock: Clock)
+class ControllerErrorHandling(using dataSource: => DataSource, errorHelpers: ErrorHelpers, clock: Clock)
     extends ErrorHandling {
   import errorHelpers.*
 

--- a/audio-api/src/main/scala/no/ndla/audioapi/controller/ControllerErrorHandling.scala
+++ b/audio-api/src/main/scala/no/ndla/audioapi/controller/ControllerErrorHandling.scala
@@ -20,7 +20,7 @@ import no.ndla.search.NdlaSearchException
 
 class ControllerErrorHandling(using
     props: Props,
-    dataSource: DataSource,
+    dataSource: => DataSource,
     errorHelpers: ErrorHelpers,
     clock: Clock
 ) extends ErrorHandling {

--- a/audio-api/src/main/scala/no/ndla/audioapi/controller/HealthController.scala
+++ b/audio-api/src/main/scala/no/ndla/audioapi/controller/HealthController.scala
@@ -14,7 +14,7 @@ import no.ndla.network.tapir.{ErrorHelpers, TapirHealthController}
 import no.ndla.network.clients.MyNDLAApiClient
 
 class HealthController(using
-    s3Client: NDLAS3Client,
+    s3Client: => NDLAS3Client,
     audioRepository: AudioRepository,
     myNDLAApiClient: MyNDLAApiClient,
     errorHelpers: ErrorHelpers,

--- a/audio-api/src/main/scala/no/ndla/audioapi/service/TranscriptionService.scala
+++ b/audio-api/src/main/scala/no/ndla/audioapi/service/TranscriptionService.scala
@@ -28,10 +28,10 @@ case class TranscriptionComplete(transcription: String)             extends Tran
 case class TranscriptionNonComplete(status: TranscriptionJobStatus) extends TranscriptionResult
 
 class TranscriptionService(using
-    s3TranscribeClient: TranscribeS3Client,
+    s3TranscribeClient: => TranscribeS3Client,
     props: Props,
     brightcoveClient: NdlaBrightcoveClient,
-    transcribeClient: NdlaAWSTranscribeClient
+    transcribeClient: => NdlaAWSTranscribeClient
 ) extends StrictLogging {
 
   def transcribeVideo(videoId: String, language: String, maxSpeakers: Int): Try[Unit] = {

--- a/audio-api/src/main/scala/no/ndla/audioapi/service/WriteService.scala
+++ b/audio-api/src/main/scala/no/ndla/audioapi/service/WriteService.scala
@@ -34,7 +34,7 @@ class WriteService(using
     audioIndexService: AudioIndexService,
     seriesIndexService: SeriesIndexService,
     tagIndexService: TagIndexService,
-    s3Client: NDLAS3Client,
+    s3Client: => NDLAS3Client,
     clock: Clock
 ) extends StrictLogging {
 

--- a/concept-api/src/main/scala/no/ndla/conceptapi/controller/ControllerErrorHandling.scala
+++ b/concept-api/src/main/scala/no/ndla/conceptapi/controller/ControllerErrorHandling.scala
@@ -10,7 +10,6 @@ package no.ndla.conceptapi.controller
 
 import no.ndla.common.Clock
 import no.ndla.common.errors.{AccessDeniedException, FileTooBigException, NotFoundException, ValidationException}
-import no.ndla.conceptapi.Props
 import no.ndla.conceptapi.model.api.{
   NotFoundException => OldNotFoundException,
   OptimisticLockException,
@@ -23,10 +22,9 @@ import no.ndla.search.{IndexNotFoundException, NdlaSearchException}
 import org.postgresql.util.PSQLException
 
 class ControllerErrorHandling(using
-    val props: Props,
-    val dataSource: DataSource,
-    val errorHelpers: ErrorHelpers,
-    val clock: Clock
+    dataSource: => DataSource,
+    errorHelpers: ErrorHelpers,
+    clock: Clock
 ) extends ErrorHandling {
   import errorHelpers.*
 

--- a/draft-api/src/main/scala/no/ndla/draftapi/controller/ControllerErrorHandling.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/controller/ControllerErrorHandling.scala
@@ -29,7 +29,7 @@ import no.ndla.network.model.HttpRequestException
 import org.postgresql.util.PSQLException
 
 class ControllerErrorHandling(using
-    dataSource: DataSource,
+    dataSource: => DataSource,
     errorHelpers: ErrorHelpers,
     draftErrorHelpers: DraftErrorHelpers,
     clock: => Clock

--- a/image-api/src/main/scala/no/ndla/imageapi/controller/ControllerErrorHandling.scala
+++ b/image-api/src/main/scala/no/ndla/imageapi/controller/ControllerErrorHandling.scala
@@ -23,7 +23,7 @@ import no.ndla.search.NdlaSearchException
 import no.ndla.search.IndexNotFoundException
 import org.postgresql.util.PSQLException
 
-class ControllerErrorHandling(using props: Props, dataSource: DataSource, errorHelpers: ErrorHelpers)
+class ControllerErrorHandling(using props: Props, dataSource: => DataSource, errorHelpers: ErrorHelpers)
     extends ErrorHandling {
   import errorHelpers.*
   import no.ndla.imageapi.model.ImageErrorHelpers.*

--- a/image-api/src/main/scala/no/ndla/imageapi/service/ImageStorageService.scala
+++ b/image-api/src/main/scala/no/ndla/imageapi/service/ImageStorageService.scala
@@ -25,7 +25,7 @@ import software.amazon.awssdk.services.s3.model.NoSuchKeyException
 import scala.util.{Failure, Success, Try}
 
 class ImageStorageService(using
-    s3Client: NdlaS3Client,
+    s3Client: => NdlaS3Client,
     readService: ReadService,
     props: Props
 ) extends StrictLogging {

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/controller/ControllerErrorHandling.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/controller/ControllerErrorHandling.scala
@@ -20,7 +20,7 @@ import no.ndla.common.errors.OperationNotAllowedException
 import no.ndla.learningpathapi.model.api.ResultWindowTooLargeException
 
 class ControllerErrorHandling(using
-    dataSource: DataSource,
+    dataSource: => DataSource,
     errorHelpers: ErrorHelpers
 ) extends ErrorHandling {
   import errorHelpers.*

--- a/myndla-api/src/main/scala/no/ndla/myndlaapi/controller/ControllerErrorHandling.scala
+++ b/myndla-api/src/main/scala/no/ndla/myndlaapi/controller/ControllerErrorHandling.scala
@@ -18,7 +18,7 @@ import org.postgresql.util.PSQLException
 
 class ControllerErrorHandling(using
     clock: Clock,
-    dataSource: DataSource,
+    dataSource: => DataSource,
     errorHelpers: ErrorHelpers
 ) extends ErrorHandling
     with StrictLogging {


### PR DESCRIPTION
Når DI-oppsettet ble refaktorert, ble lazy-loadede `DataSource` ikke lenger lastet lazily. Dette førte til at kjøring av `generateTypescript` feilet på CI for alle komponenter som krevde miljøvariabler ved oppstart.

Fikser problemet ved å sende inn dataSource og noen andre avhengigheter som en [by-name-parameter](https://docs.scala-lang.org/tour/by-name-parameters.html) der de tidligere ble brukt ved oppstart.