### PR TITLE
refactor: do not rely on fromFolderId when copying resources

### DIFF
--- a/myndla-api/src/main/scala/no/ndla/myndlaapi/controller/FolderController.scala
+++ b/myndla-api/src/main/scala/no/ndla/myndlaapi/controller/FolderController.scala
@@ -13,6 +13,7 @@ import no.ndla.common.model.domain.ResourceType
 import no.ndla.common.model.domain.myndla.FolderStatus
 import no.ndla.myndlaapi.integration.InternalMyNDLAApiClient
 import no.ndla.myndlaapi.model.api.{
+  CopyResourcesDTO,
   FolderDTO,
   FolderSortRequestDTO,
   MoveResourceDTO,
@@ -299,7 +300,7 @@ class FolderController(using
     .description("Copy several resources from one folder to another")
     .in("resources" / "copy" / "batch")
     .out(noContent)
-    .in(jsonBody[MoveResourcesDTO])
+    .in(jsonBody[CopyResourcesDTO])
     .errorOut(errorOutputsFor(400, 401, 403, 404))
     .withFeideUser
     .serverLogicPure { feide => move =>

--- a/myndla-api/src/main/scala/no/ndla/myndlaapi/model/api/FolderDTO.scala
+++ b/myndla-api/src/main/scala/no/ndla/myndlaapi/model/api/FolderDTO.scala
@@ -206,3 +206,10 @@ case class MoveResourcesDTO(
     @description("The resources to move")
     resourceIds: List[UUID],
 )
+
+case class CopyResourcesDTO(
+    @description("Folder to move to. Empty value moves resource to root.")
+    toFolderId: NullableOrValue[UUID],
+    @description("The resources to move")
+    resourceIds: List[UUID],
+)

--- a/myndla-api/src/main/scala/no/ndla/myndlaapi/repository/FolderRepository.scala
+++ b/myndla-api/src/main/scala/no/ndla/myndlaapi/repository/FolderRepository.scala
@@ -445,6 +445,15 @@ class FolderRepository(using
       case Some(resource) => Success(resource)
     })
 
+  def userResourcesWithIds(ids: List[UUID], feideId: FeideID)(implicit
+      session: DBSession = dbUtility.readOnlySession
+  ): Try[List[Resource]] = {
+    resourcesWhere(sqls"r.feide_id=$feideId and r.id in ($ids)").flatMap({
+      case resources if resources.size != ids.size => Failure(NotFoundException("Failed to find requested resources"))
+      case resources                               => Success(resources)
+    })
+  }
+
   def userResourceWithId(path: String, feideId: FeideID)(implicit session: DBSession): Try[Option[Resource]] =
     resourceWhere(sqls"path=$path and feide_id=$feideId")
 

--- a/myndla-api/src/main/scala/no/ndla/myndlaapi/service/FolderWriteService.scala
+++ b/myndla-api/src/main/scala/no/ndla/myndlaapi/service/FolderWriteService.scala
@@ -14,7 +14,7 @@ import no.ndla.common.Clock
 import no.ndla.common.errors.{AccessDeniedException, NotFoundException, ValidationException}
 import no.ndla.common.implicits.*
 import no.ndla.common.model.NDLADate
-import no.ndla.common.model.api.{NullableOrValue}
+import no.ndla.common.model.api.NullableOrValue
 import no.ndla.common.model.domain.ResourceType
 import no.ndla.common.model.domain.myndla.{FolderStatus, MyNDLAUser}
 import no.ndla.database.DBUtility
@@ -26,6 +26,7 @@ import no.ndla.myndlaapi.model.domain.FolderSortObject.{
   SharedFolderSorting,
 }
 import no.ndla.myndlaapi.model.api.{
+  CopyResourcesDTO,
   ExportedUserDataDTO,
   FolderDTO,
   FolderSortRequestDTO,
@@ -376,28 +377,21 @@ class FolderWriteService(using
     resourcesToMove.partitionMap(resource => toResourcesById.get(resource.id).toRight(resource))
   }
 
-  def copyResourceConnections(move: MoveResourcesDTO, feide: FeideUserWrapper): Try[Unit] = dbUtility
+  def copyResourceConnections(move: CopyResourcesDTO, feide: FeideUserWrapper): Try[Unit] = dbUtility
     .rollbackOnFailure { implicit session =>
       for {
-        (fromFolderId, toFolderId) <- getMoveFolderIds(move.fromFolderId, move.toFolderId)
-        user                       <- feide.userOrAccessDenied
-        _                          <- canWriteOrAccessDenied(feide)
-        _                          <- fromFolderId.traverse(fid => folderRepository.folderWithId(fid).flatMap(_.isOwner(user.feideId)))
-        toFolder                   <- toFolderId.traverse(fid => folderRepository.folderWithId(fid))
-        _                          <- toFolder.traverse(_.isOwner(user.feideId))
-        fromResources              <- getResourcesFromFolderOrRoot(fromFolderId, user)
-        resourcesToMove            <- getResourcesToMove(fromResources, move.resourceIds)
-        toResources                <- getResourcesFromFolderOrRoot(toFolder.map(_.id), user)
-        (toCopy, _)                 = getResourcesToMoveAndRemove(resourcesToMove, toResources)
-        _                          <- toCopy
+        user        <- feide.userOrAccessDenied
+        _           <- canWriteOrAccessDenied(feide)
+        toFolderId   = move.toFolderId.toOption
+        toFolder    <- toFolderId.traverse(fid => folderRepository.folderWithId(fid))
+        _           <- toFolder.traverse(_.isOwner(user.feideId))
+        resources   <- folderRepository.userResourcesWithIds(move.resourceIds, user.feideId)
+        toResources <- getResourcesFromFolderOrRoot(toFolder.map(_.id), user)
+        (toCopy, _)  = getResourcesToMoveAndRemove(resources, toResources)
+        _           <- toCopy
           .zipWithIndex
           .traverse((res, i) =>
-            folderRepository.createResourceConnection(
-              toFolderId,
-              res.id,
-              getNextRank(toResources) + i,
-              res.connection.get.favoritedDate,
-            )
+            folderRepository.createResourceConnection(toFolderId, res.id, getNextRank(toResources) + i, clock.now())
           )
         _ = toCopy.foreach(resource => updateSearchApi(resource))
       } yield ()

--- a/myndla-api/src/test/scala/no/ndla/myndlaapi/service/FolderWriteServiceTest.scala
+++ b/myndla-api/src/test/scala/no/ndla/myndlaapi/service/FolderWriteServiceTest.scala
@@ -14,7 +14,14 @@ import no.ndla.common.model.api.{Missing, NullValue, UpdateWith, Value}
 import no.ndla.common.model.domain.ResourceType
 import no.ndla.common.model.domain.myndla.{FolderStatus, UserRole}
 import no.ndla.myndlaapi.TestData.{emptyDomainFolder, emptyDomainResource, emptyMyNDLAUser}
-import no.ndla.myndlaapi.model.api.{FolderDTO, FolderSortRequestDTO, MoveResourcesDTO, NewFolderDTO, NewResourceDTO}
+import no.ndla.myndlaapi.model.api.{
+  CopyResourcesDTO,
+  FolderDTO,
+  FolderSortRequestDTO,
+  MoveResourcesDTO,
+  NewFolderDTO,
+  NewResourceDTO,
+}
 import no.ndla.myndlaapi.model.{api, domain}
 import no.ndla.myndlaapi.model.domain.FolderSortObject.FolderSorting
 import no.ndla.myndlaapi.model.domain.{FolderAndDirectChildren, Resource, ResourceConnection, SavedSharedFolder}
@@ -1338,7 +1345,6 @@ class FolderWriteServiceTest extends UnitTestSuite with TestEnvironment {
   test("that copying resources only copies resources not in the target folder") {
     val feideId        = "feideId"
     val myNDLAUser     = emptyMyNDLAUser.copy(userRole = UserRole.EMPLOYEE, feideId = feideId)
-    val sourceFolderId = UUID.randomUUID()
     val targetFolderId = UUID.randomUUID()
 
     val favoritedDate = NDLADate.now()
@@ -1355,52 +1361,34 @@ class FolderWriteServiceTest extends UnitTestSuite with TestEnvironment {
     val resource4 = emptyDomainResource.copy(id = resource4Id, feideId = feideId)
     val resource5 = emptyDomainResource.copy(id = resource5Id, feideId = feideId)
 
-    val sourceFolder = emptyDomainFolder.copy(id = sourceFolderId, feideId = feideId)
     val targetFolder = emptyDomainFolder.copy(id = targetFolderId, feideId = feideId)
 
     when(userService.getMyNDLAUser(any, any)(using any[DBSession])).thenReturn(Success(myNDLAUser))
     when(configService.isMyNDLAWriteRestricted).thenReturn(Success(true))
-    when(folderRepository.folderWithId(eqTo(sourceFolderId))(using any)).thenReturn(Success(sourceFolder))
     when(folderRepository.folderWithId(eqTo(targetFolderId))(using any)).thenReturn(Success(targetFolder))
 
-    val sourceFolderResources = List(
-      resource1.copy(connection = Some(ResourceConnection(Some(sourceFolderId), resource1Id, 1, favoritedDate))),
-      resource2.copy(connection = Some(ResourceConnection(Some(sourceFolderId), resource2Id, 2, favoritedDate))),
-      resource4.copy(connection = Some(ResourceConnection(Some(sourceFolderId), resource4Id, 3, favoritedDate))),
-      resource5.copy(connection = Some(ResourceConnection(Some(sourceFolderId), resource5Id, 4, favoritedDate))),
-    )
     val targetFolderResources = List(
       resource1.copy(connection = Some(ResourceConnection(Some(targetFolderId), resource1Id, 1, favoritedDate))),
       resource3.copy(connection = Some(ResourceConnection(Some(targetFolderId), resource3Id, 2, favoritedDate))),
       resource4.copy(connection = Some(ResourceConnection(Some(targetFolderId), resource4Id, 3, favoritedDate))),
     )
-    when(folderRepository.getFolderResources(eqTo(sourceFolderId))(using any)).thenReturn(
-      Success(sourceFolderResources)
-    )
+    when(
+      folderRepository.userResourcesWithIds(eqTo(List(resource1Id, resource2Id, resource5Id)), eqTo(feideId))(using any)
+    ).thenReturn(Success(List(resource1, resource2, resource5)))
     when(folderRepository.getFolderResources(eqTo(targetFolderId))(using any)).thenReturn(
       Success(targetFolderResources)
     )
 
     when(
-      folderRepository.createResourceConnection(
-        eqTo(Some(targetFolderId)),
-        eqTo(resource2Id),
-        eqTo(4),
-        eqTo(favoritedDate),
-      )(using any)
+      folderRepository.createResourceConnection(eqTo(Some(targetFolderId)), eqTo(resource2Id), eqTo(4), any)(using any)
     ).thenReturn(Success(ResourceConnection(Some(targetFolderId), resource4Id, 4, favoritedDate)))
     when(
-      folderRepository.createResourceConnection(
-        eqTo(Some(targetFolderId)),
-        eqTo(resource5Id),
-        eqTo(5),
-        eqTo(favoritedDate),
-      )(using any)
+      folderRepository.createResourceConnection(eqTo(Some(targetFolderId)), eqTo(resource5Id), eqTo(5), any)(using any)
     ).thenReturn(Success(ResourceConnection(Some(targetFolderId), resource5Id, 5, favoritedDate)))
 
     service
       .copyResourceConnections(
-        MoveResourcesDTO(Value(sourceFolderId), Value(targetFolderId), List(resource1Id, resource2Id, resource5Id)),
+        CopyResourcesDTO(Value(targetFolderId), List(resource1Id, resource2Id, resource5Id)),
         feideWrapper(feideId, role = UserRole.EMPLOYEE),
       )
       .failIfFailure


### PR DESCRIPTION
Synes det gir mer mening å ikke være avhengige av `fromFolderId` når man kopierer ressurser inn en annen mappe. Gir også mening at dette fører til en ny `favoritedDate`.