### PR TITLE
feat: auto delete myndla users after inactivity

### DIFF
--- a/common/package.mill
+++ b/common/package.mill
@@ -10,7 +10,7 @@ object `package` extends BaseModule {
   def mvnDeps: T[Seq[Dep]] = logging ++
     enumeratum ++
     tapirCirce ++
-    Seq(sttp, scalikejdbc, awsCloudfront, awsS3, awsTranscribe, jsoup)
+    Seq(sttp, scalikejdbc, awsCloudfront, awsS3, awsTranscribe, awsSesV2, jsoup)
   override def moduleDeps = Seq(build.language)
   object test extends TestBase {
     override def moduleDeps = super.moduleDeps :+ build.testbase

--- a/common/src/main/scala/no/ndla/common/aws/NdlaAWSTranscribeClient.scala
+++ b/common/src/main/scala/no/ndla/common/aws/NdlaAWSTranscribeClient.scala
@@ -8,18 +8,19 @@
 
 package no.ndla.common.aws
 
+import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.transcribe.model.*
 import software.amazon.awssdk.services.transcribe.{TranscribeClient, TranscribeClientBuilder}
 
 import scala.util.{Failure, Try}
 
 class NdlaAWSTranscribeClient(region: Option[String]) {
-
-  private val builder: TranscribeClientBuilder = TranscribeClient.builder()
-
-  val client: TranscribeClient = region match {
-    case Some(value) => builder.region(software.amazon.awssdk.regions.Region.of(value)).build()
-    case None        => builder.build()
+  lazy val client: TranscribeClient = {
+    val builder: TranscribeClientBuilder = TranscribeClient.builder()
+    region match {
+      case Some(value) => builder.region(Region.of(value)).build()
+      case None        => builder.build()
+    }
   }
 
   def startTranscriptionJob(

--- a/common/src/main/scala/no/ndla/common/aws/NdlaEmailClient.scala
+++ b/common/src/main/scala/no/ndla/common/aws/NdlaEmailClient.scala
@@ -1,0 +1,48 @@
+/*
+ * Part of NDLA common
+ * Copyright (C) 2026 NDLA
+ *
+ * See LICENSE
+ *
+ */
+
+package no.ndla.common.aws
+
+import no.ndla.common.TryUtil.throwIfInterrupted
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.sesv2.{SesV2Client, SesV2ClientBuilder}
+import software.amazon.awssdk.services.sesv2.model.*
+
+import scala.util.Try
+
+class NdlaEmailClient(senderEmail: String, senderName: String, region: Option[String]) {
+  lazy val client: SesV2Client = {
+    val builder: SesV2ClientBuilder = SesV2Client.builder()
+    region match {
+      case Some(value) => builder.region(Region.of(value)).build()
+      case None        => builder.build()
+    }
+  }
+
+  def sendEmail(to: String, subject: String, bodyStr: String): Try[Boolean] = {
+    Try.throwIfInterrupted {
+      val destination      = Destination.builder().toAddresses(to).build()
+      val content          = Content.builder().data(bodyStr).build()
+      val sub              = Content.builder().data(subject).build()
+      val body             = Body.builder().html(content).build()
+      val msg              = Message.builder().subject(sub).body(body).build()
+      val bodyEmailContent = EmailContent.builder().simple(msg).build()
+      val emailRequest     = SendEmailRequest
+        .builder()
+        .destination(destination)
+        .fromEmailAddress(s"$senderName <$senderEmail>")
+        .content(bodyEmailContent)
+        .build()
+
+      val response = client.sendEmail(emailRequest)
+
+      Option(response.messageId()).exists(_.nonEmpty)
+    }
+  }
+
+}

--- a/common/src/main/scala/no/ndla/common/aws/NdlaS3Client.scala
+++ b/common/src/main/scala/no/ndla/common/aws/NdlaS3Client.scala
@@ -22,14 +22,13 @@ import scala.jdk.CollectionConverters.*
 import scala.util.{Failure, Try}
 
 class NdlaS3Client(bucket: String, region: Option[String]) {
-  private val builder: S3ClientBuilder = S3Client.builder()
-
-  val client: S3Client = region match {
-    case Some(value) => builder.region(Region.of(value)).build()
-    case None        => builder.build()
+  lazy val client: S3Client = {
+    val builder: S3ClientBuilder = S3Client.builder()
+    region match {
+      case Some(value) => builder.region(Region.of(value)).build()
+      case None        => builder.build()
+    }
   }
-
-  val foundRegion: Region = client.serviceClientConfiguration().region()
 
   def headObject(key: String): Try[HeadObjectResponse] = Try.throwIfInterrupted {
     val headObjectRequest = HeadObjectRequest.builder().bucket(bucket).key(key).build()

--- a/common/src/main/scala/no/ndla/common/errors/NDLAErrors.scala
+++ b/common/src/main/scala/no/ndla/common/errors/NDLAErrors.scala
@@ -32,6 +32,7 @@ case class OperationNotAllowedException(message: String)  extends RuntimeExcepti
 case class TaxonomyException(message: String)             extends RuntimeException(message)
 case class MissingBucketKeyException(bucketKey: String)
     extends RuntimeException(s"The bucket key '$bucketKey' does not exist")
+case class InactivityEmailException(message: String) extends RuntimeException(message)
 
 class MultipleExceptions(message: String, exs: Seq[Throwable]) extends RuntimeException(message) {
   exs.foreach(ex => addSuppressed(ex))

--- a/common/src/main/scala/no/ndla/common/model/NDLADate.scala
+++ b/common/src/main/scala/no/ndla/common/model/NDLADate.scala
@@ -26,14 +26,15 @@ case class NDLADate(underlying: ZonedDateTime) extends Ordered[NDLADate] {
 
   def asUtcLocalDateTime: LocalDateTime = underlying.withZoneSameInstant(ZoneId.of("UTC")).toLocalDateTime
 
-  def minusSeconds(seconds: Long): NDLADate = withUnderlying(_.minusSeconds(seconds))
-  def plusSeconds(seconds: Long): NDLADate  = withUnderlying(_.plusSeconds(seconds))
-  def minusDays(days: Long): NDLADate       = withUnderlying(_.minusDays(days))
-  def plusDays(days: Long): NDLADate        = withUnderlying(_.plusDays(days))
-  def plusYears(years: Long): NDLADate      = withUnderlying(_.plusYears(years))
-  def minusYears(years: Long): NDLADate     = withUnderlying(_.minusYears(years))
-  def isAfter(date: NDLADate): Boolean      = underlying.isAfter(date.underlying)
-  def isBefore(date: NDLADate): Boolean     = underlying.isBefore(date.underlying)
+  def minusSeconds(seconds: Long): NDLADate                    = withUnderlying(_.minusSeconds(seconds))
+  def plusSeconds(seconds: Long): NDLADate                     = withUnderlying(_.plusSeconds(seconds))
+  def minusDays(days: Long): NDLADate                          = withUnderlying(_.minusDays(days))
+  def plusDays(days: Long): NDLADate                           = withUnderlying(_.plusDays(days))
+  def plusYears(years: Long): NDLADate                         = withUnderlying(_.plusYears(years))
+  def minusYears(years: Long): NDLADate                        = withUnderlying(_.minusYears(years))
+  def isAfter(date: NDLADate): Boolean                         = underlying.isAfter(date.underlying)
+  def isBefore(date: NDLADate): Boolean                        = underlying.isBefore(date.underlying)
+  def between(startDate: NDLADate, endDate: NDLADate): Boolean = isAfter(startDate) && isBefore(endDate)
 
   def withYear(year: Int): NDLADate             = withUnderlying(_.withYear(year))
   def withMonth(month: Int): NDLADate           = withUnderlying(_.withMonth(month))

--- a/common/src/test/scala/no/ndla/common/aws/NdlaEmailClientIntegrationTest.scala
+++ b/common/src/test/scala/no/ndla/common/aws/NdlaEmailClientIntegrationTest.scala
@@ -1,0 +1,30 @@
+/*
+ * Part of NDLA common
+ * Copyright (C) 2026 NDLA
+ *
+ * See LICENSE
+ *
+ */
+
+package no.ndla.common.aws
+
+import no.ndla.testbase.UnitTestSuiteBase
+
+class NdlaEmailClientIntegrationTest extends UnitTestSuiteBase {
+  test("Send email via AWS SES (manual)") {
+    val areWeTesting = Option(System.getenv("NDLA_TEST_AWS_SES")).contains("true")
+    val to           = Option(System.getenv("NDLA_TEST_AWS_SES_EMAIL"))
+    assume(areWeTesting && to.isDefined)
+
+    val client = new NdlaEmailClient(
+      senderEmail = "noreply@mail.test.ndla.no",
+      senderName = "NDLA-testing",
+      region = Some("eu-west-1"),
+    )
+
+    val subject = "NDLA SES test email"
+    val body    = "This is a test email sent by NdlaEmailClient via AWS SES."
+    val result  = client.sendEmail(to.get, subject, body)
+    result.failIfFailure should be(true)
+  }
+}

--- a/modules/versions.mill
+++ b/modules/versions.mill
@@ -63,6 +63,7 @@ object SharedDependencies {
   val sttp          = mvn"com.softwaremill.sttp.client3::core:$SttpV"
   val awsS3         = mvn"software.amazon.awssdk:s3:$AwsSdkV"
   val awsTranscribe = mvn"software.amazon.awssdk:transcribe:$AwsSdkV"
+  val awsSesV2      = mvn"software.amazon.awssdk:sesv2:$AwsSdkV"
   val awsCloudfront = mvn"software.amazon.awssdk:cloudfront:$AwsSdkV"
 
   val circe: Seq[Dep] =

--- a/myndla-api/src/main/resources/no/ndla/myndlaapi/db/migration/V27__add_last_cleanup_date_table.sql
+++ b/myndla-api/src/main/resources/no/ndla/myndlaapi/db/migration/V27__add_last_cleanup_date_table.sql
@@ -1,0 +1,8 @@
+CREATE TABLE user_cleanup_audit (
+    id BIGINT GENERATED ALWAYS AS IDENTITY,
+    num_cleanup INT,
+    num_emailed INT,
+    last_cleanup_date TIMESTAMP
+);
+
+

--- a/myndla-api/src/main/scala/no/ndla/myndlaapi/ComponentRegistry.scala
+++ b/myndla-api/src/main/scala/no/ndla/myndlaapi/ComponentRegistry.scala
@@ -9,6 +9,7 @@
 package no.ndla.myndlaapi
 
 import no.ndla.common.Clock
+import no.ndla.common.aws.NdlaEmailClient
 import no.ndla.database.{DBMigrator, DBUtility, DataSource}
 import no.ndla.myndlaapi.controller.{
   ConfigController,
@@ -71,26 +72,28 @@ class ComponentRegistry(properties: MyNdlaApiProperties) extends TapirApplicatio
   given dbSavedSharedFolder: DBSavedSharedFolder   = new DBSavedSharedFolder
   given dbRobotDefinition: DBRobotDefinition       = new DBRobotDefinition
 
-  given ndlaClient: NdlaClient                                  = new NdlaClient
-  implicit lazy val myndlaApiClient: InternalMyNDLAApiClient    = new InternalMyNDLAApiClient
-  implicit lazy val redisClient: RedisClient                    = new RedisClient(props.RedisHost, props.RedisPort)
-  implicit lazy val feideApiClient: FeideApiClient              = new FeideApiClient
-  implicit lazy val nodebb: NodeBBClient                        = new NodeBBClient
-  given errorHelpers: ErrorHelpers                              = new ErrorHelpers
-  given errorHandling: ControllerErrorHandling                  = new ControllerErrorHandling
-  implicit lazy val folderRepository: FolderRepository          = new FolderRepository
-  given folderConverterService: FolderConverterService          = new FolderConverterService
-  implicit lazy val userRepository: UserRepository              = new UserRepository
-  given configRepository: ConfigRepository                      = new ConfigRepository
-  given configService: ConfigService                            = new ConfigService
-  implicit lazy val folderReadService: FolderReadService        = new FolderReadService
-  implicit lazy val folderWriteService: FolderWriteService      = new FolderWriteService
-  implicit lazy val userService: UserService                    = new UserService
-  given robotRepository: RobotRepository                        = new RobotRepository
-  given robotService: RobotService                              = new RobotService
-  implicit lazy val searchApiClient: SearchApiClient            = new SearchApiClient
-  given taxonomyApiClient: TaxonomyApiClient                    = new TaxonomyApiClient
-  given learningPathApiClient: LearningPathApiClient            = new LearningPathApiClient
+  given ndlaClient: NdlaClient                               = new NdlaClient
+  implicit lazy val myndlaApiClient: InternalMyNDLAApiClient = new InternalMyNDLAApiClient
+  implicit lazy val redisClient: RedisClient                 = new RedisClient(props.RedisHost, props.RedisPort)
+  implicit lazy val feideApiClient: FeideApiClient           = new FeideApiClient
+  implicit lazy val nodebb: NodeBBClient                     = new NodeBBClient
+  given errorHelpers: ErrorHelpers                           = new ErrorHelpers
+  given errorHandling: ControllerErrorHandling               = new ControllerErrorHandling
+  implicit lazy val folderRepository: FolderRepository       = new FolderRepository
+  given folderConverterService: FolderConverterService       = new FolderConverterService
+  implicit lazy val userRepository: UserRepository           = new UserRepository
+  given configRepository: ConfigRepository                   = new ConfigRepository
+  given configService: ConfigService                         = new ConfigService
+  implicit lazy val folderReadService: FolderReadService     = new FolderReadService
+  implicit lazy val folderWriteService: FolderWriteService   = new FolderWriteService
+  implicit lazy val userService: UserService                 = new UserService
+  given robotRepository: RobotRepository                     = new RobotRepository
+  given robotService: RobotService                           = new RobotService
+  implicit lazy val searchApiClient: SearchApiClient         = new SearchApiClient
+  given taxonomyApiClient: TaxonomyApiClient                 = new TaxonomyApiClient
+  given learningPathApiClient: LearningPathApiClient         = new LearningPathApiClient
+  implicit lazy val emailClient: NdlaEmailClient             =
+    new NdlaEmailClient(props.outgoingEmail, props.outgoingEmailName, props.AWSEmailRegion)
   lazy val v16__MigrateResourcePaths: V16__MigrateResourcePaths = new V16__MigrateResourcePaths
 
   given userController: UserController          = new UserController

--- a/myndla-api/src/main/scala/no/ndla/myndlaapi/MyNdlaApiProperties.scala
+++ b/myndla-api/src/main/scala/no/ndla/myndlaapi/MyNdlaApiProperties.scala
@@ -28,4 +28,15 @@ class MyNdlaApiProperties extends BaseProps with DatabaseProps {
   def nodeBBUrl: String = propOrElse("NODEBB_URL", s"$ApiGatewayUrl/groups")
 
   override def MetaMigrationLocation: String = "no/ndla/myndlaapi/db/migration"
+
+  def emailDomain: String = Environment match {
+    case "prod"  => "mail.ndla.no"
+    case "local" => s"mail.test.ndla.no"
+    case _       => s"mail.$Environment.ndla.no"
+  }
+
+  def outgoingEmailName: String      = propOrElse("NDLA_MYNDLA_EMAIL_NAME", "NDLA")
+  def outgoingEmail: String          = propOrElse("NDLA_MYNDLA_EMAIL", s"noreply@$emailDomain")
+  def MyNDLAContactEmail: String     = propOrElse("MYNDLA_CONTACT_EMAIL", "hjelp@ndla.no")
+  def AWSEmailRegion: Option[String] = propOrNone("NDLA_AWS_EMAIL_REGION")
 }

--- a/myndla-api/src/main/scala/no/ndla/myndlaapi/model/api/InactiveUserResultDTO.scala
+++ b/myndla-api/src/main/scala/no/ndla/myndlaapi/model/api/InactiveUserResultDTO.scala
@@ -1,0 +1,19 @@
+/*
+ * Part of NDLA myndla-api
+ * Copyright (C) 2026 NDLA
+ *
+ * See LICENSE
+ *
+ */
+
+package no.ndla.myndlaapi.model.api
+
+import io.circe.{Decoder, Encoder}
+import io.circe.generic.semiauto.*
+
+case class InactiveUserResultDTO(numberOfUsersDeleted: Int, numberOfUsersEmailed: Int)
+
+object InactiveUserResultDTO {
+  implicit def encoder: Encoder[InactiveUserResultDTO] = deriveEncoder[InactiveUserResultDTO]
+  implicit def decoder: Decoder[InactiveUserResultDTO] = deriveDecoder[InactiveUserResultDTO]
+}

--- a/myndla-api/src/main/scala/no/ndla/myndlaapi/model/domain/InactiveUserCleanupResult.scala
+++ b/myndla-api/src/main/scala/no/ndla/myndlaapi/model/domain/InactiveUserCleanupResult.scala
@@ -1,0 +1,13 @@
+/*
+ * Part of NDLA myndla-api
+ * Copyright (C) 2026 NDLA
+ *
+ * See LICENSE
+ *
+ */
+
+package no.ndla.myndlaapi.model.domain
+
+import no.ndla.common.model.NDLADate
+
+case class InactiveUserCleanupResult(id: Long, numCleanup: Int, numEmailed: Int, lastCleanupDate: NDLADate)

--- a/myndla-api/src/main/scala/no/ndla/myndlaapi/repository/UserRepository.scala
+++ b/myndla-api/src/main/scala/no/ndla/myndlaapi/repository/UserRepository.scala
@@ -13,9 +13,9 @@ import no.ndla.common.CirceUtil
 import no.ndla.common.errors.NotFoundException
 import no.ndla.common.model.NDLADate
 import no.ndla.common.model.domain.myndla.{MyNDLAUser, MyNDLAUserDocument, UserRole}
-import no.ndla.database.DBUtility
+import no.ndla.database.{DBUtility, ReadableDbSession, WriteableDbSession}
 import no.ndla.database.implicits.*
-import no.ndla.myndlaapi.model.domain.{DBMyNDLAUser, NDLASQLException}
+import no.ndla.myndlaapi.model.domain.{DBMyNDLAUser, InactiveUserCleanupResult, NDLASQLException}
 import no.ndla.network.model.FeideID
 import org.postgresql.util.PGobject
 import scalikejdbc.*
@@ -151,9 +151,9 @@ class UserRepository(using dbUtility: DBUtility, dbMyNDLAUser: DBMyNDLAUser) ext
     }
   }
 
-  def deleteAllUsers(implicit session: DBSession): Try[Unit] = Try {
-    val _ = tsql"delete from ${dbMyNDLAUser.table}".execute()
-  }
+  def deleteAllUsers(implicit session: DBSession): Try[Unit] = tsql"delete from ${dbMyNDLAUser.table}"
+    .execute()
+    .map(_ => ())
 
   def resetSequences(implicit session: DBSession): Try[Unit] = Try {
     val _ = tsql"alter sequence my_ndla_users_id_seq restart with 1".execute()
@@ -217,5 +217,59 @@ class UserRepository(using dbUtility: DBUtility, dbMyNDLAUser: DBMyNDLAUser) ext
   def getAllUsers(implicit session: DBSession): List[MyNDLAUser] = {
     val u = dbMyNDLAUser.syntax("u")
     tsql"select ${u.result.*} from ${dbMyNDLAUser.as(u)}".map(dbMyNDLAUser.fromResultSet(u)).runList().get
+  }
+
+  def getUserNotSeenSince(cutoffDate: NDLADate)(implicit session: DBSession): Try[List[MyNDLAUser]] = {
+    val u = DBMyNDLAUser.syntax("u")
+    tsql"""
+         select ${u.result.*} from ${DBMyNDLAUser.as(u)}
+         where last_seen < ${NDLADate.parameterBinderFactory(cutoffDate)}
+         """.map(DBMyNDLAUser.fromResultSet(u)).runList()
+  }
+
+  def getUserNotSeenBeforeOrAfter(beforeDate: NDLADate, afterDate: NDLADate)(implicit
+      session: DBSession
+  ): Try[List[MyNDLAUser]] = {
+    val u = DBMyNDLAUser.syntax("u")
+    tsql"""
+         select ${u.result.*} from ${DBMyNDLAUser.as(u)}
+         where last_seen < ${NDLADate.parameterBinderFactory(beforeDate)}
+         or last_seen > ${NDLADate.parameterBinderFactory(afterDate)}
+         """.map(DBMyNDLAUser.fromResultSet(u)).runList()
+  }
+
+  def getLastCleanup(implicit session: ReadableDbSession): Try[Option[InactiveUserCleanupResult]] = {
+    tsql"""
+         select id, num_cleanup, num_emailed, last_cleanup_date from user_cleanup_audit
+         order by last_cleanup_date desc
+         limit 1
+         """
+      .map(rs =>
+        InactiveUserCleanupResult(
+          id = rs.long("id"),
+          numCleanup = rs.int("num_cleanup"),
+          numEmailed = rs.int("num_emailed"),
+          lastCleanupDate = NDLADate.fromUtcDate(rs.localDateTime("last_cleanup_date")),
+        )
+      )
+      .runSingle()
+  }
+
+  def insertCleanupResult(numCleanup: Int, numEmailed: Int, lastCleanupDate: NDLADate)(implicit
+      session: WriteableDbSession
+  ): Try[InactiveUserCleanupResult] = {
+    tsql"""
+         insert into user_cleanup_audit (num_cleanup, num_emailed, last_cleanup_date)
+         values ($numCleanup, $numEmailed, ${NDLADate.parameterBinderFactory(lastCleanupDate)})
+         """
+      .updateAndReturnGeneratedKey()
+      .map(id =>
+        InactiveUserCleanupResult(
+          id = id,
+          numCleanup = numCleanup,
+          numEmailed = numEmailed,
+          lastCleanupDate = lastCleanupDate,
+        )
+      )
   }
 }

--- a/myndla-api/src/main/scala/no/ndla/myndlaapi/repository/UserRepository.scala
+++ b/myndla-api/src/main/scala/no/ndla/myndlaapi/repository/UserRepository.scala
@@ -227,17 +227,6 @@ class UserRepository(using dbUtility: DBUtility, dbMyNDLAUser: DBMyNDLAUser) ext
          """.map(DBMyNDLAUser.fromResultSet(u)).runList()
   }
 
-  def getUserNotSeenBeforeOrAfter(beforeDate: NDLADate, afterDate: NDLADate)(implicit
-      session: DBSession
-  ): Try[List[MyNDLAUser]] = {
-    val u = DBMyNDLAUser.syntax("u")
-    tsql"""
-         select ${u.result.*} from ${DBMyNDLAUser.as(u)}
-         where last_seen < ${NDLADate.parameterBinderFactory(beforeDate)}
-         or last_seen > ${NDLADate.parameterBinderFactory(afterDate)}
-         """.map(DBMyNDLAUser.fromResultSet(u)).runList()
-  }
-
   def getLastCleanup(implicit session: ReadableDbSession): Try[Option[InactiveUserCleanupResult]] = {
     tsql"""
          select id, num_cleanup, num_emailed, last_cleanup_date from user_cleanup_audit

--- a/myndla-api/src/main/scala/no/ndla/myndlaapi/repository/UserRepository.scala
+++ b/myndla-api/src/main/scala/no/ndla/myndlaapi/repository/UserRepository.scala
@@ -220,11 +220,11 @@ class UserRepository(using dbUtility: DBUtility, dbMyNDLAUser: DBMyNDLAUser) ext
   }
 
   def getUserNotSeenSince(cutoffDate: NDLADate)(implicit session: DBSession): Try[List[MyNDLAUser]] = {
-    val u = DBMyNDLAUser.syntax("u")
+    val u = dbMyNDLAUser.syntax("u")
     tsql"""
-         select ${u.result.*} from ${DBMyNDLAUser.as(u)}
+         select ${u.result.*} from ${dbMyNDLAUser.as(u)}
          where last_seen < ${NDLADate.parameterBinderFactory(cutoffDate)}
-         """.map(DBMyNDLAUser.fromResultSet(u)).runList()
+         """.map(dbMyNDLAUser.fromResultSet(u)).runList()
   }
 
   def getLastCleanup(implicit session: ReadableDbSession): Try[Option[InactiveUserCleanupResult]] = {

--- a/myndla-api/src/main/scala/no/ndla/myndlaapi/service/UserService.scala
+++ b/myndla-api/src/main/scala/no/ndla/myndlaapi/service/UserService.scala
@@ -251,6 +251,8 @@ class UserService(using
     usersToEmailFiltered = lastCleanupRun match {
       case None          => emailCandidates
       case Some(lastRun) =>
+        // NOTE: This is the cutoff for which users would have been sent an email in the last run.
+        //       Since we only want to email users once, we filter out users that would have been emailed in the last run, even if they are still inactive.
         val lastEmailCutoff = lastRun.lastCleanupDate.minusDays(emailAfter)
         emailCandidates.filter(user => user.lastSeen.isAfter(lastEmailCutoff))
     }

--- a/myndla-api/src/main/scala/no/ndla/myndlaapi/service/UserService.scala
+++ b/myndla-api/src/main/scala/no/ndla/myndlaapi/service/UserService.scala
@@ -228,10 +228,11 @@ class UserService(using
   def sendInactivityEmailIgnoreEnvironment(email: String): Try[Boolean] =
     emailClient.sendEmail(email, UserService.emailSubject, UserService.emailBody)
 
-  private def getUsersToEmail(now: NDLADate)(implicit session: ReadableDbSession): Try[List[MyNDLAUser]] = for {
-    lastCleanupRun      <- userRepository.getLastCleanup
-    emailCandidates     <- userRepository.getUserNotSeenSince(now.minusDays(UserService.emailAfter))
-    usersToEmailFiltered = lastCleanupRun match {
+  private def filterUsersToEmail(
+      emailCandidates: List[MyNDLAUser]
+  )(implicit session: ReadableDbSession): Try[List[MyNDLAUser]] = userRepository
+    .getLastCleanup
+    .map {
       case None          => emailCandidates
       case Some(lastRun) =>
         // NOTE: This is the cutoff for which users would have been sent an email in the last run.
@@ -239,7 +240,6 @@ class UserService(using
         val lastEmailCutoff = lastRun.lastCleanupDate.minusDays(UserService.emailAfter)
         emailCandidates.filter(user => user.lastSeen.isAfter(lastEmailCutoff))
     }
-  } yield usersToEmailFiltered
 
   private def sendInactivityEmails(usersToEmail: List[MyNDLAUser]) = usersToEmail.traverse(user =>
     sendInactivityEmail(user).flatMap {
@@ -253,12 +253,12 @@ class UserService(using
     val deleteBeforeDate = now.minusDays(UserService.deleteAfter)
 
     for {
-      usersToDelete <- userRepository.getUserNotSeenSince(deleteBeforeDate)
-      deleteFeideIds = usersToDelete.map(_.feideId).toSet
-      usersToEmail  <- getUsersToEmail(now).map(_.filterNot(user => deleteFeideIds.contains(user.feideId)))
-      _             <- sendInactivityEmails(usersToEmail)
-      _             <- usersToDelete.traverse(user => userRepository.deleteUser(user.feideId).map(_ => ()))
-      cleanupResult <- userRepository.insertCleanupResult(usersToDelete.size, usersToEmail.size, now)
+      usersToEmailOrDelete              <- userRepository.getUserNotSeenSince(now.minusDays(UserService.emailAfter))
+      (usersToDelete, usersToMaybeEmail) = usersToEmailOrDelete.partition(_.lastSeen.isBefore(deleteBeforeDate))
+      usersToEmail                      <- filterUsersToEmail(usersToMaybeEmail)
+      _                                 <- sendInactivityEmails(usersToEmail)
+      _                                 <- usersToDelete.traverse(user => userRepository.deleteUser(user.feideId).map(_ => ()))
+      cleanupResult                     <- userRepository.insertCleanupResult(usersToDelete.size, usersToEmail.size, now)
     } yield InactiveUserResultDTO(cleanupResult.numCleanup, cleanupResult.numEmailed)
   }
 }

--- a/myndla-api/src/main/scala/no/ndla/myndlaapi/service/UserService.scala
+++ b/myndla-api/src/main/scala/no/ndla/myndlaapi/service/UserService.scala
@@ -214,6 +214,56 @@ class UserService(using
     } yield ()
   })
 
+  def sendInactivityEmail(user: MyNDLAUser): Try[Boolean] = {
+    props.Environment match {
+      case "prod" =>
+        logger.info(s"Sending inactivity email to user ${user.feideId} at email ${user.email}")
+        emailClient.sendEmail(user.email, UserService.emailSubject, UserService.emailBody)
+      case _ =>
+        logger.info(s"Skipping sending inactivity email to user ${user.feideId} in non-prod environment")
+        Success(true)
+    }
+  }
+
+  def sendInactivityEmailIgnoreEnvironment(email: String): Try[Boolean] =
+    emailClient.sendEmail(email, UserService.emailSubject, UserService.emailBody)
+
+  private def getUsersToEmail(now: NDLADate)(implicit session: ReadableDbSession): Try[List[MyNDLAUser]] = for {
+    lastCleanupRun      <- userRepository.getLastCleanup
+    emailCandidates     <- userRepository.getUserNotSeenSince(now.minusDays(UserService.emailAfter))
+    usersToEmailFiltered = lastCleanupRun match {
+      case None          => emailCandidates
+      case Some(lastRun) =>
+        // NOTE: This is the cutoff for which users would have been sent an email in the last run.
+        //       Since we only want to email users once, we filter out users that would have been emailed in the last run, even if they are still inactive.
+        val lastEmailCutoff = lastRun.lastCleanupDate.minusDays(UserService.emailAfter)
+        emailCandidates.filter(user => user.lastSeen.isAfter(lastEmailCutoff))
+    }
+  } yield usersToEmailFiltered
+
+  private def sendInactivityEmails(usersToEmail: List[MyNDLAUser]) = usersToEmail.traverse(user =>
+    sendInactivityEmail(user).flatMap {
+      case true  => Success(())
+      case false => Failure(InactivityEmailException(s"Failed to send inactivity email to user ${user.id}"))
+    }
+  )
+
+  def cleanupInactiveUsers(): Try[InactiveUserResultDTO] = dbUtility.writeSession { implicit session =>
+    val now              = clock.now()
+    val deleteBeforeDate = now.minusDays(UserService.deleteAfter)
+
+    for {
+      usersToDelete <- userRepository.getUserNotSeenSince(deleteBeforeDate)
+      deleteFeideIds = usersToDelete.map(_.feideId).toSet
+      usersToEmail  <- getUsersToEmail(now).map(_.filterNot(user => deleteFeideIds.contains(user.feideId)))
+      _             <- sendInactivityEmails(usersToEmail)
+      _             <- usersToDelete.traverse(user => userRepository.deleteUser(user.feideId).map(_ => ()))
+      cleanupResult <- userRepository.insertCleanupResult(usersToDelete.size, usersToEmail.size, now)
+    } yield InactiveUserResultDTO(cleanupResult.numCleanup, cleanupResult.numEmailed)
+  }
+}
+
+object UserService {
   private val emailAfter           = 180
   private val deleteAfter          = 210
   private def emailSubject: String = "Min NDLA brukeren din blir snart slettet"
@@ -231,51 +281,4 @@ class UserService(using
                                         |NDLA<br>
                                         |""".stripMargin
 
-  def sendInactivityEmail(user: MyNDLAUser): Try[Boolean] = {
-    props.Environment match {
-      case "prod" =>
-        logger.info(s"Sending inactivity email to user ${user.feideId} at email ${user.email}")
-        emailClient.sendEmail(user.email, emailSubject, emailBody)
-      case _ =>
-        logger.info(s"Skipping sending inactivity email to user ${user.feideId} in non-prod environment")
-        Success(true)
-    }
-  }
-
-  def sendInactivityEmailIgnoreEnvironment(email: String): Try[Boolean] =
-    emailClient.sendEmail(email, emailSubject, emailBody)
-
-  private def getUsersToEmail(now: NDLADate)(implicit session: ReadableDbSession): Try[List[MyNDLAUser]] = for {
-    lastCleanupRun      <- userRepository.getLastCleanup
-    emailCandidates     <- userRepository.getUserNotSeenSince(now.minusDays(emailAfter))
-    usersToEmailFiltered = lastCleanupRun match {
-      case None          => emailCandidates
-      case Some(lastRun) =>
-        // NOTE: This is the cutoff for which users would have been sent an email in the last run.
-        //       Since we only want to email users once, we filter out users that would have been emailed in the last run, even if they are still inactive.
-        val lastEmailCutoff = lastRun.lastCleanupDate.minusDays(emailAfter)
-        emailCandidates.filter(user => user.lastSeen.isAfter(lastEmailCutoff))
-    }
-  } yield usersToEmailFiltered
-
-  private def sendInactivityEmails(usersToEmail: List[MyNDLAUser]) = usersToEmail.traverse(user =>
-    sendInactivityEmail(user).flatMap {
-      case true  => Success(())
-      case false => Failure(InactivityEmailException(s"Failed to send inactivity email to user ${user.id}"))
-    }
-  )
-
-  def cleanupInactiveUsers(): Try[InactiveUserResultDTO] = dbUtility.writeSession { implicit session =>
-    val now              = clock.now()
-    val deleteBeforeDate = now.minusDays(deleteAfter)
-
-    for {
-      usersToDelete <- userRepository.getUserNotSeenSince(deleteBeforeDate)
-      deleteFeideIds = usersToDelete.map(_.feideId).toSet
-      usersToEmail  <- getUsersToEmail(now).map(_.filterNot(user => deleteFeideIds.contains(user.feideId)))
-      _             <- sendInactivityEmails(usersToEmail)
-      _             <- usersToDelete.traverse(user => userRepository.deleteUser(user.feideId).map(_ => ()))
-      cleanupResult <- userRepository.insertCleanupResult(usersToDelete.size, usersToEmail.size, now)
-    } yield InactiveUserResultDTO(cleanupResult.numCleanup, cleanupResult.numEmailed)
-  }
 }

--- a/myndla-api/src/test/scala/no/ndla/myndlaapi/repository/UserRepositoryTest.scala
+++ b/myndla-api/src/test/scala/no/ndla/myndlaapi/repository/UserRepositoryTest.scala
@@ -161,26 +161,4 @@ class UserRepositoryTest extends DatabaseIntegrationSuite with UnitSuite with Te
     results.map(_.username).toSet should be(Set("old1", "old2"))
   }
 
-  test("that getUserNotSeenBeforeOrAfter respects before/after boundaries") {
-    implicit val session: DBSession = DBUtil.autoSession
-
-    val beforeDate = NDLADate.of(2024, 2, 1, 0, 0, 0).withNano(0)
-    val afterDate  = NDLADate.of(2024, 3, 1, 0, 0, 0).withNano(0)
-
-    insertUser("feide-before", userDocument("Before", "before", UserRole.STUDENT))
-    insertUser("feide-between", userDocument("Between", "between", UserRole.STUDENT))
-    insertUser("feide-after", userDocument("After", "after", UserRole.EMPLOYEE))
-    insertUser("feide-boundary-before", userDocument("Boundary Before", "boundary-before", UserRole.EMPLOYEE))
-    insertUser("feide-boundary-after", userDocument("Boundary After", "boundary-after", UserRole.EMPLOYEE))
-
-    repository.updateLastSeen("feide-before", NDLADate.of(2024, 1, 15, 0, 0, 0).withNano(0)).get
-    repository.updateLastSeen("feide-between", NDLADate.of(2024, 2, 15, 0, 0, 0).withNano(0)).get
-    repository.updateLastSeen("feide-after", NDLADate.of(2024, 3, 15, 0, 0, 0).withNano(0)).get
-    repository.updateLastSeen("feide-boundary-before", beforeDate).get
-    repository.updateLastSeen("feide-boundary-after", afterDate).get
-
-    val results = repository.getUserNotSeenBeforeOrAfter(beforeDate, afterDate)(using session).get
-    results.map(_.username).toSet should be(Set("before", "after"))
-  }
-
 }

--- a/myndla-api/src/test/scala/no/ndla/myndlaapi/service/UserServiceTest.scala
+++ b/myndla-api/src/test/scala/no/ndla/myndlaapi/service/UserServiceTest.scala
@@ -311,8 +311,7 @@ class UserServiceTest extends UnitTestSuite with TestEnvironment {
 
     when(userRepository.getLastCleanup(using any)).thenReturn(Success(None))
     when(userRepository.getUserNotSeenSince(any[NDLADate])(using any)).thenReturn(
-      Success(usersToDelete),
-      Success(emailCandidates),
+      Success(usersToDelete ++ emailCandidates)
     )
     when(userRepository.deleteUser(any)(using any)).thenReturn(Success("deleted"))
     when(userRepository.insertCleanupResult(eqTo(usersToDelete.size), eqTo(emailCandidates.size), eqTo(now))(using any))
@@ -336,19 +335,19 @@ class UserServiceTest extends UnitTestSuite with TestEnvironment {
     val deleteUser      = userWithLastSeen(id = 1, feideId = "delete-1", lastSeen = now.minusDays(220))
     val usersToDelete   = List(deleteUser)
     val shouldEmail     = userWithLastSeen(id = 2, feideId = "email-1", lastSeen = now.minusDays(181))
-    val emailCandidates = List(deleteUser, shouldEmail)
+    val emailCandidates = List(shouldEmail)
     val expectedEmailed = 1
 
     when(userRepository.getLastCleanup(using any)).thenReturn(Success(None))
     when(userRepository.getUserNotSeenSince(any[NDLADate])(using any)).thenReturn(
-      Success(usersToDelete),
-      Success(emailCandidates),
+      Success(usersToDelete ++ emailCandidates)
     )
     when(userRepository.deleteUser(any)(using any)).thenReturn(Success("deleted"))
     when(userRepository.insertCleanupResult(eqTo(usersToDelete.size), eqTo(expectedEmailed), eqTo(now))(using any))
       .thenReturn(Success(InactiveUserCleanupResult(1, usersToDelete.size, expectedEmailed, now)))
 
-    service.cleanupInactiveUsers() should be(Success(InactiveUserResultDTO(usersToDelete.size, expectedEmailed)))
+    val result = service.cleanupInactiveUsers()
+    result should be(Success(InactiveUserResultDTO(usersToDelete.size, expectedEmailed)))
 
     verify(service, times(1)).sendInactivityEmail(eqTo(shouldEmail))
     verify(service, times(0)).sendInactivityEmail(eqTo(deleteUser))
@@ -372,8 +371,7 @@ class UserServiceTest extends UnitTestSuite with TestEnvironment {
       Success(Some(InactiveUserCleanupResult(1, 0, 0, lastCleanupDate)))
     )
     when(userRepository.getUserNotSeenSince(any[NDLADate])(using any)).thenReturn(
-      Success(usersToDelete),
-      Success(emailCandidates),
+      Success(usersToDelete ++ emailCandidates)
     )
     when(userRepository.insertCleanupResult(eqTo(0), eqTo(1), eqTo(now))(using any)).thenReturn(
       Success(InactiveUserCleanupResult(2, 0, 1, now))


### PR DESCRIPTION


Implementerer et endepunkt som InternController i myndla-api som skal kalles daglig av en cronjob.

Den søker opp brukere fra databasen som ikke har vært innlogget på 180 dager og sender de en epost.
Dersom jobben ikke har vært kjørt mellom brukerens siste innlogging+180 dager så sender den også en epost.

Den søker også opp brukere som ikke har vært innlogget på 220 dager og sletter de fra databasen.

Trenger noen rettigheter i aws for å fungere.