### PR TITLE
fix: delete learning path language when no steps match language

### DIFF
--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/ConverterService.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/ConverterService.scala
@@ -366,41 +366,35 @@ class ConverterService(using
   }
 
   def deleteLearningStepLanguage(step: LearningStep, language: String): Try[LearningStep] = {
-    step.title.size match {
-      case 1 =>
-        Failure(
-          errors.OperationNotAllowedException(s"Cannot delete last title for step with id ${step.id.getOrElse(-1)}")
-        )
-      case _ =>
-        Success(
-          step.copy(
-            title = step.title.filterNot(_.language == language),
-            introduction = step.introduction.filterNot(_.language == language),
-            description = step.description.filterNot(_.language == language),
-            embedUrl = step.embedUrl.filterNot(_.language == language),
-            lastUpdated = clock.now()
-          )
-        )
+    val withDeleted = step.copy(
+      title = step.title.filterNot(_.language == language),
+      introduction = step.introduction.filterNot(_.language == language),
+      description = step.description.filterNot(_.language == language),
+      embedUrl = step.embedUrl.filterNot(_.language == language),
+      lastUpdated = clock.now()
+    )
+
+    val id = step.id.getOrElse(-1)
+
+    withDeleted.title.size match {
+      case 0 => Failure(errors.OperationNotAllowedException(s"Cannot delete last title for step with id $id"))
+      case _ => Success(withDeleted)
     }
   }
 
   def deleteLearningPathLanguage(learningPath: LearningPath, language: String): Try[LearningPath] = {
-    learningPath.title.size match {
-      case 1 =>
-        Failure(
-          errors.OperationNotAllowedException(
-            s"Cannot delete last language for learning path with id ${learningPath.id.getOrElse(-1)}"
-          )
-        )
-      case _ =>
-        Success(
-          learningPath.copy(
-            title = learningPath.title.filterNot(_.language == language),
-            description = learningPath.description.filterNot(_.language == language),
-            tags = learningPath.tags.filterNot(_.language == language),
-            lastUpdated = clock.now()
-          )
-        )
+    val id          = learningPath.id.getOrElse(-1)
+    val withDeleted = learningPath.copy(
+      title = learningPath.title.filterNot(_.language == language),
+      description = learningPath.description.filterNot(_.language == language),
+      tags = learningPath.tags.filterNot(_.language == language),
+      lastUpdated = clock.now()
+    )
+
+    withDeleted.title.size match {
+      case 0 =>
+        Failure(errors.OperationNotAllowedException(s"Cannot delete last language for learning path with id $id"))
+      case _ => Success(withDeleted)
     }
   }
 

--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/UpdateServiceTest.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/UpdateServiceTest.scala
@@ -1645,4 +1645,20 @@ class UpdateServiceTest extends UnitSuite with UnitTestEnvironment {
       .updateLearningStep(any)(using any)
     res.supportedLanguages should be(Seq("nn"))
   }
+
+  test("That delete learning path language should succeed even if learning step doesn't contain said language") {
+    val learningPath = PRIVATE_LEARNINGPATH.copy(
+      title = PRIVATE_LEARNINGPATH.title :+ Title("Tittel", "nn"),
+      description = PRIVATE_LEARNINGPATH.description :+ Description("Beskrivelse", "nn")
+    )
+    when(learningPathRepository.withId(eqTo(PRIVATE_ID))(using any[DBSession])).thenReturn(Some(learningPath))
+    when(learningPathRepository.updateLearningStep(any)(using any[DBSession])).thenAnswer(_.getArgument(0))
+    when(learningPathRepository.update(any)(using any[DBSession])).thenAnswer(_.getArgument(0))
+
+    val res = service.deleteLearningPathLanguage(PRIVATE_ID, "nn", PRIVATE_OWNER.toCombined).failIfFailure
+    verify(learningPathRepository, times(PRIVATE_LEARNINGPATH.learningsteps.get.size))
+      .updateLearningStep(any)(using any)
+    res.supportedLanguages should be(Seq("nb"))
+
+  }
 }


### PR DESCRIPTION
Hvis man tidligere hadde en sti på flere språk som inneholdt et steg med kun ett språk feilet slettingen av språket