### PR TITLE
fix: run HikariCP in main thread group

### DIFF
--- a/network/src/main/scala/no/ndla/network/tapir/NdlaTapirMain.scala
+++ b/network/src/main/scala/no/ndla/network/tapir/NdlaTapirMain.scala
@@ -83,10 +83,11 @@ trait NdlaTapirMain[T <: TapirApplication[?]] extends StrictLogging {
   private def runServer(): Try[Unit] = {
     logCopyrightHeader()
     setupShutdownHook()
+    beforeStart()
+
     Try(
       startServerAndWait(props.ApplicationName, props.ApplicationPort) { binding =>
         this.serverBinding = Some(binding)
-        beforeStart()
         performWarmup()
       }
     ).recover { ex =>


### PR DESCRIPTION
Et forsøk på å fikse stack overflow som oppstod med en image-api pod i prod.

Teorien er at HikariCP sine tråder ble starta som en del av virtual thread gruppen til Ox/Netty, og dermed fikk for liten stack space.