### PR TITLE
Make sure children is fetched sorted before deleting

### DIFF
--- a/myndla-api/src/main/scala/no/ndla/myndlaapi/repository/FolderRepository.scala
+++ b/myndla-api/src/main/scala/no/ndla/myndlaapi/repository/FolderRepository.scala
@@ -236,7 +236,7 @@ class FolderRepository(using clock: Clock, dbUtility: DBUtility) extends StrictL
 
   def getConnections(folderId: UUID)(implicit session: DBSession = AutoSession): Try[List[FolderResource]] = {
     Try(
-      sql"select resource_id, folder_id, rank, favorited_date from ${FolderResource.table} where folder_id=$folderId"
+      sql"select resource_id, folder_id, rank, favorited_date from ${FolderResource.table} where folder_id=$folderId ORDER BY rank"
         .map(rs => {
           for {
             resourceId <- rs.get[Try[UUID]]("resource_id")
@@ -417,7 +417,7 @@ class FolderRepository(using clock: Clock, dbUtility: DBUtility) extends StrictL
       case Some(pid) => sqls"f.parent_id=$pid"
       case None      => sqls"f.parent_id is null"
     }
-    foldersWhere(sqls"$parentIdClause and f.feide_id=$feideId")
+    foldersWhere(sqls"$parentIdClause and f.feide_id=$feideId ORDER BY f.rank")
   }
 
   def buildTreeStructureFromListOfChildren(

--- a/myndla-api/src/main/scala/no/ndla/myndlaapi/repository/FolderRepository.scala
+++ b/myndla-api/src/main/scala/no/ndla/myndlaapi/repository/FolderRepository.scala
@@ -236,7 +236,7 @@ class FolderRepository(using clock: Clock, dbUtility: DBUtility) extends StrictL
 
   def getConnections(folderId: UUID)(implicit session: DBSession = AutoSession): Try[List[FolderResource]] = {
     Try(
-      sql"select resource_id, folder_id, rank, favorited_date from ${FolderResource.table} where folder_id=$folderId ORDER BY rank"
+      sql"select resource_id, folder_id, rank, favorited_date from ${FolderResource.table} where folder_id=$folderId order by rank ASC"
         .map(rs => {
           for {
             resourceId <- rs.get[Try[UUID]]("resource_id")
@@ -417,7 +417,7 @@ class FolderRepository(using clock: Clock, dbUtility: DBUtility) extends StrictL
       case Some(pid) => sqls"f.parent_id=$pid"
       case None      => sqls"f.parent_id is null"
     }
-    foldersWhere(sqls"$parentIdClause and f.feide_id=$feideId ORDER BY f.rank")
+    foldersWhere(sqls"$parentIdClause and f.feide_id=$feideId order by f.rank ASC")
   }
 
   def buildTreeStructureFromListOfChildren(


### PR DESCRIPTION
Ved sletting av ressurs, sorteres alle søsken til ressursen på nytt. Dette skjer ved at FolderResources hentes fra basen, den aktuelle ressursen fjernes, og resten sorteres i den rekkefølgen dei ligger i lista. Men siden postgres returnerer rekkefølge avhengig av sist oppdatert så lenge du ikkje har ORDER BY så risikerer du at ressursene dine plutselig er hulter til bulter! Dette omgår problemet ved å eksplisitt sortere ressursene i mappa.