### PR TITLE
refactor(learningpath-api)!: change valid step type values to reflect frontend usage

### DIFF
--- a/common/src/main/scala/no/ndla/common/model/domain/learningpath/StepType.scala
+++ b/common/src/main/scala/no/ndla/common/model/domain/learningpath/StepType.scala
@@ -9,17 +9,16 @@
 package no.ndla.common.model.domain.learningpath
 
 import enumeratum.*
+import sttp.tapir.Codec.PlainCodec
+import sttp.tapir.Schema
+import sttp.tapir.codec.enumeratum.*
 import no.ndla.common.errors.{ValidationException, ValidationMessage}
 
 sealed trait StepType extends EnumEntry
 object StepType       extends Enum[StepType] with CirceEnum[StepType] {
-  case object INTRODUCTION extends StepType
-  case object TEXT         extends StepType
-  case object QUIZ         extends StepType
-  case object TASK         extends StepType
-  case object MULTIMEDIA   extends StepType
-  case object SUMMARY      extends StepType
-  case object TEST         extends StepType
+  case object ARTICLE  extends StepType
+  case object TEXT     extends StepType
+  case object EXTERNAL extends StepType
 
   def valueOf(s: String): Option[StepType]  = StepType.values.find(_.toString == s)
   def valueOfOrDefault(s: String): StepType = valueOf(s).getOrElse(StepType.TEXT)
@@ -33,4 +32,6 @@ object StepType       extends Enum[StepType] with CirceEnum[StepType] {
   }
 
   override def values: IndexedSeq[StepType] = findValues
+  implicit val schema: Schema[StepType]     = schemaForEnumEntry[StepType]
+  implicit val codec: PlainCodec[StepType]  = plainCodecEnumEntry[StepType]
 }

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/db/migration/V62__ConvertLearningStepType.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/db/migration/V62__ConvertLearningStepType.scala
@@ -1,0 +1,58 @@
+/*
+ * Part of NDLA learningpath-api
+ * Copyright (C) 2026 NDLA
+ *
+ * See LICENSE
+ *
+ */
+
+package no.ndla.learningpathapi.db.migration
+
+import no.ndla.common.CirceUtil
+import no.ndla.common.model.domain.learningpath.{EmbedUrl, StepType}
+import no.ndla.learningpathapi.db.util.*
+import io.circe.syntax.EncoderOps
+
+class V62__ConvertLearningStepType extends LearningPathAndStepMigration {
+
+  private[migration] def convertStep(document: String): String = {
+    val step      = CirceUtil.tryParse(document).get
+    val embedUrl  = step.hcursor.get[Option[Seq[EmbedUrl]]]("embedUrl").toTry.get.get
+    val articleId = step.hcursor.get[Option[Int]]("articleId").toTry.get
+    if (articleId.isDefined) {
+      return step
+        .mapObject(doc =>
+          doc
+            .remove("type")
+            .add("type", StepType.ARTICLE.entryName.asJson)
+            .remove("embedUrl")
+            .add("embedUrl", Seq.empty[EmbedUrl].asJson)
+        )
+        .noSpaces
+    }
+
+    val newStepType =
+      if (embedUrl.exists(url => url.url.nonEmpty)) StepType.EXTERNAL
+      else StepType.TEXT
+
+    step
+      .mapObject(doc =>
+        doc
+          .remove("type")
+          .add("type", newStepType.entryName.asJson)
+          .remove("embedUrl")
+          .add("embedUrl", embedUrl.filterNot(_.url.isEmpty).asJson)
+      )
+      .noSpaces
+  }
+
+  override def convertPathAndSteps(
+      lpData: LpDocumentRow,
+      stepDatas: List[StepDocumentRow],
+  ): (LpDocumentRow, List[StepDocumentRow]) = {
+    val updatedSteps = stepDatas.map(step => step.copy(learningStepDocument = convertStep(step.learningStepDocument)))
+
+    (lpData, updatedSteps)
+  }
+
+}

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/model/api/LearningStepV2DTO.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/model/api/LearningStepV2DTO.scala
@@ -12,6 +12,7 @@ import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
 import io.circe.{Decoder, Encoder}
 import no.ndla.common.model.NDLADate
 import no.ndla.common.model.api.LicenseDTO
+import no.ndla.common.model.domain.learningpath.StepType
 import sttp.tapir.Schema.annotations.{deprecated, description}
 
 @description("Information about a learningstep")
@@ -35,7 +36,7 @@ case class LearningStepV2DTO(
     @description("Determines if the title of the step should be displayed in viewmode")
     showTitle: Boolean,
     @description("The type of the step")
-    `type`: String,
+    `type`: StepType,
     @description("Describes the copyright information for the learningstep")
     @deprecated
     license: Option[LicenseDTO],

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/ConverterService.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/ConverterService.scala
@@ -578,60 +578,8 @@ class ConverterService(using
     CopyrightDTO(asApiLicense(License.CC_BY.toString), contributors)
   }
 
-  def getApiIntroduction(learningSteps: Seq[LearningStep]): Seq[api.IntroductionDTO] = {
-    learningSteps
-      .find(_.`type` == learningpath.StepType.INTRODUCTION)
-      .toList
-      .flatMap(x => x.description)
-      .map(x => api.IntroductionDTO(x.description, x.language))
-  }
-
   def languageIsNotSupported(supportedLanguages: Seq[String], language: String): Boolean = {
     supportedLanguages.isEmpty || (!supportedLanguages.contains(language) && language != AllLanguages)
-  }
-
-  def asApiLearningpathSummaryV2(learningpath: LearningPath, user: CombinedUser): Try[api.LearningPathSummaryV2DTO] = {
-    val supportedLanguages = learningpath.supportedLanguages
-
-    val title = findByLanguageOrBestEffort(learningpath.title, AllLanguages)
-      .map(asApiTitle)
-      .getOrElse(api.TitleDTO("", DefaultLanguage))
-    val description = findByLanguageOrBestEffort(learningpath.description, AllLanguages)
-      .map(asApiDescription)
-      .getOrElse(api.DescriptionDTO("", DefaultLanguage))
-    val tags = findByLanguageOrBestEffort(learningpath.tags, AllLanguages)
-      .map(asApiLearningPathTags)
-      .getOrElse(api.LearningPathTagsDTO(Seq(), DefaultLanguage))
-    val introduction = findByLanguageOrBestEffort(learningpath.introduction.map(asApiIntroduction), AllLanguages)
-      .getOrElse(
-        findByLanguageOrBestEffort(getApiIntroduction(learningpath.learningsteps), AllLanguages).getOrElse(
-          api.IntroductionDTO("", DefaultLanguage)
-        )
-      )
-
-    val message = learningpath.message.filter(_ => learningpath.canEditPath(user)).map(_.message)
-
-    Success(
-      api.LearningPathSummaryV2DTO(
-        learningpath.id.get,
-        revision = learningpath.revision,
-        title,
-        description,
-        introduction,
-        createUrlToLearningPath(learningpath),
-        learningpath.coverPhotoId.flatMap(asCoverPhoto).map(_.url),
-        learningpath.duration,
-        learningpath.status.toString,
-        learningpath.created,
-        learningpath.lastUpdated,
-        tags,
-        asApiCopyright(learningpath.copyright),
-        supportedLanguages,
-        learningpath.isBasedOn,
-        message,
-        learningpath.grepCodes,
-      )
-    )
   }
 
   private def languageIsSupported(supportedLangs: Seq[String], language: String): Boolean = {
@@ -670,7 +618,7 @@ class ConverterService(using
           embedUrl = embedUrl,
           articleId = ls.articleId,
           showTitle = ls.showTitle,
-          `type` = ls.`type`.toString,
+          `type` = ls.`type`,
           license = copyright.map(_.license),
           copyright = copyright,
           metaUrl = createUrlToLearningStep(ls, lp),

--- a/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/search/SearchConverterServiceComponent.scala
+++ b/learningpath-api/src/main/scala/no/ndla/learningpathapi/service/search/SearchConverterServiceComponent.scala
@@ -10,7 +10,7 @@ package no.ndla.learningpathapi.service.search
 
 import com.sksamuel.elastic4s.requests.searches.SearchHit
 import no.ndla.common.model.api.search.{LanguageValue, SearchableLanguageList, SearchableLanguageValues}
-import no.ndla.common.model.domain.learningpath.{LearningPath, LearningStep, StepType}
+import no.ndla.common.model.domain.learningpath.{LearningPath, LearningStep}
 import no.ndla.language.Language.{
   findByLanguageOrBestEffort,
   getDefault,
@@ -35,15 +35,10 @@ class SearchConverterServiceComponent(using converterService: ConverterService, 
       .descriptions
       .languageValues
       .map(lv => api.DescriptionDTO(lv.value, lv.language))
-    val introductions = searchableLearningPath.introductions.languageValues.size match {
-      case 0 => searchableLearningPath
-          .learningsteps
-          .find(_.stepType == StepType.INTRODUCTION.toString)
-          .map(step => step.descriptions.languageValues.map(lv => api.IntroductionDTO(lv.value, lv.language)))
-          .getOrElse(Seq.empty)
-      case _ =>
-        searchableLearningPath.introductions.languageValues.map(lv => api.IntroductionDTO(lv.value, lv.language))
-    }
+    val introductions = searchableLearningPath
+      .introductions
+      .languageValues
+      .map(lv => api.IntroductionDTO(lv.value, lv.language))
     val tags               = searchableLearningPath.tags.languageValues.map(lv => api.LearningPathTagsDTO(lv.value, lv.language))
     val supportedLanguages = getSupportedLanguages(titles, descriptions, introductions, tags)
 

--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/TestData.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/TestData.scala
@@ -55,7 +55,7 @@ object TestData {
     description = List(Description("Step1Description", "nb")),
     embedUrl = List(),
     articleId = None,
-    `type` = StepType.INTRODUCTION,
+    `type` = StepType.TEXT,
     copyright = None,
     created = today,
     lastUpdated = today,

--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/db/migration/V62__ConvertLearningStepTypeTest.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/db/migration/V62__ConvertLearningStepTypeTest.scala
@@ -1,0 +1,120 @@
+/*
+ * Part of NDLA learningpath-api
+ * Copyright (C) 2026 NDLA
+ *
+ * See LICENSE
+ *
+ */
+
+package no.ndla.learningpathapi.db.migration
+
+import no.ndla.common.CirceUtil
+import no.ndla.learningpathapi.{TestEnvironment, UnitSuite}
+
+class V62__ConvertLearningStepTypeTest extends UnitSuite with TestEnvironment {
+  val migration = new V62__ConvertLearningStepType
+  test("that article steps removes remaining embedUrls") {
+    val document = """
+        |{
+        | "type": "TEXT",
+        | "embedUrl": [
+        |   {
+        |     "url": "/article-iframe/12345",
+        |     "language": "nb",
+        |     "embedType": "iframe"
+        |   }
+        |  ],
+        |  "articleId": 1
+        |}
+        |""".stripMargin
+
+    val expectedDocument = """
+        |{
+        |   "type": "ARTICLE",
+        |   "embedUrl": [],
+        |   "articleId": 1
+        |}
+        |""".stripMargin
+
+    val result = migration.convertStep(document)
+
+    val resultJson   = CirceUtil.unsafeParse(result)
+    val expectedJson = CirceUtil.unsafeParse(expectedDocument)
+    resultJson should be(expectedJson)
+  }
+
+  test("That steps with empty embedUrls are converted to text steps") {
+
+    val document = """
+        |{
+        | "type": "INTRODUCTION",
+        | "embedUrl": [
+        |   {
+        |     "url": "",
+        |     "language": "nb",
+        |     "embedType": "iframe"
+        |   }
+        |  ],
+        |  "articleId": null
+        |}
+        |""".stripMargin
+
+    val expectedDocument = """
+         |{
+         |   "type": "TEXT",
+         |   "embedUrl": [],
+         |   "articleId": null
+         |}
+         |""".stripMargin
+
+    val result = migration.convertStep(document)
+
+    val resultJson   = CirceUtil.unsafeParse(result)
+    val expectedJson = CirceUtil.unsafeParse(expectedDocument)
+    resultJson should be(expectedJson)
+  }
+
+  test("That steps containing embedUrls are converted to EXTERNAL and stripped of empty embed urls") {
+
+    val document = """
+         |{
+         | "type": "INTRODUCTION",
+         | "embedUrl": [
+         |   {
+         |     "url": "/article-iframe/12345",
+         |     "language": "nb",
+         |     "embedType": "iframe"
+         |   },
+         |   {
+         |    "url": "",
+         |    "language": "nn",
+         |    "embedType": "iframe"
+         |   }
+         |  ],
+         |  "articleId": null
+         |}
+         |""".stripMargin
+
+    val expectedDocument = """
+         |{
+         |   "type": "EXTERNAL",
+         |   "embedUrl": [
+         |    {
+         |     "url": "/article-iframe/12345",
+         |     "language": "nb",
+         |     "embedType": "iframe"
+         |    }
+         |   ],
+         |   "articleId": null
+         |}
+         |""".stripMargin
+
+    val result = migration.convertStep(document)
+
+    val resultJson   = CirceUtil.unsafeParse(result)
+    val expectedJson = CirceUtil.unsafeParse(expectedDocument)
+    resultJson should be(expectedJson)
+
+  }
+
+}

--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/ConverterServiceTest.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/ConverterServiceTest.scala
@@ -84,7 +84,7 @@ class ConverterServiceTest extends UnitSuite with UnitTestEnvironment {
     description = List(),
     embedUrl = List(),
     articleId = None,
-    `type` = StepType.INTRODUCTION,
+    `type` = StepType.TEXT,
     copyright = None,
     created = today,
     lastUpdated = today,
@@ -102,7 +102,7 @@ class ConverterServiceTest extends UnitSuite with UnitTestEnvironment {
     description = List(Description("deskripsjon", "nb")),
     embedUrl = List(),
     articleId = None,
-    `type` = StepType.INTRODUCTION,
+    `type` = StepType.TEXT,
     copyright = None,
     created = today,
     lastUpdated = today,
@@ -265,41 +265,6 @@ class ConverterServiceTest extends UnitSuite with UnitTestEnvironment {
     ) should equal(expected)
   }
 
-  test("asApiLearningpathSummaryV2 converts domain to api LearningpathSummaryV2") {
-    val expected = Success(
-      api.LearningPathSummaryV2DTO(
-        1,
-        Some(1),
-        api.TitleDTO("tittel", props.DefaultLanguage),
-        api.DescriptionDTO("deskripsjon", props.DefaultLanguage),
-        api.IntroductionDTO("<section><p>introduction</p></section>", props.DefaultLanguage),
-        "http://api-gateway.ndla-local/learningpath-api/v2/learningpaths/1",
-        None,
-        Some(60),
-        LearningPathStatus.PRIVATE.toString,
-        randomDate,
-        randomDate,
-        api.LearningPathTagsDTO(Seq("tag"), props.DefaultLanguage),
-        api.CopyrightDTO(
-          commonApi.LicenseDTO(
-            CC_BY.toString,
-            Some("Creative Commons Attribution 4.0 International"),
-            Some("https://creativecommons.org/licenses/by/4.0/"),
-          ),
-          List.empty,
-        ),
-        List("nb", "en"),
-        None,
-        None,
-        Seq.empty,
-      )
-    )
-    service.asApiLearningpathSummaryV2(
-      domainLearningPath.copy(title = domainLearningPath.title :+ Title("test", "en")),
-      TokenUser.PublicUser.toCombined,
-    ) should equal(expected)
-  }
-
   test("asApiLearningStepV2 converts domain learningstep to api LearningStepV2") {
     val learningstep = Success(
       api.LearningStepV2DTO(
@@ -312,7 +277,7 @@ class ConverterServiceTest extends UnitSuite with UnitTestEnvironment {
         embedUrl = None,
         articleId = None,
         showTitle = false,
-        `type` = "INTRODUCTION",
+        `type` = StepType.TEXT,
         license = None,
         copyright = None,
         metaUrl = "http://api-gateway.ndla-local/learningpath-api/v2/learningpaths/1/learningsteps/1",
@@ -363,7 +328,7 @@ class ConverterServiceTest extends UnitSuite with UnitTestEnvironment {
         embedUrl = None,
         articleId = None,
         showTitle = false,
-        `type` = "INTRODUCTION",
+        `type` = StepType.TEXT,
         license = None,
         copyright = None,
         metaUrl = "http://api-gateway.ndla-local/learningpath-api/v2/learningpaths/1/learningsteps/1",
@@ -390,7 +355,7 @@ class ConverterServiceTest extends UnitSuite with UnitTestEnvironment {
         1,
         1,
         api.TitleDTO("tittel", props.DefaultLanguage),
-        "INTRODUCTION",
+        "TEXT",
         "http://api-gateway.ndla-local/learningpath-api/v2/learningpaths/1/learningsteps/1",
       )
     )
@@ -406,7 +371,7 @@ class ConverterServiceTest extends UnitSuite with UnitTestEnvironment {
         1,
         1,
         api.TitleDTO("tittel", props.DefaultLanguage),
-        "INTRODUCTION",
+        "TEXT",
         "http://api-gateway.ndla-local/learningpath-api/v2/learningpaths/1/learningsteps/1",
       )
     )
@@ -436,34 +401,6 @@ class ConverterServiceTest extends UnitSuite with UnitTestEnvironment {
     service.createUrlToLearningPath(apiLearningPath.copy(status = "PRIVATE")) should equal(
       s"${props.Domain}${props.LearningpathControllerPath}1"
     )
-  }
-
-  test("That asApiIntroduction returns an introduction for a given step") {
-    val introductions = service.getApiIntroduction(
-      Seq(
-        domainLearningStep.copy(description =
-          Seq(
-            Description("Introduksjon på bokmål", "nb"),
-            Description("Introduksjon på nynorsk", "nn"),
-            Description("Introduction in english", "en"),
-          )
-        )
-      )
-    )
-
-    introductions.size should be(3)
-    introductions.find(_.language.contains("nb")).map(_.introduction) should be(Some("Introduksjon på bokmål"))
-    introductions.find(_.language.contains("nn")).map(_.introduction) should be(Some("Introduksjon på nynorsk"))
-    introductions.find(_.language.contains("en")).map(_.introduction) should be(Some("Introduction in english"))
-  }
-
-  test("That asApiIntroduction returns empty list if no descriptions are available") {
-    val introductions = service.getApiIntroduction(Seq(domainLearningStep))
-    introductions.size should be(0)
-  }
-
-  test("That asApiIntroduction returns an empty list if given a None") {
-    service.getApiIntroduction(Seq()) should equal(Seq())
   }
 
   test("asApiLicense returns a License object for a given valid license") {

--- a/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/search/SearchServiceTest.scala
+++ b/learningpath-api/src/test/scala/no/ndla/learningpathapi/service/search/SearchServiceTest.scala
@@ -89,7 +89,7 @@ class SearchServiceTest extends ElasticsearchIntegrationSuite with UnitSuite wit
     description = List(),
     embedUrl = List(),
     articleId = None,
-    `type` = StepType.INTRODUCTION,
+    `type` = StepType.TEXT,
     copyright = Some(LearningpathCopyright(license, Seq.empty)),
     status = StepStatus.ACTIVE,
     created = today,

--- a/search-api/src/test/scala/no/ndla/searchapi/model/search/SearchableLearningPathTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/model/search/SearchableLearningPathTest.scala
@@ -48,8 +48,8 @@ class SearchableLearningPathTest extends UnitSuite with TestEnvironment {
     val tags = SearchableLanguageList(Seq(LanguageValue("en", Seq("Mum", "Car", "Wroom"))))
 
     val learningsteps = List(
-      SearchableLearningStep(stepType = StepType.INTRODUCTION.toString),
-      SearchableLearningStep(stepType = StepType.SUMMARY.toString),
+      SearchableLearningStep(stepType = StepType.ARTICLE.toString),
+      SearchableLearningStep(stepType = StepType.EXTERNAL.toString),
       SearchableLearningStep(stepType = StepType.TEXT.toString),
     )
 

--- a/search-api/src/test/scala/no/ndla/searchapi/model/search/SearchableLearningStepTest.scala
+++ b/search-api/src/test/scala/no/ndla/searchapi/model/search/SearchableLearningStepTest.scala
@@ -15,8 +15,8 @@ import no.ndla.searchapi.{TestEnvironment, UnitSuite}
 class SearchableLearningStepTest extends UnitSuite with TestEnvironment {
 
   test("That serializing a SearchableLearningStep to json and deserializing back to object does not change content") {
-    val original1 = SearchableLearningStep(stepType = StepType.INTRODUCTION.toString)
-    val original2 = SearchableLearningStep(stepType = StepType.QUIZ.toString)
+    val original1 = SearchableLearningStep(stepType = StepType.ARTICLE.toString)
+    val original2 = SearchableLearningStep(stepType = StepType.EXTERNAL.toString)
     val original3 = SearchableLearningStep(stepType = StepType.TEXT.toString)
 
     val json1         = CirceUtil.toJsonString(original1)


### PR DESCRIPTION
Fixes https://github.com/ndlano/issues/issues/4438

Denne er vel egentlig breaking.



Endrer step-type til å reflektere måten vi viser frem ting i ndla-frontend, og måten vi tillater brukere å sette inn steg nå. PDD i frontend viser vi ikke frem eventuelle embeds som er knyttet til et steg som også har artikkel-ID, så å fjerne disse embed-URL'ene er strengt tatt ikke visuelt breaking. La også merke til at vi har en del embed-url'er som er tomme, så konverterer disse like så godt til helt vanlige tekst-steg.

Dette endrer også oppførselen til læringssti-introduksjoner. Før falt vi tilbake til introduksjonssteg dersom en læringssti i søk ikke hadde en introduksjon. For vanlig henting av læringssti falt vi tilbake til tom introduksjon. Nå faller vi tilbake til tom introduksjon over alt.


I dag bruker vi egentlig ikke step-typen på noen nevneverdig måte, vi bare henter den. 