### PR TITLE
refactor(myndla-api): convert `timestamp` to `timestamptz`

### DIFF
--- a/common/src/main/scala/no/ndla/common/model/NDLADate.scala
+++ b/common/src/main/scala/no/ndla/common/model/NDLADate.scala
@@ -13,13 +13,13 @@ import io.circe.{Decoder, Encoder, FailedCursor}
 import scalikejdbc.*
 import sttp.tapir.Schema
 
-import java.sql.ResultSet
+import java.sql.{PreparedStatement, ResultSet}
 import java.time.*
 import java.time.format.DateTimeFormatter
 import scala.annotation.tailrec
 import scala.util.{Failure, Success, Try}
 
-case class NDLADate(underlying: ZonedDateTime) extends Ordered[NDLADate] {
+case class NDLADate(underlying: ZonedDateTime) extends Ordered[NDLADate], ParameterBinder {
 
   private def withUnderlying(f: ZonedDateTime => ZonedDateTime): NDLADate = {
     this.copy(underlying = f(underlying))
@@ -57,7 +57,7 @@ case class NDLADate(underlying: ZonedDateTime) extends Ordered[NDLADate] {
     this.underlying.compareTo(that.underlying)
   }
 
-  def toTimestamptzParameterBinder: ParameterBinderWithValue = NDLADate.timestamptzBinder.apply(this)
+  override def apply(ps: PreparedStatement, idx: Int): Unit = ps.setObject(idx, toOffsetDateTime)
 }
 
 object NDLADate {
@@ -161,16 +161,8 @@ object NDLADate {
 
   implicit val schema: Schema[NDLADate] = Schema.schemaForLocalDateTime.as[NDLADate]
 
-  implicit val parameterBinderFactory: ParameterBinderFactory[NDLADate] = ParameterBinderFactory[NDLADate] {
-    v => (ps, idx) =>
-      ps.setObject(idx, v.asUtcLocalDateTime)
-  }
-
-  val timestamptzBinder: Binders[NDLADate] = new Binders[NDLADate] {
-    override def apply(value: NDLADate): ParameterBinderWithValue = {
-      if (value == null) ParameterBinder.NullParameterBinder
-      else ParameterBinder(value, (ps, idx) => ps.setObject(idx, value.toOffsetDateTime))
-    }
+  given timestamptzBinder: Binders[NDLADate] = new Binders[NDLADate] {
+    override def apply(v: NDLADate): ParameterBinderWithValue = ParameterBinder(v, v.apply)
 
     override def apply(rs: ResultSet, columnIndex: Int): NDLADate = {
       val offsetDateTime = rs.getObject(columnIndex, classOf[OffsetDateTime])
@@ -182,6 +174,4 @@ object NDLADate {
       NDLADate(offsetDateTime.atZoneSameInstant(localZone))
     }
   }
-
-  given TypeBinder[NDLADate] = timestamptzBinder
 }

--- a/common/src/test/scala/no/ndla/common/model/NDLADateTest.scala
+++ b/common/src/test/scala/no/ndla/common/model/NDLADateTest.scala
@@ -161,11 +161,10 @@ class NDLADateTest extends DatabaseIntegrationSuite, UnitTestSuite, TestEnvironm
   }
 
   test("that timestamptz binder works") {
-    val date                = NDLADate.fromString("2023-08-03T06:01:31.000Z").get
-    val dateBinderWithValue = date.toTimestamptzParameterBinder
+    val date = NDLADate.fromString("2023-08-03T06:01:31.000Z").get
 
     DB.autoCommit { implicit session =>
-      sql"insert into test_tz values (1, $dateBinderWithValue)".execute()
+      sql"insert into test_tz values (1, $date)".execute()
 
       // Ensure that stored timestamptz is correct
       val res = sql"select 1 from test_tz where data = '2023-08-03T06:01:31.000Z'::timestamptz"
@@ -185,7 +184,7 @@ class NDLADateTest extends DatabaseIntegrationSuite, UnitTestSuite, TestEnvironm
     val date = NDLADate.fromString("2023-08-03T06:01:31.000Z").get
 
     DB.autoCommit { implicit session =>
-      sql"insert into test_without_tz values (1, ${NDLADate.parameterBinderFactory(date)})".execute()
+      sql"insert into test_without_tz values (1, ${date.asUtcLocalDateTime})".execute()
 
       val oldReadWithoutTz = sql"select data from test_without_tz where id = 1"
         .map(rs => NDLADate.fromUtcDate(rs.localDateTime("data")))

--- a/draft-api/src/main/scala/no/ndla/draftapi/repository/DraftRepository.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/repository/DraftRepository.scala
@@ -38,10 +38,7 @@ class DraftRepository(using draftErrorHelpers: DraftErrorHelpers, clock: Clock, 
     dataObject.setType("jsonb")
     dataObject.setValue(CirceUtil.toJsonString(article))
     val slug                                  = article.slug.map(_.toLowerCase)
-    val (responsibleId, responsibleUpdatedAt) = article
-      .responsible
-      .map(r => (r.responsibleId, r.lastUpdated.toTimestamptzParameterBinder))
-      .unzip
+    val (responsibleId, responsibleUpdatedAt) = article.responsible.map(r => (r.responsibleId, r.lastUpdated)).unzip
 
     for {
       dbId <- tsql"""
@@ -98,7 +95,7 @@ class DraftRepository(using draftErrorHelpers: DraftErrorHelpers, clock: Clock, 
           slug                                  = article.slug.map(_.toLowerCase)
           (responsibleId, responsibleUpdatedAt) = copiedArticle
             .responsible
-            .map(r => (r.responsibleId, r.lastUpdated.toTimestamptzParameterBinder))
+            .map(r => (r.responsibleId, r.lastUpdated))
             .unzip
           _ <- tsql"""
             insert into ${dbDraft.table} (external_id, external_subject_id, document, revision, import_id, article_id, slug, responsible, responsible_updated_at)
@@ -152,10 +149,7 @@ class DraftRepository(using draftErrorHelpers: DraftErrorHelpers, clock: Clock, 
     val oldRevision                           = article.revision.getOrElse(0)
     val newRevision                           = oldRevision + 1
     val slug                                  = article.slug.map(_.toLowerCase)
-    val (responsibleId, responsibleUpdatedAt) = article
-      .responsible
-      .map(r => (r.responsibleId, r.lastUpdated.toTimestamptzParameterBinder))
-      .unzip
+    val (responsibleId, responsibleUpdatedAt) = article.responsible.map(r => (r.responsibleId, r.lastUpdated)).unzip
 
     val whereClause = sqls"""
       where dr.article_id=${article.id}

--- a/myndla-api/src/main/resources/no/ndla/myndlaapi/db/migration/V28__convert_timestamp_to_timestamptz.sql
+++ b/myndla-api/src/main/resources/no/ndla/myndlaapi/db/migration/V28__convert_timestamp_to_timestamptz.sql
@@ -1,0 +1,21 @@
+alter table resources
+    alter column created type timestamptz using created at time zone 'UTC';
+
+alter table folders
+    alter column created type timestamptz using created at time zone 'UTC',
+    alter column updated type timestamptz using updated at time zone 'UTC',
+    alter column shared  type timestamptz using shared  at time zone 'UTC';
+
+alter table resource_connections
+    alter column favorited_date type timestamptz using favorited_date at time zone 'UTC';
+
+alter table my_ndla_users
+    alter column last_seen type timestamptz using last_seen at time zone 'UTC';
+
+alter table robot_definitions
+    alter column created type timestamptz using created at time zone 'UTC',
+    alter column updated type timestamptz using updated at time zone 'UTC',
+    alter column shared  type timestamptz using shared  at time zone 'UTC';
+
+alter table user_cleanup_audit
+    alter column last_cleanup_date type timestamptz using last_cleanup_date at time zone 'UTC';

--- a/myndla-api/src/main/scala/no/ndla/myndlaapi/repository/FolderRepository.scala
+++ b/myndla-api/src/main/scala/no/ndla/myndlaapi/repository/FolderRepository.scala
@@ -765,7 +765,7 @@ class FolderRepository(using
             resource.feideId,
             resource.path,
             resource.resourceType.entryName,
-            NDLADate.parameterBinderFactory(resource.created),
+            resource.created,
             document,
           )
         }
@@ -799,7 +799,7 @@ class FolderRepository(using
                     resource.path,
                     c.folderId,
                     c.rank,
-                    NDLADate.parameterBinderFactory(c.favoritedDate),
+                    c.favoritedDate,
                   )
                 )
 
@@ -836,9 +836,9 @@ class FolderRepository(using
           folder.name,
           folder.status.toString,
           folder.rank,
-          NDLADate.parameterBinderFactory(folder.created),
-          NDLADate.parameterBinderFactory(folder.updated),
-          folder.shared.map(d => NDLADate.parameterBinderFactory(d)),
+          folder.created,
+          folder.updated,
+          folder.shared,
           folder.description,
         )
       }

--- a/myndla-api/src/main/scala/no/ndla/myndlaapi/repository/UserRepository.scala
+++ b/myndla-api/src/main/scala/no/ndla/myndlaapi/repository/UserRepository.scala
@@ -73,7 +73,7 @@ class UserRepository(using dbUtility: DBUtility, dbMyNDLAUser: DBMyNDLAUser) ext
 
     tsql"""
         update ${dbMyNDLAUser.table}
-        set document=$dataObject, last_seen=${NDLADate.parameterBinderFactory(lastSeen)}
+        set document=$dataObject, last_seen=$lastSeen
         where feide_id=$feideId
         """
       .updateAndReturnGeneratedKey()
@@ -112,7 +112,7 @@ class UserRepository(using dbUtility: DBUtility, dbMyNDLAUser: DBMyNDLAUser) ext
     tsql"""
         update ${dbMyNDLAUser.table}
                   set document=$dataObject,
-                      last_seen=${NDLADate.parameterBinderFactory(user.lastSeen)}
+                      last_seen=${user.lastSeen}
                   where feide_id=$feideId
         """
       .update()
@@ -127,7 +127,7 @@ class UserRepository(using dbUtility: DBUtility, dbMyNDLAUser: DBMyNDLAUser) ext
   def updateLastSeen(feideId: FeideID, lastSeen: NDLADate)(implicit session: DBSession): Try[NDLADate] = {
     tsql"""
         update ${dbMyNDLAUser.table}
-        set last_seen=${NDLADate.parameterBinderFactory(lastSeen)}
+        set last_seen=$lastSeen
         where feide_id=$feideId
         """
       .update()
@@ -179,7 +179,7 @@ class UserRepository(using dbUtility: DBUtility, dbMyNDLAUser: DBMyNDLAUser) ext
             with inserted as (
                 insert into ${dbMyNDLAUser.table}
                 (feide_id, document, last_seen)
-                values ($feideId, null, ${NDLADate.parameterBinderFactory(lastSeen)})
+                values ($feideId, null, $lastSeen)
                 on conflict do nothing
                 returning id, feide_id, document
             )
@@ -223,7 +223,7 @@ class UserRepository(using dbUtility: DBUtility, dbMyNDLAUser: DBMyNDLAUser) ext
     val u = dbMyNDLAUser.syntax("u")
     tsql"""
          select ${u.result.*} from ${dbMyNDLAUser.as(u)}
-         where last_seen < ${NDLADate.parameterBinderFactory(cutoffDate)}
+         where last_seen < $cutoffDate
          """.map(dbMyNDLAUser.fromResultSet(u)).runList()
   }
 
@@ -249,7 +249,7 @@ class UserRepository(using dbUtility: DBUtility, dbMyNDLAUser: DBMyNDLAUser) ext
   ): Try[InactiveUserCleanupResult] = {
     tsql"""
          insert into user_cleanup_audit (num_cleanup, num_emailed, last_cleanup_date)
-         values ($numCleanup, $numEmailed, ${NDLADate.parameterBinderFactory(lastCleanupDate)})
+         values ($numCleanup, $numEmailed, $lastCleanupDate)
          """
       .updateAndReturnGeneratedKey()
       .map(id =>


### PR DESCRIPTION
Stacker på #927 

Endrer DB-kolonner som bruker `timestamp` til å bruke `timestamptz` ([ref. Postgres wiki](https://wiki.postgresql.org/wiki/Don%27t_Do_This#Don't_use_timestamp_(without_time_zone)_to_store_UTC_times)).

Implementerer også `ParameterBinder` på `NDLADate`, slik at man kan bruke `NDLADate` direkte som parameter i SQL spørringer.