### PR TITLE
Fetch resources for folder

### DIFF
--- a/myndla-api/src/main/scala/no/ndla/myndlaapi/controller/FolderController.scala
+++ b/myndla-api/src/main/scala/no/ndla/myndlaapi/controller/FolderController.scala
@@ -186,6 +186,18 @@ class FolderController(using
       folderWriteService.newFolderResourceConnection(folderId, newResource, feideHeader)
     }
 
+  private def getFolderResources: ServerEndpoint[Any, Eff] = endpoint
+    .get
+    .summary("Fetch resources in a folder")
+    .description("Fetch resources in a folder")
+    .in(feideHeader)
+    .in(pathFolderId / "resources")
+    .errorOut(errorOutputsFor(400, 401, 403, 404))
+    .out(jsonBody[List[ResourceDTO]])
+    .serverLogicPure { case (feideHeader, folderId) =>
+      folderReadService.getFolderResources(folderId, feideHeader)
+    }
+
   private def updateResource(): ServerEndpoint[Any, Eff] = endpoint
     .patch
     .summary("Updated selected resource")
@@ -326,6 +338,7 @@ class FolderController(using
     updateFolder(),
     removeFolder(),
     createFolderResource,
+    getFolderResources,
     updateResource(),
     deleteResource(),
     fetchSharedFolder,

--- a/myndla-api/src/main/scala/no/ndla/myndlaapi/service/FolderReadService.scala
+++ b/myndla-api/src/main/scala/no/ndla/myndlaapi/service/FolderReadService.scala
@@ -228,6 +228,18 @@ class FolderReadService(using
     } yield convertedResources
   }
 
+  def getFolderResources(folderId: UUID, feideAccessToken: Option[FeideAccessToken]): Try[List[ResourceDTO]] = {
+    for {
+      feideId            <- feideApiClient.getFeideID(feideAccessToken)
+      resources          <- folderRepository.getFolderResources(folderId)
+      _                  <- resources.traverse(r => r.isOwner(feideId))
+      convertedResources <- folderConverterService.domainToApiModel(
+        resources,
+        resource => folderConverterService.toApiResource(resource, isOwner = true),
+      )
+    } yield convertedResources
+  }
+
   private def createFavorite(feideId: FeideID): Try[domain.Folder] = {
     val favoriteFolder = domain.NewFolderData(
       parentId = None,


### PR DESCRIPTION
Legger til endepunkt for å hente alle ressurser for ei mappe. Kan brukes i stedet for full rekursiv henting av mapper med innhold.