### PR TITLE
refactor(ci): utilize `semanticDbData` from mill

### DIFF
--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -1,5 +1,5 @@
-name: 'Linting & Formatting'
-on: [ push, pull_request ]
+name: "Linting & Formatting"
+on: [push, pull_request]
 env:
   CI_RELEASE_ROLE: ${{ secrets.CI_RELEASE_ROLE }}
   CI_GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
@@ -28,7 +28,7 @@ jobs:
         with:
           distribution: temurin
           java-version: ${{ vars.JAVA_VERSION }}
-      - name: Compile
-        run: ./mill _.compile
+      - name: Build required semanticdb files
+        run: ./mill _.semanticDbData
       - name: Check dependency cycles
         run: ./mill dependency-graph.run

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ target/
 .vscode/
 out/
 metals.sbt
-*.semanticdb
 
 /typescript/**/node_modules
 /typescript/**/build

--- a/dependency-graph/README.md
+++ b/dependency-graph/README.md
@@ -1,0 +1,15 @@
+# Dependency graph cycle lint
+
+This module is a module to parse all the scala files in the repository to detect if we have any cycical dependencies across classes that are initialized in the `ComponentRegistry` files.
+
+Ideally this should probably be a build-system (mill) plugin, but we will have to wait until [this](https://github.com/com-lihaoyi/mill/pull/5790) is released.
+
+# Usage
+
+```
+# need to stand in the root of the project
+cd $NDLA_HOME/backend
+
+./mill _.semanticDbData
+./mill dependency-graph.run
+```

--- a/dependency-graph/src/Main.scala
+++ b/dependency-graph/src/Main.scala
@@ -34,8 +34,9 @@ object Main {
 
   def parseModule(module: String): Unit = {
     Logger.info(s"---- $module ----")
-    val files   = getScalaFilesRecursivly(module)
-    val classes = files.flatMap(ScalaFileParser.parseScalaFile)
+    val files            = getScalaFilesRecursivly(module)
+    val semanticDbPrefix = ScalaFileParser.getSemanticDbPrefix(module)
+    val classes          = files.flatMap(f => ScalaFileParser.parseScalaFile(f, semanticDbPrefix))
     CycleDetector.findCyclicalDependencies(classes)
   }
 
@@ -51,8 +52,8 @@ object Main {
     if (d.exists && d.isDirectory) {
       val nestedDirectories = d.listFiles.filter(_.isDirectory).toList
       val filesInD          = d.listFiles.filter(_.isFile).toList
-      val scalaFiles        = filesInD.filter(filterFile).map(_.getAbsolutePath)
-      val nestedFiles       = nestedDirectories.flatMap(f => getScalaFilesRecursivly(f.getAbsolutePath))
+      val scalaFiles        = filesInD.filter(filterFile).map(_.getPath())
+      val nestedFiles       = nestedDirectories.flatMap(f => getScalaFilesRecursivly(f.getPath()))
       scalaFiles ++ nestedFiles
     } else {
       List[String]()

--- a/dependency-graph/src/ScalaFileParser.scala
+++ b/dependency-graph/src/ScalaFileParser.scala
@@ -121,10 +121,15 @@ object ScalaFileParser {
     x.flatten
   }
 
-  def parseScalaFile(filePath: String): List[ClassWithArguments] = {
-    val semanticDBFile = new File(s"$filePath.semanticdb")
+  def getSemanticDbPrefix(moduleName: String): String = {
+    val outDir = Option(System.getenv("MILL_OUTPUT_DIR")).getOrElse("out")
+    s"$outDir/$moduleName/semanticDbDataDetailed.dest/classes/META-INF/semanticdb"
+  }
+
+  def parseScalaFile(filePath: String, semanticDbPrefix: String): List[ClassWithArguments] = {
+    val semanticDBFile = new File(s"$semanticDbPrefix/$filePath.semanticdb")
     if (!semanticDBFile.exists()) {
-      Logger.error(s"No semanticdb file found for $filePath, please compile module first.")
+      Logger.error(s"No semanticdb file found for $semanticDBFile, please run `./mill _.semanticDbData` first.")
       exit(1)
     }
     val dbBytes       = Files.readAllBytes(semanticDBFile.toPath)

--- a/modules/DefaultOptions.mill
+++ b/modules/DefaultOptions.mill
@@ -68,8 +68,7 @@ trait DefaultOptions extends ScalaModule {
       "-Wunused:privates",
       "-Wconf:src=src_managed/.*:silent",
       "-Yretain-trees"   -> scala3,
-      "-Xmax-inlines:50" -> scala3,
-      "-Xsemanticdb"
+      "-Xmax-inlines:50" -> scala3
     ).filterByVersion(scalaVersion())
   }
 


### PR DESCRIPTION
Denne gjør at vi slipper å ha semanticdb filer ved siden av kildekodefilene 🛩️ 
Dere kan kjøre denne for å fjerne de tror jeg `git clean -fd "*.semanticdb"`