### PR TITLE
chore: migrate away teacher availability

### DIFF
--- a/article-api/src/main/resources/no/ndla/articleapi/db/migration/V63__RemoveTeacherAvailability.sql
+++ b/article-api/src/main/resources/no/ndla/articleapi/db/migration/V63__RemoveTeacherAvailability.sql
@@ -1,0 +1,4 @@
+update contentdata
+set document = jsonb_set(document, '{availability}', '"everyone"')
+where document->>'availability' = 'teacher'
+and document is not null;

--- a/draft-api/src/main/resources/no/ndla/draftapi/db/migration/V77__RemoveTeacherAvailability.sql
+++ b/draft-api/src/main/resources/no/ndla/draftapi/db/migration/V77__RemoveTeacherAvailability.sql
@@ -1,0 +1,4 @@
+update articledata
+set document = jsonb_set(document, '{availability}', '"everyone"')
+where document->>'availability' = 'teacher'
+and document is not null;


### PR DESCRIPTION
Ganske mye availability-relatert kode i backend som kanskje er greit å beholde i tilfelle NDLA vil ha dette tilbake igjen. Migrerer bort resterende teacher-verdier istedenfor.