### PR TITLE
fix(CircleUtil): use `entryName` for invalid enum message

### DIFF
--- a/common/src/main/scala/no/ndla/common/CirceUtil.scala
+++ b/common/src/main/scala/no/ndla/common/CirceUtil.scala
@@ -70,7 +70,7 @@ object CirceUtil {
       stringDecoder(c).flatMap { s =>
         withNameEither(s).left.map { notFound =>
           val enumName = this.getClass.getSimpleName.stripSuffix("$")
-          val enumList = s"[${notFound.enumValues.mkString("'", "','", "'")}]"
+          val enumList = s"[${notFound.enumValues.map(_.entryName).mkString("'", "','", "'")}]"
           val message  = s"'${notFound.notFoundName}' is not a member of enum '$enumName'. Must be one of $enumList"
           DecodingFailure(message, c.history)
         }


### PR DESCRIPTION
Makes sure the error message when failing to decode an enum lists the `entryName`s instead of the object name.