### PR TITLE
fix: migrate negative seqNo to positive

### DIFF
--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/db/migration/V53__FixNegativeSeqNo.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/db/migration/V53__FixNegativeSeqNo.scala
@@ -1,0 +1,39 @@
+/*
+ * Part of NDLA learningpath-api
+ * Copyright (C) 2025 NDLA
+ *
+ * See LICENSE
+ *
+ */
+
+package no.ndla.learningpathapi.db.migration
+
+import no.ndla.learningpathapi.db.util.LearningPathAndStepMigration
+import no.ndla.learningpathapi.db.util.LpDocumentRow
+import no.ndla.learningpathapi.db.util.StepDocumentRow
+import no.ndla.common.CirceUtil
+import io.circe.Encoder
+import io.circe.syntax.EncoderOps
+
+class V53__FixNegativeSeqNo extends LearningPathAndStepMigration {
+  override def convertPathAndSteps(
+      lpData: LpDocumentRow,
+      stepDatas: List[StepDocumentRow]
+  ): (LpDocumentRow, List[StepDocumentRow]) = {
+    val sortedSteps = stepDatas.sortBy(step => {
+      val stepDocument = CirceUtil.tryParse(step.learningStepDocument).get
+      val seqNo        = stepDocument.hcursor.get[Option[Long]]("seqNo").toTry.get.get
+      seqNo
+    })
+
+    (lpData, convertSteps(sortedSteps))
+  }
+
+  private def convertSteps(sortedSteps: List[StepDocumentRow])(using encoder: Encoder[Int]): List[StepDocumentRow] = {
+    sortedSteps.zipWithIndex.map((step, i) => {
+      val stepDocument = CirceUtil.tryParse(step.learningStepDocument).get
+      val newData      = stepDocument.mapObject(doc => doc.remove("seqNo").add("seqNo", i.asJson))
+      step.copy(learningStepDocument = newData.noSpaces)
+    })
+  }
+}

--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/db/migration/V53__FixNegativeSeqNoTest.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/db/migration/V53__FixNegativeSeqNoTest.scala
@@ -1,0 +1,36 @@
+/*
+ * Part of NDLA learningpath-api
+ * Copyright (C) 2025 NDLA
+ *
+ * See LICENSE
+ *
+ */
+
+package no.ndla.learningpathapi.db.migration
+
+import no.ndla.learningpathapi.{TestEnvironment, UnitSuite}
+import no.ndla.learningpathapi.db.util.StepDocumentRow
+import no.ndla.learningpathapi.db.util.LpDocumentRow
+
+class V53__FixNegativeSeqNoTest extends UnitSuite with TestEnvironment {
+
+  test("That negative seqNo are converted to non-negative seqNo") {
+    val migration = new V53__FixNegativeSeqNo
+
+    val lpData = LpDocumentRow(1, "")
+
+    val stepDatas = List(
+      StepDocumentRow(1, """{"seqNo":-2}"""),
+      StepDocumentRow(2, """{"seqNo":-1}"""),
+      StepDocumentRow(3, """{"seqNo":0}"""),
+      StepDocumentRow(4, """{"seqNo":1}""")
+    )
+    val expectedStepDatas = List(
+      StepDocumentRow(1, """{"seqNo":0}"""),
+      StepDocumentRow(2, """{"seqNo":1}"""),
+      StepDocumentRow(3, """{"seqNo":2}"""),
+      StepDocumentRow(4, """{"seqNo":3}""")
+    )
+    migration.convertPathAndSteps(lpData, stepDatas) should be((lpData, expectedStepDatas))
+  }
+}


### PR DESCRIPTION
Vet egentlig ikke om det er så mye mer enn dette man bør teste? Dette vil strengt tatt også fjerne andre rare seqNo-rekker (1, 2, 3, 4) (1, 3, 5, 7), men det er vel heller ikke problematisk.