### PR TITLE
Stop preventing copying of learningpaths

### DIFF
--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/validation/LearningPathValidator.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/validation/LearningPathValidator.scala
@@ -30,9 +30,6 @@ class LearningPathValidator(
   private val MY_NDLA_LANGUAGE_MISMATCH =
     "A learning path created in MyNDLA must have exactly one supported language."
 
-  private val MY_NDLA_INVALID_LANGUAGES =
-    "A learning path created in MyNDLA must have exactly one supported language."
-
   private val MISSING_DESCRIPTION = "At least one description is required."
 
   private val INVALID_COVER_PHOTO =
@@ -64,8 +61,7 @@ class LearningPathValidator(
       newLearningPath: LearningPath,
       allowUnknownLanguage: Boolean
   ): Seq[ValidationMessage] = {
-    validateSupportedLanguages(newLearningPath) ++
-      titleValidator.validate(newLearningPath.title, allowUnknownLanguage) ++
+    titleValidator.validate(newLearningPath.title, allowUnknownLanguage) ++
       titleValidator.validate(newLearningPath.title, allowUnknownLanguage) ++
       validateIntroduction(newLearningPath.introduction, allowUnknownLanguage) ++ validateDescription(
         newLearningPath.description,
@@ -87,13 +83,6 @@ class LearningPathValidator(
         updatedLearningPath.language,
         allowUnknownLanguage = true
       )
-
-  private def validateSupportedLanguages(learningPath: LearningPath) =
-    (learningPath.supportedLanguages.size, learningPath.isMyNDLAOwner) match {
-      case (1, true)  => List()
-      case (_, true)  => List(ValidationMessage("supportedLanguages", MY_NDLA_INVALID_LANGUAGES))
-      case (_, false) => List()
-    }
 
   def validateIntroduction(
       introductions: Seq[Introduction],

--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/validation/LearningPathValidatorTest.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/validation/LearningPathValidatorTest.scala
@@ -327,20 +327,13 @@ class LearningPathValidatorTest extends UnitSuite with TestEnvironment {
   //   res.head.field should equal("revisionMeta")
   // }
 
-  test("That validate returns error when MyNDLA path supports multiple languages") {
+  test("That validate returns ok MyNDLA path supports multiple languages") {
     val learningPath =
       ValidLearningPath.copy(isMyNDLAOwner = true, title = ValidLearningPath.title :+ Title("Tittel", "nn"))
-    validator.validateLearningPath(learningPath, true) should be(
-      Seq(
-        ValidationMessage(
-          "supportedLanguages",
-          "A learning path created in MyNDLA must have exactly one supported language."
-        )
-      )
-    )
+    validator.validateLearningPath(learningPath, true) should be(Seq.empty)
   }
 
-  test("That validate reurns error when MyNDLA path is updated with wrong language") {
+  test("That validate returns error when MyNDLA path is updated with wrong language") {
     val updated  = UPDATED_PRIVATE_LEARNINGPATHV2.copy(title = Some("Tittel"), language = "nn")
     val existing = ValidLearningPath.copy(isMyNDLAOwner = true)
     validator.validateLearningPathUpdate(updated, existing) should be(


### PR DESCRIPTION
Slutter å forhindre at offentlige læringsstier kan kopieres til Min NDLA. 
Dette har sluppet gjennom sprekkene tidligere, fordi isMyNDLAOwner ikkje blei satt som det skulle, men etter siste endringene blokkeres det.