### PR TITLE
feat: allow deletion of step title

### DIFF
--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/model/api/UpdatedLearningStepV2DTO.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/model/api/UpdatedLearningStepV2DTO.scala
@@ -18,7 +18,7 @@ case class UpdatedLearningStepV2DTO(
     @description("The revision number for this learningstep")
     revision: Int,
     @description("The title of the learningstep")
-    title: Option[String],
+    title: UpdateOrDelete[String],
     @description("The introduction of the learningstep")
     introduction: UpdateOrDelete[String],
     @description("The chosen language")

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/ConverterService.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/ConverterService.scala
@@ -406,9 +406,9 @@ class ConverterService(using
 
   def mergeLearningSteps(existing: LearningStep, updated: UpdatedLearningStepV2DTO): Try[LearningStep] = {
     val titles = updated.title match {
-      case None        => existing.title
-      case Some(value) =>
-        mergeLanguageFields(existing.title, Seq(common.Title(value, updated.language)))
+      case Missing           => existing.title
+      case Delete            => existing.title.filterNot(_.language == updated.language)
+      case UpdateWith(value) => mergeLanguageFields(existing.title, Seq(common.Title(value, updated.language)))
     }
 
     val introductions = updated.introduction match {

--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/ConverterServiceTest.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/ConverterServiceTest.scala
@@ -640,7 +640,7 @@ class ConverterServiceTest extends UnitSuite with UnitTestEnvironment {
   test("mergeLearningSteps correctly retains nullable fields") {
     val updatedStep = api.UpdatedLearningStepV2DTO(
       2,
-      None,
+      commonApi.Missing,
       commonApi.Missing,
       "nb",
       commonApi.Missing,
@@ -660,7 +660,7 @@ class ConverterServiceTest extends UnitSuite with UnitTestEnvironment {
   test("mergeLearningSteps correctly deletes correct language version of nullable fields") {
     val updatedStep = api.UpdatedLearningStepV2DTO(
       2,
-      None,
+      commonApi.Delete,
       commonApi.Delete,
       "nn",
       commonApi.Delete,
@@ -672,6 +672,7 @@ class ConverterServiceTest extends UnitSuite with UnitTestEnvironment {
       commonApi.Missing
     )
     val result = service.mergeLearningSteps(multiLanguageDomainStep, updatedStep).get
+    result.title shouldEqual Seq(Title("Tittel på bokmål", "nb"))
     result.introduction shouldEqual Seq(Introduction("Introduksjon på bokmål", "nb"))
     result.description shouldEqual Seq(Description("Beskrivelse på bokmål", "nb"))
     result.embedUrl shouldEqual Seq(EmbedUrl("https://www.ndla.no/123", "nb", EmbedType.OEmbed))
@@ -680,7 +681,7 @@ class ConverterServiceTest extends UnitSuite with UnitTestEnvironment {
   test("mergeLearningSteps correctly updates language fields") {
     val updatedStep = api.UpdatedLearningStepV2DTO(
       2,
-      Some("Tittel på bokmål oppdatert"),
+      commonApi.UpdateWith("Tittel på bokmål oppdatert"),
       commonApi.UpdateWith("Introduksjon på bokmål oppdatert"),
       "nb",
       commonApi.UpdateWith("Beskrivelse på bokmål oppdatert"),

--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/UpdateServiceTest.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/UpdateServiceTest.scala
@@ -167,7 +167,7 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
   val UPDATED_STEPV2: UpdatedLearningStepV2DTO =
     UpdatedLearningStepV2DTO(
       1,
-      Option("Tittel"),
+      commonApi.UpdateWith("Tittel"),
       commonApi.Missing,
       "nb",
       commonApi.UpdateWith("Beskrivelse"),
@@ -1271,7 +1271,7 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
     val updatedLs =
       UpdatedLearningStepV2DTO(
         1,
-        Some("Dårlig tittel"),
+        commonApi.UpdateWith("Dårlig tittel"),
         commonApi.Missing,
         "nb",
         commonApi.Missing,
@@ -1313,7 +1313,7 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
     val updatedLs =
       UpdatedLearningStepV2DTO(
         1,
-        Some("Dårlig tittel"),
+        commonApi.UpdateWith("Dårlig tittel"),
         commonApi.Missing,
         "nb",
         commonApi.Missing,


### PR DESCRIPTION
Vi har en del ressurssteg som har tittel, selv om de ikke nødvendigvis trenger det lenger. Man ender da ofte opp med steg som dette: https://test.ndla.no/r/verktoykassa---for-elever/bloff-med-statistikk/d9709169df/9382. Med denne endringen vil folk få muligheten til å nullstille dette i ED.