### PR TITLE
fix(network): call `wait()` on `this`

### DIFF
--- a/network/src/main/scala/no/ndla/network/tapir/NdlaTapirMain.scala
+++ b/network/src/main/scala/no/ndla/network/tapir/NdlaTapirMain.scala
@@ -40,7 +40,7 @@ trait NdlaTapirMain[T <: TapirApplication[?]] {
     val server = componentRegistry.routes.startJdkServerAsync(name, port)(warmupFunc)
     this.server = Some(server)
     // NOTE: Since JdkHttpServer does not block, we need to block the main thread to keep the application alive
-    synchronized { wait() }
+    synchronized { this.wait() }
   }
 
   private def performWarmup(): Unit = if (!props.disableWarmup) {


### PR DESCRIPTION
For some strange reason this was causing the server to crash when running through IntelliJ.