### PR TITLE
Ensure document has id set

### DIFF
--- a/article-api/src/main/resources/no/ndla/articleapi/db/migration/R__SetIdFromArticleId.sql
+++ b/article-api/src/main/resources/no/ndla/articleapi/db/migration/R__SetIdFromArticleId.sql
@@ -1,0 +1,4 @@
+update contentdata c
+set document = jsonb_set(c.document, '{id}', c.article_id::text::jsonb)
+where document->>'id' is null
+and document is not null;

--- a/draft-api/src/main/resources/no/ndla/draftapi/db/migration/R__SetIdFromArticleId.sql
+++ b/draft-api/src/main/resources/no/ndla/draftapi/db/migration/R__SetIdFromArticleId.sql
@@ -1,0 +1,4 @@
+update articledata a
+set document = jsonb_set(a.document, '{id}', a.article_id::text::jsonb)
+where document->>'id' is null
+and document is not null;


### PR DESCRIPTION
Setter id-feltet fra article-id. Mange av disse har null i id-feltet, som egentlig ikkje har så masse å sei. Men siden eg trenger articleid for å snakke med taksonomi hadde det vore en fordel om id var satt.
Noen som ser en god grunn til ikkje å gjøre dette?