### PR TITLE
chore: add unique constraints for article_id and revision in databases

### DIFF
--- a/article-api/src/main/resources/no/ndla/articleapi/db/migration/V70__AddUniqueRevisionConstraint.sql
+++ b/article-api/src/main/resources/no/ndla/articleapi/db/migration/V70__AddUniqueRevisionConstraint.sql
@@ -1,0 +1,9 @@
+-- delete the oldest row of the singular duplicate
+delete
+from contentdata
+where id = 50237;
+
+alter table contentdata
+    add constraint contentdata_article_id_revision_key unique (article_id, revision);
+
+drop index if exists contentdata_article_id_idx;

--- a/draft-api/src/main/resources/no/ndla/draftapi/db/migration/V88__AddUniqueRevisionConstraint.sql
+++ b/draft-api/src/main/resources/no/ndla/draftapi/db/migration/V88__AddUniqueRevisionConstraint.sql
@@ -1,0 +1,9 @@
+-- delete the oldest row of the singular duplicate
+delete
+from articledata
+where id = 72537;
+
+alter table articledata
+    add constraint articledata_article_id_revision_key unique (article_id, revision);
+
+drop index if exists articledata_article_id_idx;


### PR DESCRIPTION
Har funnet én draft og artikkel med duplikat revisjon, som har samme ID i alle miljøene. Migreringa sletter den eldste raden i konflikten, og lager en `UNIQUE` constraint på `(article_id, revision)`.

Fjerner også den eksisterende indeksen på `article_id`, siden `UNIQUE` lager en indeks på `(article_id, revision)` som bør funke de samme stedene som den forrige indeksen gjorde.