### PR TITLE
fix(taxonomy-api): slow locking quality evaluation

### DIFF
--- a/modules/versions.mill
+++ b/modules/versions.mill
@@ -120,6 +120,7 @@ object SharedDependencies {
     mvn"org.springframework.boot:spring-boot-starter-data-jpa",
     mvn"org.springframework.boot:spring-boot-starter-security",
     mvn"org.springframework.boot:spring-boot-starter-actuator",
+    mvn"org.springframework.boot:spring-boot-starter-aop",
     mvn"org.springframework.security:spring-security-web",
   )
 
@@ -137,6 +138,7 @@ object SharedDependencies {
     mvn"com.auth0:jwks-rsa:$JwksRsaV",
     mvn"org.apache.commons:commons-lang3:$CommonsLang3V",
     mvn"commons-codec:commons-codec",
+    mvn"org.springframework.retry:spring-retry",
     mvn"org.jsoup:jsoup:$TaxonomyJsoupV",
     mvn"net.bull.javamelody:javamelody-spring-boot-starter:$JavaMelodySpringV",
     mvn"io.micrometer:micrometer-registry-prometheus",

--- a/taxonomy-api/src/main/java/no/ndla/taxonomy/config/RetryConfig.java
+++ b/taxonomy-api/src/main/java/no/ndla/taxonomy/config/RetryConfig.java
@@ -1,0 +1,22 @@
+/*
+ * Part of NDLA taxonomy-api
+ * Copyright (C) 2026 NDLA
+ *
+ * See LICENSE
+ */
+
+package no.ndla.taxonomy.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+import org.springframework.retry.annotation.EnableRetry;
+
+/**
+ * Enables {@code @Retryable} processing. Ordered with higher precedence (lower value) than the
+ * default {@link Ordered#LOWEST_PRECEDENCE} of the {@code @Transactional} advisor so retry sits
+ * outside the transaction: a deadlock-rolled-back transaction is fully replayed by the retry
+ * advisor, not just the failed statement.
+ */
+@Configuration
+@EnableRetry(order = Ordered.LOWEST_PRECEDENCE - 10)
+public class RetryConfig {}

--- a/taxonomy-api/src/main/java/no/ndla/taxonomy/integration/DraftApiClient.java
+++ b/taxonomy-api/src/main/java/no/ndla/taxonomy/integration/DraftApiClient.java
@@ -42,7 +42,7 @@ public class DraftApiClient {
 
     // Only update notes in the base schema
     private boolean notBaseSchema() {
-        return !VersionContext.getCurrentVersion().equals(defaultSchema);
+        return !Objects.equals(VersionContext.getCurrentVersion(), defaultSchema);
     }
 
     public void updateNotesWithNewConnection(NodeConnection newConnection) {

--- a/taxonomy-api/src/main/java/no/ndla/taxonomy/repositories/NodeRepository.java
+++ b/taxonomy-api/src/main/java/no/ndla/taxonomy/repositories/NodeRepository.java
@@ -152,7 +152,14 @@ public interface NodeRepository extends TaxonomyRepository<Node> {
      * Concurrent calls accumulate via EPQ: SET expressions reference only n.* columns, so on
      * lock-wait unblock under READ COMMITTED, Postgres re-evaluates them against the freshly
      * committed row instead of overwriting. Lock order within the statement is plan-determined;
-     * overlapping concurrent calls rely on Postgres' deadlock detector.
+     * overlapping concurrent calls rely on Postgres' deadlock detector — on deadlock one
+     * transaction aborts with SQLSTATE 40P01. The {@code @Retryable} annotation on the affected
+     * REST controllers (configured by {@link no.ndla.taxonomy.config.RetryConfig}) replays the
+     * outer transaction up to a fixed number of attempts so the rollback is recoverable.
+     *
+     * The recursive CTE is evaluated once at statement start; concurrent commits to node_connection
+     * between CTE evaluation and row-lock acquisition are not reflected in the ancestor set. Use
+     * updateEntireAverageTreeForNode to repair if a connect/disconnect raced with this update.
      *
      * :oldGrade and :newGrade keep their CASTs — a NULL-bound Integer used only in a NULL check
      * otherwise breaks Postgres type inference.
@@ -162,6 +169,11 @@ public interface NodeRepository extends TaxonomyRepository<Node> {
     void applyQualityEvaluationDeltaToAncestors(
             Collection<Integer> startIds, Integer oldGrade, Integer newGrade, int sumDelta, int countDelta);
 
+    /**
+     * Variant of {@link #applyQualityEvaluationDeltaToAncestors} that leaves the persistence
+     * context intact. Use when the caller still needs entities loaded earlier in this transaction
+     * (e.g. the freshly refreshed child or parent in a connect/disconnect flow).
+     */
     @Modifying(flushAutomatically = true)
     @Query(value = APPLY_QUALITY_EVALUATION_GRADE_DELTA_TO_ANCESTORS_QUERY, nativeQuery = true)
     void applyQualityEvaluationDeltaToAncestorsWithoutClearing(
@@ -171,8 +183,12 @@ public interface NodeRepository extends TaxonomyRepository<Node> {
      * Adds (or removes, via negative deltas) a child's already-calculated subtree average to every
      * non-LINK ancestor. Used on connect/disconnect of topic-style children.
      *
+     * Differs from the grade-delta query in how the add/remove signal is encoded: branches gate on
+     * the sign of :countDelta rather than nullable :newGrade, since the source here is an
+     * already-aggregated subtree average rather than a single grade transition.
+     *
      * Does NOT clear the persistence context — current callers keep child/parent in memory.
-     * EPQ accumulation and deadlock characteristics match the grade-delta query above.
+     * EPQ accumulation, CTE-snapshot, and deadlock characteristics match the grade-delta query.
      */
     @Modifying(flushAutomatically = true)
     @Query(value = APPLY_QUALITY_EVALUATION_AVERAGE_DELTA_TO_ANCESTORS_QUERY, nativeQuery = true)

--- a/taxonomy-api/src/main/java/no/ndla/taxonomy/repositories/NodeRepository.java
+++ b/taxonomy-api/src/main/java/no/ndla/taxonomy/repositories/NodeRepository.java
@@ -139,27 +139,23 @@ public interface NodeRepository extends TaxonomyRepository<Node> {
 
     /**
      * Applies a (sumDelta, countDelta) to child_quality_evaluation_sum/count for every non-LINK
-     * ancestor (inclusive of the given start ids) in a single atomic SQL statement.
+     * ancestor (inclusive of start ids) in one atomic UPDATE. Shared ancestors are aggregated by
+     * the recursive CTE; deltas are occurrence-weighted (one occurrence per branch path).
      *
-     * Matches the semantics of Node.updateChildQualityEvaluationAverage:
-     *   - empty-state self-heal: if count = 0 or sum = 0 and a new grade is given, set one
-     *     occurrence per ancestor path (the pre-existing corruption-recovery branch);
-     *   - remove-to-zero: removing a grade (old set, new null) that would take either value <= 0
-     *     zeros both columns;
-     *   - otherwise: apply the deltas.
+     * Branches mirror Node.updateChildQualityEvaluationAverage:
+     *   - self-heal: count = 0 or sum = 0 + newGrade present → (occurrences, newGrade * occurrences).
+     *     Caveat: with corrupt (count > 0, sum = 0) + both grades, this overwrites instead of
+     *     applying the diff (SQL recovers once; the old recursion did so per visit);
+     *   - remove-to-zero: oldGrade present, newGrade null, delta would push either ≤ 0 → zero both;
+     *   - else: apply deltas.
      *
-     * Concurrency note: every reference in the SET expressions (and their CASE predicates) is to
-     * the target row's own columns — never to a join-captured snapshot. Under READ COMMITTED,
-     * when a concurrent transaction holds the row lock, Postgres waits; on unblock EPQ
-     * re-evaluates the expressions against the newly committed row version, so concurrent
-     * (sumDelta, countDelta) applications accumulate instead of overwriting each other.
+     * Concurrent calls accumulate via EPQ: SET expressions reference only n.* columns, so on
+     * lock-wait unblock under READ COMMITTED, Postgres re-evaluates them against the freshly
+     * committed row instead of overwriting. Lock order within the statement is plan-determined;
+     * overlapping concurrent calls rely on Postgres' deadlock detector.
      *
-     * The recursive CTE supplies one row for each ancestor path. Shared ancestors are grouped and
-     * receive occurrence-weighted deltas so reused resources match updateEntireAverageTree()
-     * semantics. The path column prevents cycles within a single branch path.
-     *
-     * :oldGrade and :newGrade keep their CASTs because a NULL-bound Integer parameter used only
-     * in a NULL check can otherwise make Postgres fail to infer the expression's type.
+     * :oldGrade and :newGrade keep their CASTs — a NULL-bound Integer used only in a NULL check
+     * otherwise breaks Postgres type inference.
      */
     @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query(value = APPLY_QUALITY_EVALUATION_GRADE_DELTA_TO_ANCESTORS_QUERY, nativeQuery = true)
@@ -172,9 +168,11 @@ public interface NodeRepository extends TaxonomyRepository<Node> {
             Collection<Integer> startIds, Integer oldGrade, Integer newGrade, int sumDelta, int countDelta);
 
     /**
-     * Applies a whole subtree average delta to every non-LINK ancestor. This is used when a
-     * topic/subtree connection is created or deleted, where the child node's already-calculated
-     * average should be added to or removed from the new parent branch.
+     * Adds (or removes, via negative deltas) a child's already-calculated subtree average to every
+     * non-LINK ancestor. Used on connect/disconnect of topic-style children.
+     *
+     * Does NOT clear the persistence context — current callers keep child/parent in memory.
+     * EPQ accumulation and deadlock characteristics match the grade-delta query above.
      */
     @Modifying(flushAutomatically = true)
     @Query(value = APPLY_QUALITY_EVALUATION_AVERAGE_DELTA_TO_ANCESTORS_QUERY, nativeQuery = true)

--- a/taxonomy-api/src/main/java/no/ndla/taxonomy/repositories/NodeRepository.java
+++ b/taxonomy-api/src/main/java/no/ndla/taxonomy/repositories/NodeRepository.java
@@ -74,26 +74,26 @@ public interface NodeRepository extends TaxonomyRepository<Node> {
                 child_quality_evaluation_count = CASE
                     WHEN n.child_quality_evaluation_count = 0
                          OR n.child_quality_evaluation_sum = 0
-                        THEN CASE WHEN CAST(:newGrade AS integer) IS NOT NULL THEN a.occurrences
+                        THEN CASE WHEN CAST(:newGrade AS integer) IS NOT NULL THEN delta.occurrences
                                   ELSE n.child_quality_evaluation_count END
                     WHEN CAST(:oldGrade AS integer) IS NOT NULL AND CAST(:newGrade AS integer) IS NULL
-                         AND (n.child_quality_evaluation_count + a.count_delta <= 0
-                              OR n.child_quality_evaluation_sum + a.sum_delta <= 0)
+                         AND (n.child_quality_evaluation_count + delta.count_delta <= 0
+                              OR n.child_quality_evaluation_sum + delta.sum_delta <= 0)
                         THEN 0
-                    ELSE n.child_quality_evaluation_count + a.count_delta
+                    ELSE n.child_quality_evaluation_count + delta.count_delta
                 END,
                 child_quality_evaluation_sum = CASE
                     WHEN n.child_quality_evaluation_count = 0
                          OR n.child_quality_evaluation_sum = 0
-                        THEN COALESCE(CAST(:newGrade AS integer) * a.occurrences, n.child_quality_evaluation_sum)
+                        THEN COALESCE(CAST(:newGrade AS integer) * delta.occurrences, n.child_quality_evaluation_sum)
                     WHEN CAST(:oldGrade AS integer) IS NOT NULL AND CAST(:newGrade AS integer) IS NULL
-                         AND (n.child_quality_evaluation_count + a.count_delta <= 0
-                              OR n.child_quality_evaluation_sum + a.sum_delta <= 0)
+                         AND (n.child_quality_evaluation_count + delta.count_delta <= 0
+                              OR n.child_quality_evaluation_sum + delta.sum_delta <= 0)
                         THEN 0
-                    ELSE n.child_quality_evaluation_sum + a.sum_delta
+                    ELSE n.child_quality_evaluation_sum + delta.sum_delta
                 END
-            FROM ancestor_deltas a
-            WHERE n.id = a.id
+            FROM ancestor_deltas delta
+            WHERE n.id = delta.id
             """;
 
     String APPLY_QUALITY_EVALUATION_AVERAGE_DELTA_TO_ANCESTORS_QUERY = """
@@ -116,25 +116,25 @@ public interface NodeRepository extends TaxonomyRepository<Node> {
                 child_quality_evaluation_count = CASE
                     WHEN n.child_quality_evaluation_count = 0
                          OR n.child_quality_evaluation_sum = 0
-                        THEN CASE WHEN :countDelta > 0 THEN a.count_delta
+                        THEN CASE WHEN :countDelta > 0 THEN delta.count_delta
                                   ELSE n.child_quality_evaluation_count END
-                    WHEN n.child_quality_evaluation_count + a.count_delta <= 0
-                         OR n.child_quality_evaluation_sum + a.sum_delta <= 0
+                    WHEN n.child_quality_evaluation_count + delta.count_delta <= 0
+                         OR n.child_quality_evaluation_sum + delta.sum_delta <= 0
                         THEN 0
-                    ELSE n.child_quality_evaluation_count + a.count_delta
+                    ELSE n.child_quality_evaluation_count + delta.count_delta
                 END,
                 child_quality_evaluation_sum = CASE
                     WHEN n.child_quality_evaluation_count = 0
                          OR n.child_quality_evaluation_sum = 0
-                        THEN CASE WHEN :countDelta > 0 THEN a.sum_delta
+                        THEN CASE WHEN :countDelta > 0 THEN delta.sum_delta
                                   ELSE n.child_quality_evaluation_sum END
-                    WHEN n.child_quality_evaluation_count + a.count_delta <= 0
-                         OR n.child_quality_evaluation_sum + a.sum_delta <= 0
+                    WHEN n.child_quality_evaluation_count + delta.count_delta <= 0
+                         OR n.child_quality_evaluation_sum + delta.sum_delta <= 0
                         THEN 0
-                    ELSE n.child_quality_evaluation_sum + a.sum_delta
+                    ELSE n.child_quality_evaluation_sum + delta.sum_delta
                 END
-            FROM ancestor_deltas a
-            WHERE n.id = a.id
+            FROM ancestor_deltas delta
+            WHERE n.id = delta.id
             """;
 
     /**

--- a/taxonomy-api/src/main/java/no/ndla/taxonomy/repositories/NodeRepository.java
+++ b/taxonomy-api/src/main/java/no/ndla/taxonomy/repositories/NodeRepository.java
@@ -53,6 +53,133 @@ public interface NodeRepository extends TaxonomyRepository<Node> {
             """)
     void wipeQualityEvaluationAverages();
 
+    String APPLY_QUALITY_EVALUATION_GRADE_DELTA_TO_ANCESTORS_QUERY = """
+            WITH RECURSIVE ancestors(id, path) AS (
+                SELECT n0.id, ARRAY[n0.id] FROM node n0 WHERE n0.id IN (:startIds)
+                UNION ALL
+                SELECT nc.parent_id, a.path || nc.parent_id FROM node_connection nc
+                JOIN ancestors a ON nc.child_id = a.id
+                WHERE nc.connection_type <> 'LINK'
+                  AND nc.parent_id IS NOT NULL
+                  AND NOT nc.parent_id = ANY(a.path)
+            ), ancestor_deltas AS (
+                SELECT id,
+                       CAST(COUNT(*) AS integer) AS occurrences,
+                       CAST(COUNT(*) AS integer) * :countDelta AS count_delta,
+                       CAST(COUNT(*) AS integer) * :sumDelta AS sum_delta
+                FROM ancestors
+                GROUP BY id
+            )
+            UPDATE node n SET
+                child_quality_evaluation_count = CASE
+                    WHEN n.child_quality_evaluation_count = 0
+                         OR n.child_quality_evaluation_sum = 0
+                        THEN CASE WHEN CAST(:newGrade AS integer) IS NOT NULL THEN a.occurrences
+                                  ELSE n.child_quality_evaluation_count END
+                    WHEN CAST(:oldGrade AS integer) IS NOT NULL AND CAST(:newGrade AS integer) IS NULL
+                         AND (n.child_quality_evaluation_count + a.count_delta <= 0
+                              OR n.child_quality_evaluation_sum + a.sum_delta <= 0)
+                        THEN 0
+                    ELSE n.child_quality_evaluation_count + a.count_delta
+                END,
+                child_quality_evaluation_sum = CASE
+                    WHEN n.child_quality_evaluation_count = 0
+                         OR n.child_quality_evaluation_sum = 0
+                        THEN COALESCE(CAST(:newGrade AS integer) * a.occurrences, n.child_quality_evaluation_sum)
+                    WHEN CAST(:oldGrade AS integer) IS NOT NULL AND CAST(:newGrade AS integer) IS NULL
+                         AND (n.child_quality_evaluation_count + a.count_delta <= 0
+                              OR n.child_quality_evaluation_sum + a.sum_delta <= 0)
+                        THEN 0
+                    ELSE n.child_quality_evaluation_sum + a.sum_delta
+                END
+            FROM ancestor_deltas a
+            WHERE n.id = a.id
+            """;
+
+    String APPLY_QUALITY_EVALUATION_AVERAGE_DELTA_TO_ANCESTORS_QUERY = """
+            WITH RECURSIVE ancestors(id, path) AS (
+                SELECT n0.id, ARRAY[n0.id] FROM node n0 WHERE n0.id IN (:startIds)
+                UNION ALL
+                SELECT nc.parent_id, a.path || nc.parent_id FROM node_connection nc
+                JOIN ancestors a ON nc.child_id = a.id
+                WHERE nc.connection_type <> 'LINK'
+                  AND nc.parent_id IS NOT NULL
+                  AND NOT nc.parent_id = ANY(a.path)
+            ), ancestor_deltas AS (
+                SELECT id,
+                       CAST(COUNT(*) AS integer) * :countDelta AS count_delta,
+                       CAST(COUNT(*) AS integer) * :sumDelta AS sum_delta
+                FROM ancestors
+                GROUP BY id
+            )
+            UPDATE node n SET
+                child_quality_evaluation_count = CASE
+                    WHEN n.child_quality_evaluation_count = 0
+                         OR n.child_quality_evaluation_sum = 0
+                        THEN CASE WHEN :countDelta > 0 THEN a.count_delta
+                                  ELSE n.child_quality_evaluation_count END
+                    WHEN n.child_quality_evaluation_count + a.count_delta <= 0
+                         OR n.child_quality_evaluation_sum + a.sum_delta <= 0
+                        THEN 0
+                    ELSE n.child_quality_evaluation_count + a.count_delta
+                END,
+                child_quality_evaluation_sum = CASE
+                    WHEN n.child_quality_evaluation_count = 0
+                         OR n.child_quality_evaluation_sum = 0
+                        THEN CASE WHEN :countDelta > 0 THEN a.sum_delta
+                                  ELSE n.child_quality_evaluation_sum END
+                    WHEN n.child_quality_evaluation_count + a.count_delta <= 0
+                         OR n.child_quality_evaluation_sum + a.sum_delta <= 0
+                        THEN 0
+                    ELSE n.child_quality_evaluation_sum + a.sum_delta
+                END
+            FROM ancestor_deltas a
+            WHERE n.id = a.id
+            """;
+
+    /**
+     * Applies a (sumDelta, countDelta) to child_quality_evaluation_sum/count for every non-LINK
+     * ancestor (inclusive of the given start ids) in a single atomic SQL statement.
+     *
+     * Matches the semantics of Node.updateChildQualityEvaluationAverage:
+     *   - empty-state self-heal: if count = 0 or sum = 0 and a new grade is given, set one
+     *     occurrence per ancestor path (the pre-existing corruption-recovery branch);
+     *   - remove-to-zero: removing a grade (old set, new null) that would take either value <= 0
+     *     zeros both columns;
+     *   - otherwise: apply the deltas.
+     *
+     * Concurrency note: every reference in the SET expressions (and their CASE predicates) is to
+     * the target row's own columns — never to a join-captured snapshot. Under READ COMMITTED,
+     * when a concurrent transaction holds the row lock, Postgres waits; on unblock EPQ
+     * re-evaluates the expressions against the newly committed row version, so concurrent
+     * (sumDelta, countDelta) applications accumulate instead of overwriting each other.
+     *
+     * The recursive CTE supplies one row for each ancestor path. Shared ancestors are grouped and
+     * receive occurrence-weighted deltas so reused resources match updateEntireAverageTree()
+     * semantics. The path column prevents cycles within a single branch path.
+     *
+     * :oldGrade and :newGrade keep their CASTs because a NULL-bound Integer parameter used only
+     * in a NULL check can otherwise make Postgres fail to infer the expression's type.
+     */
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
+    @Query(value = APPLY_QUALITY_EVALUATION_GRADE_DELTA_TO_ANCESTORS_QUERY, nativeQuery = true)
+    void applyQualityEvaluationDeltaToAncestors(
+            Collection<Integer> startIds, Integer oldGrade, Integer newGrade, int sumDelta, int countDelta);
+
+    @Modifying(flushAutomatically = true)
+    @Query(value = APPLY_QUALITY_EVALUATION_GRADE_DELTA_TO_ANCESTORS_QUERY, nativeQuery = true)
+    void applyQualityEvaluationDeltaToAncestorsWithoutClearing(
+            Collection<Integer> startIds, Integer oldGrade, Integer newGrade, int sumDelta, int countDelta);
+
+    /**
+     * Applies a whole subtree average delta to every non-LINK ancestor. This is used when a
+     * topic/subtree connection is created or deleted, where the child node's already-calculated
+     * average should be added to or removed from the new parent branch.
+     */
+    @Modifying(flushAutomatically = true)
+    @Query(value = APPLY_QUALITY_EVALUATION_AVERAGE_DELTA_TO_ANCESTORS_QUERY, nativeQuery = true)
+    void applyQualityEvaluationAverageDeltaToAncestors(Collection<Integer> startIds, int sumDelta, int countDelta);
+
     @Query("""
             SELECT n.id FROM Node n
             LEFT JOIN n.parentConnections pc

--- a/taxonomy-api/src/main/java/no/ndla/taxonomy/rest/v1/CrudController.java
+++ b/taxonomy-api/src/main/java/no/ndla/taxonomy/rest/v1/CrudController.java
@@ -109,16 +109,16 @@ public abstract class CrudController<T extends DomainEntity> {
         T entity = repository.getByPublicId(id);
         validator.validate(id, entity);
 
-        var oldGrade = entity instanceof Node node && qualityEvaluationService != null
-                ? qualityEvaluationService.getOldGradeForQualityEvaluationUpdate(node, command)
-                : getOldGrade(entity);
+        var oldQualityEvaluationState = entity instanceof Node node && qualityEvaluationService != null
+                ? qualityEvaluationService.getQualityEvaluationUpdateState(node, command)
+                : null;
 
         command.apply(entity);
 
         if (entity instanceof Node node) {
             if (contextUpdaterService != null) contextUpdaterService.updateContexts(node);
             if (qualityEvaluationService != null)
-                qualityEvaluationService.updateQualityEvaluationOfParents(node, oldGrade, command);
+                qualityEvaluationService.updateQualityEvaluationOfParents(node, oldQualityEvaluationState, command);
         }
 
         if (entity instanceof ResourceType resourceType && resourceTypeService != null) {
@@ -140,7 +140,9 @@ public abstract class CrudController<T extends DomainEntity> {
                 validator.validate(id, entity);
                 entity.setPublicId(id);
             });
-            var oldGrade = getOldGrade(entity);
+            var oldQualityEvaluationState = entity instanceof Node node && qualityEvaluationService != null
+                    ? qualityEvaluationService.getCurrentQualityEvaluationUpdateState(node)
+                    : null;
 
             command.apply(entity);
             URI location = URI.create(getLocation() + "/" + entity.getPublicId());
@@ -149,7 +151,7 @@ public abstract class CrudController<T extends DomainEntity> {
             if (entity instanceof Node node) {
                 if (contextUpdaterService != null) contextUpdaterService.updateContexts(node);
                 if (qualityEvaluationService != null)
-                    qualityEvaluationService.updateQualityEvaluationOfParents(node, oldGrade, command);
+                    qualityEvaluationService.updateQualityEvaluationOfParents(node, oldQualityEvaluationState, command);
             }
 
             if (entity instanceof ResourceType resourceType && resourceTypeService != null) {

--- a/taxonomy-api/src/main/java/no/ndla/taxonomy/rest/v1/CrudController.java
+++ b/taxonomy-api/src/main/java/no/ndla/taxonomy/rest/v1/CrudController.java
@@ -109,11 +109,9 @@ public abstract class CrudController<T extends DomainEntity> {
         T entity = repository.getByPublicId(id);
         validator.validate(id, entity);
 
-        // if (entity instanceof Node node && qualityEvaluationService != null) {
-        //     qualityEvaluationService.lockNodeForQualityEvaluationUpdate(node, command);
-        // }
-
-        var oldGrade = getOldGrade(entity);
+        var oldGrade = entity instanceof Node node && qualityEvaluationService != null
+                ? qualityEvaluationService.getOldGradeForQualityEvaluationUpdate(node, command)
+                : getOldGrade(entity);
 
         command.apply(entity);
 

--- a/taxonomy-api/src/main/java/no/ndla/taxonomy/rest/v1/NodeConnections.java
+++ b/taxonomy-api/src/main/java/no/ndla/taxonomy/rest/v1/NodeConnections.java
@@ -28,15 +28,22 @@ import no.ndla.taxonomy.rest.v1.dtos.NodeConnectionPUT;
 import no.ndla.taxonomy.rest.v1.responses.Created201ApiResponse;
 import no.ndla.taxonomy.service.*;
 import no.ndla.taxonomy.service.dtos.SearchResultDTO;
+import org.springframework.dao.ConcurrencyFailureException;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping(path = {"/v1/node-connections", "/v1/node-connections/"})
+@Retryable(
+        retryFor = ConcurrencyFailureException.class,
+        maxAttempts = 3,
+        backoff = @Backoff(delay = 25, multiplier = 2.0))
 public class NodeConnections extends CrudControllerWithMetadata<NodeConnection> {
     private final NodeRepository nodeRepository;
     private final NodeConnectionRepository nodeConnectionRepository;

--- a/taxonomy-api/src/main/java/no/ndla/taxonomy/rest/v1/NodeResources.java
+++ b/taxonomy-api/src/main/java/no/ndla/taxonomy/rest/v1/NodeResources.java
@@ -23,15 +23,22 @@ import no.ndla.taxonomy.rest.v1.dtos.NodeResourcePUT;
 import no.ndla.taxonomy.rest.v1.responses.Created201ApiResponse;
 import no.ndla.taxonomy.service.*;
 import no.ndla.taxonomy.service.dtos.SearchResultDTO;
+import org.springframework.dao.ConcurrencyFailureException;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping(path = {"/v1/node-resources", "/v1/node-resources/"})
+@Retryable(
+        retryFor = ConcurrencyFailureException.class,
+        maxAttempts = 3,
+        backoff = @Backoff(delay = 25, multiplier = 2.0))
 public class NodeResources extends CrudControllerWithMetadata<NodeConnection> {
 
     private final NodeRepository nodeRepository;

--- a/taxonomy-api/src/main/java/no/ndla/taxonomy/rest/v1/Nodes.java
+++ b/taxonomy-api/src/main/java/no/ndla/taxonomy/rest/v1/Nodes.java
@@ -26,15 +26,22 @@ import no.ndla.taxonomy.rest.v1.commands.NodeSearchBody;
 import no.ndla.taxonomy.rest.v1.responses.Created201ApiResponse;
 import no.ndla.taxonomy.service.*;
 import no.ndla.taxonomy.service.dtos.*;
+import org.springframework.dao.ConcurrencyFailureException;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping(path = {"/v1/nodes", "/v1/nodes/"})
+@Retryable(
+        retryFor = ConcurrencyFailureException.class,
+        maxAttempts = 3,
+        backoff = @Backoff(delay = 25, multiplier = 2.0))
 public class Nodes extends CrudControllerWithMetadata<Node> {
     private final NodeRepository nodeRepository;
     private final NodeConnectionRepository nodeConnectionRepository;

--- a/taxonomy-api/src/main/java/no/ndla/taxonomy/rest/v1/Resources.java
+++ b/taxonomy-api/src/main/java/no/ndla/taxonomy/rest/v1/Resources.java
@@ -29,14 +29,21 @@ import no.ndla.taxonomy.service.dtos.NodeDTO;
 import no.ndla.taxonomy.service.dtos.NodeWithParents;
 import no.ndla.taxonomy.service.dtos.ResourceTypeWithConnectionDTO;
 import no.ndla.taxonomy.service.dtos.SearchResultDTO;
+import org.springframework.dao.ConcurrencyFailureException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping(path = {"/v1/resources", "/v1/resources/"})
+@Retryable(
+        retryFor = ConcurrencyFailureException.class,
+        maxAttempts = 3,
+        backoff = @Backoff(delay = 25, multiplier = 2.0))
 public class Resources extends CrudControllerWithMetadata<Node> {
     private final Nodes nodes;
     private final ResourceResourceTypeRepository resourceResourceTypeRepository;

--- a/taxonomy-api/src/main/java/no/ndla/taxonomy/rest/v1/SubjectTopics.java
+++ b/taxonomy-api/src/main/java/no/ndla/taxonomy/rest/v1/SubjectTopics.java
@@ -27,15 +27,22 @@ import no.ndla.taxonomy.rest.v1.dtos.SubjectTopicPUT;
 import no.ndla.taxonomy.rest.v1.responses.Created201ApiResponse;
 import no.ndla.taxonomy.service.NodeConnectionService;
 import no.ndla.taxonomy.service.dtos.SearchResultDTO;
+import org.springframework.dao.ConcurrencyFailureException;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping(path = {"/v1/subject-topics", "/v1/subject-topics/"})
+@Retryable(
+        retryFor = ConcurrencyFailureException.class,
+        maxAttempts = 3,
+        backoff = @Backoff(delay = 25, multiplier = 2.0))
 public class SubjectTopics {
     private final NodeConnectionService connectionService;
     private final NodeRepository nodeRepository;

--- a/taxonomy-api/src/main/java/no/ndla/taxonomy/rest/v1/Subjects.java
+++ b/taxonomy-api/src/main/java/no/ndla/taxonomy/rest/v1/Subjects.java
@@ -28,14 +28,21 @@ import no.ndla.taxonomy.service.ResourceTypeService;
 import no.ndla.taxonomy.service.dtos.NodeChildDTO;
 import no.ndla.taxonomy.service.dtos.NodeDTO;
 import no.ndla.taxonomy.service.dtos.SearchResultDTO;
+import org.springframework.dao.ConcurrencyFailureException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping(path = {"/v1/subjects", "/v1/subjects/"})
+@Retryable(
+        retryFor = ConcurrencyFailureException.class,
+        maxAttempts = 3,
+        backoff = @Backoff(delay = 25, multiplier = 2.0))
 public class Subjects extends CrudControllerWithMetadata<Node> {
     private final Nodes nodes;
 

--- a/taxonomy-api/src/main/java/no/ndla/taxonomy/rest/v1/TopicResources.java
+++ b/taxonomy-api/src/main/java/no/ndla/taxonomy/rest/v1/TopicResources.java
@@ -23,15 +23,22 @@ import no.ndla.taxonomy.rest.v1.dtos.TopicResourcePUT;
 import no.ndla.taxonomy.rest.v1.responses.Created201ApiResponse;
 import no.ndla.taxonomy.service.NodeConnectionService;
 import no.ndla.taxonomy.service.dtos.SearchResultDTO;
+import org.springframework.dao.ConcurrencyFailureException;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping(path = {"/v1/topic-resources", "/v1/topic-resources/"})
+@Retryable(
+        retryFor = ConcurrencyFailureException.class,
+        maxAttempts = 3,
+        backoff = @Backoff(delay = 25, multiplier = 2.0))
 public class TopicResources {
 
     private final NodeRepository nodeRepository;

--- a/taxonomy-api/src/main/java/no/ndla/taxonomy/rest/v1/TopicSubtopics.java
+++ b/taxonomy-api/src/main/java/no/ndla/taxonomy/rest/v1/TopicSubtopics.java
@@ -28,15 +28,22 @@ import no.ndla.taxonomy.rest.v1.dtos.TopicSubtopicPUT;
 import no.ndla.taxonomy.rest.v1.responses.Created201ApiResponse;
 import no.ndla.taxonomy.service.NodeConnectionService;
 import no.ndla.taxonomy.service.dtos.SearchResultDTO;
+import org.springframework.dao.ConcurrencyFailureException;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping(path = {"/v1/topic-subtopics", "/v1/topic-subtopics/"})
+@Retryable(
+        retryFor = ConcurrencyFailureException.class,
+        maxAttempts = 3,
+        backoff = @Backoff(delay = 25, multiplier = 2.0))
 public class TopicSubtopics {
     private final NodeRepository nodeRepository;
     private final NodeConnectionRepository nodeConnectionRepository;

--- a/taxonomy-api/src/main/java/no/ndla/taxonomy/rest/v1/Topics.java
+++ b/taxonomy-api/src/main/java/no/ndla/taxonomy/rest/v1/Topics.java
@@ -29,14 +29,21 @@ import no.ndla.taxonomy.service.dtos.ConnectionDTO;
 import no.ndla.taxonomy.service.dtos.NodeChildDTO;
 import no.ndla.taxonomy.service.dtos.NodeDTO;
 import no.ndla.taxonomy.service.dtos.SearchResultDTO;
+import org.springframework.dao.ConcurrencyFailureException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping(path = {"/v1/topics", "/v1/topics/"})
+@Retryable(
+        retryFor = ConcurrencyFailureException.class,
+        maxAttempts = 3,
+        backoff = @Backoff(delay = 25, multiplier = 2.0))
 public class Topics extends CrudControllerWithMetadata<Node> {
     private final Nodes nodes;
 

--- a/taxonomy-api/src/main/java/no/ndla/taxonomy/service/NodeConnectionServiceImpl.java
+++ b/taxonomy-api/src/main/java/no/ndla/taxonomy/service/NodeConnectionServiceImpl.java
@@ -20,6 +20,8 @@ import no.ndla.taxonomy.service.exceptions.InvalidArgumentServiceException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @Transactional(propagation = Propagation.MANDATORY)
 @Service
@@ -41,6 +43,61 @@ public class NodeConnectionServiceImpl implements NodeConnectionService {
         this.nodeRepository = nodeRepository;
         this.qualityEvaluationService = qualityEvaluationService;
         this.draftApiClient = draftApiClient;
+    }
+
+    private void runAfterCommit(Runnable task) {
+        var currentVersion = VersionContext.getCurrentVersion();
+        Runnable taskWithVersionContext = () -> {
+            var previousVersion = VersionContext.getCurrentVersion();
+            try {
+                VersionContext.setCurrentVersion(currentVersion);
+                task.run();
+            } finally {
+                if (previousVersion == null) {
+                    VersionContext.clear();
+                } else {
+                    VersionContext.setCurrentVersion(previousVersion);
+                }
+            }
+        };
+
+        if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+            taskWithVersionContext.run();
+            return;
+        }
+
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                taskWithVersionContext.run();
+            }
+        });
+    }
+
+    private NodeConnection draftNoteSnapshot(NodeConnection connection) {
+        return new NodeConnection(connection);
+    }
+
+    private void updateNotesWithNewConnectionAfterCommit(NodeConnection connection) {
+        var snapshot = draftNoteSnapshot(connection);
+        runAfterCommit(() -> draftApiClient.updateNotesWithNewConnection(snapshot));
+    }
+
+    private void updateNotesWithDeletedConnectionAfterCommit(NodeConnection connection) {
+        var snapshot = draftNoteSnapshot(connection);
+        runAfterCommit(() -> draftApiClient.updateNotesWithDeletedConnection(snapshot));
+    }
+
+    private void updateRelevanceNotesWithUpdatedConnectionAfterCommit(
+            NodeConnection connection, Relevance newRelevance) {
+        var snapshot = draftNoteSnapshot(connection);
+        runAfterCommit(() -> draftApiClient.updateRelevanceNotesWithUpdatedConnection(snapshot, newRelevance));
+    }
+
+    private void updatePrimaryNotesWithUpdatedConnectionAfterCommit(
+            NodeConnection connection, Optional<Boolean> newIsPrimary) {
+        var snapshot = draftNoteSnapshot(connection);
+        runAfterCommit(() -> draftApiClient.updatePrimaryNotesWithUpdatedConnection(snapshot, newIsPrimary));
     }
 
     private NodeConnection doCreateConnection(
@@ -148,7 +205,7 @@ public class NodeConnectionServiceImpl implements NodeConnectionService {
 
         var newConnection = createConnection(parent, child, relevance, rank, isPrimary, connectionType);
         qualityEvaluationService.propagateQualityEvaluationForAddedConnection(newConnection);
-        draftApiClient.updateNotesWithNewConnection(newConnection);
+        updateNotesWithNewConnectionAfterCommit(newConnection);
         return nodeConnectionRepository.saveAndFlush(newConnection);
     }
 
@@ -165,7 +222,7 @@ public class NodeConnectionServiceImpl implements NodeConnectionService {
         final var child = nodeConnection.getChild();
 
         qualityEvaluationService.propagateQualityEvaluationForRemovedConnection(nodeConnection);
-        draftApiClient.updateNotesWithDeletedConnection(nodeConnection);
+        updateNotesWithDeletedConnectionAfterCommit(nodeConnection);
 
         nodeConnection.disassociate();
         nodeConnectionRepository.delete(nodeConnection);
@@ -219,7 +276,7 @@ public class NodeConnectionServiceImpl implements NodeConnectionService {
                     foundNewPrimary.set(true);
                     updatedConnectables.add(connectable1);
                 } else if (setPrimaryTo && connectable.getConnectionType() == NodeConnectionType.BRANCH) {
-                    draftApiClient.updatePrimaryNotesWithUpdatedConnection(connectable1, Optional.of(false));
+                    updatePrimaryNotesWithUpdatedConnectionAfterCommit(connectable1, Optional.of(false));
                     connectable1.setPrimary(false);
                     updatedConnectables.add(connectable1);
                 }
@@ -261,8 +318,8 @@ public class NodeConnectionServiceImpl implements NodeConnectionService {
             Relevance newRelevance,
             Optional<Integer> newRank,
             Optional<Boolean> isPrimary) {
-        draftApiClient.updateRelevanceNotesWithUpdatedConnection(nodeConnection, newRelevance);
-        draftApiClient.updatePrimaryNotesWithUpdatedConnection(nodeConnection, isPrimary);
+        updateRelevanceNotesWithUpdatedConnectionAfterCommit(nodeConnection, newRelevance);
+        updatePrimaryNotesWithUpdatedConnectionAfterCommit(nodeConnection, isPrimary);
         newRank.ifPresent(integer -> updateRank(nodeConnection, integer));
         isPrimary.ifPresent(primary -> updatePrimaryConnection(nodeConnection, primary));
         updateRelevance(nodeConnection, newRelevance);
@@ -305,7 +362,7 @@ public class NodeConnectionServiceImpl implements NodeConnectionService {
         var node = nodeRepository
                 .findFirstByPublicId(nodeId)
                 .orElseThrow(() -> new NotFoundHttpResponseException("Node was not found"));
-        node.getParentConnections().forEach(this::disconnectParentChildConnection);
+        Set.copyOf(node.getParentConnections()).forEach(this::disconnectParentChildConnection);
     }
 
     @Override
@@ -330,9 +387,9 @@ public class NodeConnectionServiceImpl implements NodeConnectionService {
 
     private void disconnectInvisibleConnections(Node node) {
         if (!node.isVisible()) {
-            node.getParentConnections().forEach(this::disconnectParentChildConnection);
+            Set.copyOf(node.getParentConnections()).forEach(this::disconnectParentChildConnection);
         } else {
-            node.getChildConnections()
+            Set.copyOf(node.getChildConnections())
                     .forEach(nodeConnection ->
                             nodeConnection.getChild().ifPresent(this::disconnectInvisibleConnections));
         }

--- a/taxonomy-api/src/main/java/no/ndla/taxonomy/service/NodeConnectionServiceImpl.java
+++ b/taxonomy-api/src/main/java/no/ndla/taxonomy/service/NodeConnectionServiceImpl.java
@@ -147,7 +147,7 @@ public class NodeConnectionServiceImpl implements NodeConnectionService {
         }
 
         var newConnection = createConnection(parent, child, relevance, rank, isPrimary, connectionType);
-        qualityEvaluationService.updateQualityEvaluationOfNewConnection(newConnection);
+        qualityEvaluationService.propagateQualityEvaluationForAddedConnection(newConnection);
         draftApiClient.updateNotesWithNewConnection(newConnection);
         return nodeConnectionRepository.saveAndFlush(newConnection);
     }
@@ -164,7 +164,7 @@ public class NodeConnectionServiceImpl implements NodeConnectionService {
     public void disconnectParentChildConnection(NodeConnection nodeConnection) {
         final var child = nodeConnection.getChild();
 
-        qualityEvaluationService.removeQualityEvaluationOfDeletedConnection(nodeConnection);
+        qualityEvaluationService.propagateQualityEvaluationForRemovedConnection(nodeConnection);
         draftApiClient.updateNotesWithDeletedConnection(nodeConnection);
 
         nodeConnection.disassociate();

--- a/taxonomy-api/src/main/java/no/ndla/taxonomy/service/QualityEvaluationService.java
+++ b/taxonomy-api/src/main/java/no/ndla/taxonomy/service/QualityEvaluationService.java
@@ -184,9 +184,9 @@ public class QualityEvaluationService {
     }
 
     private void propagateResourceConnectionDelta(Node parent, Node child, DeltaDirection direction) {
-        var previousGrade =
-                direction == DeltaDirection.ADD ? Optional.<Grade>empty() : child.getQualityEvaluationGrade();
-        var newGrade = direction == DeltaDirection.ADD ? child.getQualityEvaluationGrade() : Optional.<Grade>empty();
+        var grade = child.getQualityEvaluationGrade();
+        var previousGrade = direction == DeltaDirection.ADD ? Optional.<Grade>empty() : grade;
+        var newGrade = direction == DeltaDirection.ADD ? grade : Optional.<Grade>empty();
 
         propagateResourceGradeDeltaToAncestors(List.of(parent), previousGrade, newGrade, PersistenceContextMode.KEEP);
     }

--- a/taxonomy-api/src/main/java/no/ndla/taxonomy/service/QualityEvaluationService.java
+++ b/taxonomy-api/src/main/java/no/ndla/taxonomy/service/QualityEvaluationService.java
@@ -211,6 +211,10 @@ public class QualityEvaluationService {
         entityManager.refresh(node);
     }
 
+    /**
+     * Recovery/repair entry point. Walks descendants in-memory rather than ancestors via SQL —
+     * recomputes from scratch in the opposite direction from the bulk paths above.
+     */
     @Transactional
     public void updateEntireAverageTreeForNode(URI publicId) {
         var node = nodeRepository

--- a/taxonomy-api/src/main/java/no/ndla/taxonomy/service/QualityEvaluationService.java
+++ b/taxonomy-api/src/main/java/no/ndla/taxonomy/service/QualityEvaluationService.java
@@ -27,6 +27,26 @@ public class QualityEvaluationService {
     private final NodeRepository nodeRepository;
     private final EntityManager entityManager;
 
+    private enum PersistenceContextMode {
+        CLEAR,
+        KEEP
+    }
+
+    private enum DeltaDirection {
+        ADD(1),
+        REMOVE(-1);
+
+        private final int multiplier;
+
+        DeltaDirection(int multiplier) {
+            this.multiplier = multiplier;
+        }
+
+        private int applyTo(int value) {
+            return value * multiplier;
+        }
+    }
+
     public QualityEvaluationService(NodeRepository nodeRepository, EntityManager entityManager) {
         this.nodeRepository = nodeRepository;
         this.entityManager = entityManager;
@@ -71,21 +91,21 @@ public class QualityEvaluationService {
         }
 
         var newGrade = nodeCommand.get().qualityEvaluation.getValue().map(QualityEvaluationDTO::getGrade);
-        applyGradeDeltaToAncestors(node.getParentNodesForQualityEvaluation(), oldGrade, newGrade, true);
+        propagateResourceGradeDeltaToAncestors(
+                node.getParentNodesForQualityEvaluation(), oldGrade, newGrade, PersistenceContextMode.CLEAR);
     }
 
     /**
      * Applies the (oldGrade -> newGrade) delta to every non-LINK ancestor in a single atomic SQL
-     * statement. When clearPersistenceContext is true, managed entities are detached after the
-     * update so subsequent reads see DB state. Pass false when the caller still needs entities
-     * loaded earlier in the transaction (e.g. the freshly refreshed child in a connect/disconnect
-     * flow).
+     * statement. Use CLEAR when managed entities should be detached after the update so subsequent
+     * reads see DB state. Use KEEP when the caller still needs entities loaded earlier in the
+     * transaction, e.g. the freshly refreshed child in a connect/disconnect flow.
      */
-    private void applyGradeDeltaToAncestors(
+    private void propagateResourceGradeDeltaToAncestors(
             Collection<Node> directParents,
             Optional<Grade> oldGrade,
             Optional<Grade> newGrade,
-            boolean clearPersistenceContext) {
+            PersistenceContextMode persistenceContextMode) {
         if (directParents.isEmpty() || (oldGrade.isEmpty() && newGrade.isEmpty()) || oldGrade.equals(newGrade)) {
             return;
         }
@@ -96,7 +116,7 @@ public class QualityEvaluationService {
         int sumDelta = (newGradeInt == null ? 0 : newGradeInt) - (oldGradeInt == null ? 0 : oldGradeInt);
 
         var startIds = directParents.stream().map(Node::getId).toList();
-        if (clearPersistenceContext) {
+        if (persistenceContextMode == PersistenceContextMode.CLEAR) {
             nodeRepository.applyQualityEvaluationDeltaToAncestors(
                     startIds, oldGradeInt, newGradeInt, sumDelta, countDelta);
         } else {
@@ -105,21 +125,20 @@ public class QualityEvaluationService {
         }
     }
 
-    private void applyGradeAverageDeltaToAncestors(
-            Collection<Node> directParents, GradeAverage gradeAverage, boolean shouldAdd) {
+    private void propagateSubtreeAverageDeltaToAncestors(
+            Collection<Node> directParents, GradeAverage gradeAverage, DeltaDirection direction) {
         if (directParents.isEmpty() || gradeAverage.getCount() == 0 || gradeAverage.getAverageSum() == 0) {
             return;
         }
 
-        var direction = shouldAdd ? 1 : -1;
         nodeRepository.applyQualityEvaluationAverageDeltaToAncestors(
                 directParents.stream().map(Node::getId).toList(),
-                gradeAverage.getAverageSum() * direction,
-                gradeAverage.getCount() * direction);
+                direction.applyTo(gradeAverage.getAverageSum()),
+                direction.applyTo(gradeAverage.getCount()));
     }
 
     @Transactional
-    public void updateQualityEvaluationOfNewConnection(NodeConnection connection) {
+    public void propagateQualityEvaluationForAddedConnection(NodeConnection connection) {
         if (connection.getConnectionType() == NodeConnectionType.LINK) {
             return;
         }
@@ -133,17 +152,11 @@ public class QualityEvaluationService {
         entityManager.flush();
         entityManager.refresh(child);
 
-        if (shouldBeIncludedInQualityEvaluationAverage(child.getNodeType())) {
-            applyGradeDeltaToAncestors(List.of(parent), Optional.empty(), child.getQualityEvaluationGrade(), false);
-        }
-
-        child.getChildQualityEvaluationAverage().ifPresent(childAverage -> {
-            applyGradeAverageDeltaToAncestors(List.of(parent), childAverage, true);
-        });
+        propagateConnectionDelta(parent, child, DeltaDirection.ADD);
     }
 
     @Transactional
-    public void removeQualityEvaluationOfDeletedConnection(NodeConnection connectionToDelete) {
+    public void propagateQualityEvaluationForRemovedConnection(NodeConnection connectionToDelete) {
         if (connectionToDelete.getConnectionType() == NodeConnectionType.LINK) return;
 
         var noChild = connectionToDelete.getChild().isEmpty();
@@ -156,14 +169,26 @@ public class QualityEvaluationService {
         entityManager.flush();
         entityManager.refresh(child);
 
+        propagateConnectionDelta(parent, child, DeltaDirection.REMOVE);
+    }
+
+    private void propagateConnectionDelta(Node parent, Node child, DeltaDirection direction) {
         if (shouldBeIncludedInQualityEvaluationAverage(child.getNodeType())) {
-            applyGradeDeltaToAncestors(List.of(parent), child.getQualityEvaluationGrade(), Optional.empty(), false);
-            return;
+            propagateResourceConnectionDelta(parent, child, direction);
+            if (direction == DeltaDirection.REMOVE) return;
         }
 
-        if (child.getChildQualityEvaluationAverage().isEmpty()) return;
-        var childAverage = child.getChildQualityEvaluationAverage().get();
-        applyGradeAverageDeltaToAncestors(List.of(parent), childAverage, false);
+        child.getChildQualityEvaluationAverage()
+                .ifPresent(childAverage ->
+                        propagateSubtreeAverageDeltaToAncestors(List.of(parent), childAverage, direction));
+    }
+
+    private void propagateResourceConnectionDelta(Node parent, Node child, DeltaDirection direction) {
+        var previousGrade =
+                direction == DeltaDirection.ADD ? Optional.<Grade>empty() : child.getQualityEvaluationGrade();
+        var newGrade = direction == DeltaDirection.ADD ? child.getQualityEvaluationGrade() : Optional.<Grade>empty();
+
+        propagateResourceGradeDeltaToAncestors(List.of(parent), previousGrade, newGrade, PersistenceContextMode.KEEP);
     }
 
     /**
@@ -173,7 +198,7 @@ public class QualityEvaluationService {
     @Transactional
     public void updateQualityEvaluationOfRecursive(
             Collection<Node> parents, Optional<Grade> oldGrade, Optional<Grade> newGrade) {
-        applyGradeDeltaToAncestors(parents, oldGrade, newGrade, true);
+        propagateResourceGradeDeltaToAncestors(parents, oldGrade, newGrade, PersistenceContextMode.CLEAR);
     }
 
     /**
@@ -201,11 +226,11 @@ public class QualityEvaluationService {
         try (var nodeStream = nodeRepository.findNodesWithQualityEvaluation()) {
             nodeStream.forEach(node -> {
                 if (shouldBeIncludedInQualityEvaluationAverage(node.getNodeType())) {
-                    applyGradeDeltaToAncestors(
+                    propagateResourceGradeDeltaToAncestors(
                             node.getParentNodesForQualityEvaluation(),
                             Optional.empty(),
                             node.getQualityEvaluationGrade(),
-                            false);
+                            PersistenceContextMode.KEEP);
                 }
             });
         }

--- a/taxonomy-api/src/main/java/no/ndla/taxonomy/service/QualityEvaluationService.java
+++ b/taxonomy-api/src/main/java/no/ndla/taxonomy/service/QualityEvaluationService.java
@@ -16,7 +16,6 @@ import java.util.Optional;
 import no.ndla.taxonomy.domain.*;
 import no.ndla.taxonomy.repositories.NodeRepository;
 import no.ndla.taxonomy.rest.v1.commands.NodePostPut;
-import no.ndla.taxonomy.service.dtos.QualityEvaluationDTO;
 import no.ndla.taxonomy.service.exceptions.NotFoundServiceException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -47,6 +46,8 @@ public class QualityEvaluationService {
         }
     }
 
+    public record QualityEvaluationUpdateState(NodeType oldNodeType, Optional<Grade> oldGrade) {}
+
     public QualityEvaluationService(NodeRepository nodeRepository, EntityManager entityManager) {
         this.nodeRepository = nodeRepository;
         this.entityManager = entityManager;
@@ -56,27 +57,32 @@ public class QualityEvaluationService {
         return nodeType == NodeType.RESOURCE;
     }
 
-    private Optional<NodePostPut> getQualityEvaluationCommand(UpdatableDto<?> command) {
-        if (command instanceof NodePostPut nodeCommand && nodeCommand.qualityEvaluation.isChanged()) {
-            return Optional.of(nodeCommand);
-        }
-
-        return Optional.empty();
+    private boolean shouldRefreshBeforeQualityEvaluationUpdate(UpdatableDto<?> command) {
+        return command instanceof NodePostPut nodeCommand
+                && (nodeCommand.qualityEvaluation.isChanged() || nodeCommand.nodeType != null);
     }
 
     /**
-     * Returns the old grade to use for a quality-evaluation update. If the command changes quality
-     * evaluation, the node is pessimistically locked and refreshed first so the grade is based on the
-     * latest committed row.
+     * Returns the old quality-evaluation state to use for an update. If the command can affect
+     * quality evaluation, the node is pessimistically locked and refreshed first so the state is
+     * based on the latest committed row.
      */
     @Transactional
-    public Optional<Grade> getOldGradeForQualityEvaluationUpdate(Node node, UpdatableDto<?> command) {
-        if (getQualityEvaluationCommand(command).isPresent()) {
+    public QualityEvaluationUpdateState getQualityEvaluationUpdateState(Node node, UpdatableDto<?> command) {
+        if (shouldRefreshBeforeQualityEvaluationUpdate(command)) {
             entityManager.flush();
             lockAndRefresh(node);
         }
 
-        return node.getQualityEvaluationGrade();
+        return new QualityEvaluationUpdateState(node.getNodeType(), node.getQualityEvaluationGrade());
+    }
+
+    public QualityEvaluationUpdateState getCurrentQualityEvaluationUpdateState(Node node) {
+        return new QualityEvaluationUpdateState(node.getNodeType(), node.getQualityEvaluationGrade());
+    }
+
+    private Optional<Grade> gradeIncludedInAverage(NodeType nodeType, Optional<Grade> grade) {
+        return shouldBeIncludedInQualityEvaluationAverage(nodeType) ? grade : Optional.empty();
     }
 
     /**
@@ -84,13 +90,20 @@ public class QualityEvaluationService {
      * Any entities loaded earlier in this transaction become detached.
      */
     @Transactional
-    public void updateQualityEvaluationOfParents(Node node, Optional<Grade> oldGrade, UpdatableDto<?> command) {
-        var nodeCommand = getQualityEvaluationCommand(command);
-        if (nodeCommand.isEmpty() || !shouldBeIncludedInQualityEvaluationAverage(node.getNodeType())) {
+    public void updateQualityEvaluationOfParents(
+            Node node, QualityEvaluationUpdateState oldState, UpdatableDto<?> command) {
+        if (!(command instanceof NodePostPut nodeCommand)) {
             return;
         }
 
-        var newGrade = nodeCommand.get().qualityEvaluation.getValue().map(QualityEvaluationDTO::getGrade);
+        var qualityEvaluationChanged = nodeCommand.qualityEvaluation.isChanged();
+        var nodeTypeChanged = nodeCommand.nodeType != null && nodeCommand.nodeType != oldState.oldNodeType();
+        if (!qualityEvaluationChanged && !nodeTypeChanged) {
+            return;
+        }
+
+        var oldGrade = gradeIncludedInAverage(oldState.oldNodeType(), oldState.oldGrade());
+        var newGrade = gradeIncludedInAverage(node.getNodeType(), node.getQualityEvaluationGrade());
         propagateResourceGradeDeltaToAncestors(
                 node.getParentNodesForQualityEvaluation(), oldGrade, newGrade, PersistenceContextMode.CLEAR);
     }

--- a/taxonomy-api/src/main/java/no/ndla/taxonomy/service/QualityEvaluationService.java
+++ b/taxonomy-api/src/main/java/no/ndla/taxonomy/service/QualityEvaluationService.java
@@ -11,10 +11,7 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.LockModeType;
 import java.net.URI;
 import java.util.Collection;
-import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import no.ndla.taxonomy.domain.*;
 import no.ndla.taxonomy.repositories.NodeRepository;
@@ -48,31 +45,77 @@ public class QualityEvaluationService {
     }
 
     /**
-     * Acquires a pessimistic lock on the node and refreshes it from the database, ensuring
-     * that the subsequent getOldGrade/apply/updateParents sequence sees the latest persisted state.
-     * Must be called within the same transaction as the update (e.g. from CrudController.updateEntity).
+     * Returns the old grade to use for a quality-evaluation update. If the command changes quality
+     * evaluation, the node is pessimistically locked and refreshed first so the grade is based on the
+     * latest committed row.
      */
     @Transactional
-    public void lockNodeForQualityEvaluationUpdate(Node node, UpdatableDto<?> command) {
-        if (getQualityEvaluationCommand(command).isEmpty()) {
-            return;
+    public Optional<Grade> getOldGradeForQualityEvaluationUpdate(Node node, UpdatableDto<?> command) {
+        if (getQualityEvaluationCommand(command).isPresent()) {
+            entityManager.flush();
+            lockAndRefresh(node);
         }
 
-        entityManager.flush();
-        lockAndRefresh(node);
+        return node.getQualityEvaluationGrade();
     }
 
+    /**
+     * Note: this clears the Hibernate persistence context as a side effect of the bulk SQL update.
+     * Any entities loaded earlier in this transaction become detached.
+     */
     @Transactional
     public void updateQualityEvaluationOfParents(Node node, Optional<Grade> oldGrade, UpdatableDto<?> command) {
         var nodeCommand = getQualityEvaluationCommand(command);
-        if (nodeCommand.isEmpty()) {
+        if (nodeCommand.isEmpty() || !shouldBeIncludedInQualityEvaluationAverage(node.getNodeType())) {
             return;
         }
 
         var newGrade = nodeCommand.get().qualityEvaluation.getValue().map(QualityEvaluationDTO::getGrade);
+        applyGradeDeltaToAncestors(node.getParentNodesForQualityEvaluation(), oldGrade, newGrade, true);
+    }
 
-        updateQualityEvaluationOfParents(
-                node.getNodeType(), node.getParentNodesForQualityEvaluation(), oldGrade, newGrade);
+    /**
+     * Applies the (oldGrade -> newGrade) delta to every non-LINK ancestor in a single atomic SQL
+     * statement. When clearPersistenceContext is true, managed entities are detached after the
+     * update so subsequent reads see DB state. Pass false when the caller still needs entities
+     * loaded earlier in the transaction (e.g. the freshly refreshed child in a connect/disconnect
+     * flow).
+     */
+    private void applyGradeDeltaToAncestors(
+            Collection<Node> directParents,
+            Optional<Grade> oldGrade,
+            Optional<Grade> newGrade,
+            boolean clearPersistenceContext) {
+        if (directParents.isEmpty() || (oldGrade.isEmpty() && newGrade.isEmpty()) || oldGrade.equals(newGrade)) {
+            return;
+        }
+
+        var oldGradeInt = oldGrade.map(Grade::toInt).orElse(null);
+        var newGradeInt = newGrade.map(Grade::toInt).orElse(null);
+        int countDelta = (newGrade.isPresent() ? 1 : 0) - (oldGrade.isPresent() ? 1 : 0);
+        int sumDelta = (newGradeInt == null ? 0 : newGradeInt) - (oldGradeInt == null ? 0 : oldGradeInt);
+
+        var startIds = directParents.stream().map(Node::getId).toList();
+        if (clearPersistenceContext) {
+            nodeRepository.applyQualityEvaluationDeltaToAncestors(
+                    startIds, oldGradeInt, newGradeInt, sumDelta, countDelta);
+        } else {
+            nodeRepository.applyQualityEvaluationDeltaToAncestorsWithoutClearing(
+                    startIds, oldGradeInt, newGradeInt, sumDelta, countDelta);
+        }
+    }
+
+    private void applyGradeAverageDeltaToAncestors(
+            Collection<Node> directParents, GradeAverage gradeAverage, boolean shouldAdd) {
+        if (directParents.isEmpty() || gradeAverage.getCount() == 0 || gradeAverage.getAverageSum() == 0) {
+            return;
+        }
+
+        var direction = shouldAdd ? 1 : -1;
+        nodeRepository.applyQualityEvaluationAverageDeltaToAncestors(
+                directParents.stream().map(Node::getId).toList(),
+                gradeAverage.getAverageSum() * direction,
+                gradeAverage.getCount() * direction);
     }
 
     @Transactional
@@ -87,30 +130,16 @@ public class QualityEvaluationService {
             return;
         }
 
-        // Lock the parent tree once upfront to avoid double lock+refresh discarding changes.
-        // var allNodes = lockParentTree(List.of(parent));
-        // lockAndRefresh(child);
+        entityManager.flush();
+        entityManager.refresh(child);
 
-        // Update parents quality evaluation average with the newly linked one.
-        updateQualityEvaluationOfParents(
-                child.getNodeType(), List.of(parent), Optional.empty(), child.getQualityEvaluationGrade());
+        if (shouldBeIncludedInQualityEvaluationAverage(child.getNodeType())) {
+            applyGradeDeltaToAncestors(List.of(parent), Optional.empty(), child.getQualityEvaluationGrade(), false);
+        }
 
         child.getChildQualityEvaluationAverage().ifPresent(childAverage -> {
-            addGradeAverageTreeToParents(parent, childAverage);
+            applyGradeAverageDeltaToAncestors(List.of(parent), childAverage, true);
         });
-
-        // nodeRepository.saveAll(allNodes);
-    }
-
-    private void addGradeAverageTreeToParents(Node node, GradeAverage averageToAdd) {
-        node.addGradeAverageTreeToAverageCalculation(averageToAdd);
-        node.getParentNodesForQualityEvaluation().forEach(parent -> addGradeAverageTreeToParents(parent, averageToAdd));
-    }
-
-    private void removeGradeAverageTreeFromParents(Node node, GradeAverage averageToRemove) {
-        node.removeGradeAverageTreeFromAverageCalculation(averageToRemove);
-        node.getParentNodesForQualityEvaluation()
-                .forEach(parent -> removeGradeAverageTreeFromParents(parent, averageToRemove));
     }
 
     @Transactional
@@ -124,58 +153,27 @@ public class QualityEvaluationService {
         var child = connectionToDelete.getChild().get();
         var parent = connectionToDelete.getParent().get();
 
+        entityManager.flush();
+        entityManager.refresh(child);
+
         if (shouldBeIncludedInQualityEvaluationAverage(child.getNodeType())) {
-            updateQualityEvaluationOfParents(
-                    child.getNodeType(), List.of(parent), child.getQualityEvaluationGrade(), Optional.empty());
+            applyGradeDeltaToAncestors(List.of(parent), child.getQualityEvaluationGrade(), Optional.empty(), false);
             return;
         }
 
         if (child.getChildQualityEvaluationAverage().isEmpty()) return;
         var childAverage = child.getChildQualityEvaluationAverage().get();
-
-        // var allNodes = lockParentTree(List.of(parent));
-        removeGradeAverageTreeFromParents(parent, childAverage);
-        // nodeRepository.saveAll(allNodes);
+        applyGradeAverageDeltaToAncestors(List.of(parent), childAverage, false);
     }
 
-    @Transactional
-    protected void updateQualityEvaluationOfParents(
-            NodeType nodeType, Collection<Node> parentNodes, Optional<Grade> oldGrade, Optional<Grade> newGrade) {
-        if (!shouldBeIncludedInQualityEvaluationAverage(nodeType)) {
-            return;
-        }
-        if (oldGrade.isEmpty() && newGrade.isEmpty() || oldGrade.equals(newGrade)) {
-            return;
-        }
-
-        updateQualityEvaluationOfRecursive(parentNodes, oldGrade, newGrade);
-    }
-
+    /**
+     * Note: this clears the Hibernate persistence context as a side effect of the bulk SQL update.
+     * Any entities loaded earlier in this transaction become detached.
+     */
     @Transactional
     public void updateQualityEvaluationOfRecursive(
             Collection<Node> parents, Optional<Grade> oldGrade, Optional<Grade> newGrade) {
-        // var allNodes = lockParentTree(parents);
-        updateQualityEvaluationOfRecursiveUnlocked(parents, oldGrade, newGrade);
-        // nodeRepository.saveAll(allNodes);
-    }
-
-    private void updateQualityEvaluationOfRecursiveUnlocked(
-            Collection<Node> parents, Optional<Grade> oldGrade, Optional<Grade> newGrade) {
-        parents.forEach(p -> {
-            p.updateChildQualityEvaluationAverage(oldGrade, newGrade);
-            var parentsParents = p.getParentNodesForQualityEvaluation();
-            updateQualityEvaluationOfRecursiveUnlocked(parentsParents, oldGrade, newGrade);
-        });
-    }
-
-    private Collection<Node> lockParentTree(Collection<Node> parents) {
-        // Flush pending changes before locking so that refresh does not discard in-memory mutations
-        // made earlier in this transaction (e.g. command.apply on the child node).
-        entityManager.flush();
-        var allNodes = collectParentTree(parents);
-        // Lock in consistent ID order to prevent deadlocks between concurrent transactions.
-        allNodes.stream().sorted(Comparator.comparing(Node::getId)).forEach(this::lockAndRefresh);
-        return allNodes;
+        applyGradeDeltaToAncestors(parents, oldGrade, newGrade, true);
     }
 
     /**
@@ -186,23 +184,6 @@ public class QualityEvaluationService {
     private void lockAndRefresh(Node node) {
         entityManager.lock(node, LockModeType.PESSIMISTIC_WRITE);
         entityManager.refresh(node);
-    }
-
-    private Collection<Node> collectParentTree(Collection<Node> parents) {
-        Map<Integer, Node> nodesById = new HashMap<>();
-        collectParentTree(parents, nodesById);
-        return nodesById.values();
-    }
-
-    private void collectParentTree(Collection<Node> parents, Map<Integer, Node> nodesById) {
-        parents.forEach(parent -> {
-            if (parent == null || nodesById.containsKey(parent.getId())) {
-                return;
-            }
-
-            nodesById.put(parent.getId(), parent);
-            collectParentTree(parent.getParentNodesForQualityEvaluation(), nodesById);
-        });
     }
 
     @Transactional
@@ -217,11 +198,16 @@ public class QualityEvaluationService {
     @Transactional
     public void updateQualityEvaluationOfAllNodes() {
         nodeRepository.wipeQualityEvaluationAverages();
-        var nodeStream = nodeRepository.findNodesWithQualityEvaluation();
-        nodeStream.forEach(node -> updateQualityEvaluationOfParents(
-                node.getNodeType(),
-                node.getParentNodesForQualityEvaluation(),
-                Optional.empty(),
-                node.getQualityEvaluationGrade()));
+        try (var nodeStream = nodeRepository.findNodesWithQualityEvaluation()) {
+            nodeStream.forEach(node -> {
+                if (shouldBeIncludedInQualityEvaluationAverage(node.getNodeType())) {
+                    applyGradeDeltaToAncestors(
+                            node.getParentNodesForQualityEvaluation(),
+                            Optional.empty(),
+                            node.getQualityEvaluationGrade(),
+                            false);
+                }
+            });
+        }
     }
 }

--- a/taxonomy-api/src/main/java/no/ndla/taxonomy/service/QualityEvaluationService.java
+++ b/taxonomy-api/src/main/java/no/ndla/taxonomy/service/QualityEvaluationService.java
@@ -172,6 +172,12 @@ public class QualityEvaluationService {
         propagateConnectionDelta(parent, child, DeltaDirection.REMOVE);
     }
 
+    /**
+     * Note: leaves {@code parent} with stale child_quality_evaluation_* values in memory. The DB
+     * row is updated, but the managed entity is not refreshed (KEEP mode preserves child/parent
+     * for the rest of the transaction). Callers that observe parent's quality fields after this
+     * call must re-read or refresh. Current call sites only return the connection.
+     */
     private void propagateConnectionDelta(Node parent, Node child, DeltaDirection direction) {
         if (shouldBeIncludedInQualityEvaluationAverage(child.getNodeType())) {
             propagateResourceConnectionDelta(parent, child, direction);

--- a/taxonomy-api/src/test/java/no/ndla/taxonomy/rest/v1/AdminTest.java
+++ b/taxonomy-api/src/test/java/no/ndla/taxonomy/rest/v1/AdminTest.java
@@ -43,14 +43,14 @@ public class AdminTest extends RestTest {
     }
 
     public void testQualityEvaluationAverage(Node inputNode, int expectedCount, double expectedAverage) {
-        var node = nodeRepository.findFirstByPublicId(inputNode.getPublicId()).orElseThrow();
+        var node = getFreshNode(inputNode.getPublicId());
         var qe = node.getChildQualityEvaluationAverage().orElseThrow();
         assertEquals(expectedCount, qe.getCount());
         assertEquals(expectedAverage, qe.getAverageValue());
     }
 
     public void assertMissingQualityEvaluation(Node inputNode) {
-        var node = nodeRepository.findFirstByPublicId(inputNode.getPublicId()).orElseThrow();
+        var node = getFreshNode(inputNode.getPublicId());
         var qe = node.getChildQualityEvaluationAverage();
         assertTrue(qe.isEmpty());
     }

--- a/taxonomy-api/src/test/java/no/ndla/taxonomy/rest/v1/NodesTest.java
+++ b/taxonomy-api/src/test/java/no/ndla/taxonomy/rest/v1/NodesTest.java
@@ -1664,6 +1664,59 @@ public class NodesTest extends RestTest {
         testQualityEvaluationAverage(t1, 1, 3.0);
     }
 
+    @Test
+    public void updating_resource_to_topic_removes_quality_evaluation_from_parent_average() throws Exception {
+        var subject = builder.node(NodeType.SUBJECT, s -> s.name("S1").publicId("urn:subject:node-type-change-parent"));
+        var topic = builder.node(NodeType.TOPIC, t -> t.name("T1").publicId("urn:topic:node-type-change-parent"));
+        var resource = builder.node(
+                NodeType.RESOURCE,
+                r -> r.name("R1")
+                        .publicId("urn:resource:node-type-change-child")
+                        .qualityEvaluation(Grade.Three));
+
+        connect(subject, topic);
+        connect(topic, resource);
+
+        testQualityEvaluationAverage(subject, 1, 3.0);
+        testQualityEvaluationAverage(topic, 1, 3.0);
+
+        var updateBody = new NodePostPut();
+        updateBody.nodeType = NodeType.TOPIC;
+        updateBody.name = Optional.of("R1 as topic");
+        testUtils.updateResource("/v1/nodes/" + resource.getPublicId(), updateBody);
+
+        assertTrue(getFreshNode(subject.getPublicId())
+                .getChildQualityEvaluationAverage()
+                .isEmpty());
+        assertTrue(getFreshNode(topic.getPublicId())
+                .getChildQualityEvaluationAverage()
+                .isEmpty());
+    }
+
+    @Test
+    public void updating_topic_to_resource_adds_quality_evaluation_to_parent_average() throws Exception {
+        var subject =
+                builder.node(NodeType.SUBJECT, s -> s.name("S1").publicId("urn:subject:node-type-change-resource"));
+        var topic = builder.node(
+                NodeType.TOPIC,
+                t -> t.name("T1")
+                        .publicId("urn:topic:node-type-change-resource")
+                        .qualityEvaluation(Grade.Four));
+
+        connect(subject, topic);
+
+        assertTrue(getFreshNode(subject.getPublicId())
+                .getChildQualityEvaluationAverage()
+                .isEmpty());
+
+        var updateBody = new NodePostPut();
+        updateBody.nodeType = NodeType.RESOURCE;
+        updateBody.name = Optional.of("T1 as resource");
+        testUtils.updateResource("/v1/nodes/" + topic.getPublicId(), updateBody);
+
+        testQualityEvaluationAverage(subject, 1, 4.0);
+    }
+
     public URI createNode(String name, NodeType nodeType, Optional<Integer> qualityEvaluation) {
         var n = new NodePostPut();
         n.name = Optional.of(name);

--- a/taxonomy-api/src/test/java/no/ndla/taxonomy/rest/v1/NodesTest.java
+++ b/taxonomy-api/src/test/java/no/ndla/taxonomy/rest/v1/NodesTest.java
@@ -1234,9 +1234,9 @@ public class NodesTest extends RestTest {
 
         { // Set quality evaluation on resource and check that average on subject & topic is updated
             testUtils.updateResourceRawInput("/v1/nodes/" + resourceId, "{\"qualityEvaluation\": {\"grade\": 5}}");
-            var dbResource = nodeRepository.getByPublicId(URI.create(resourceId));
-            var dbTopic = nodeRepository.getByPublicId(URI.create(topicId));
-            var dbSuject = nodeRepository.getByPublicId(URI.create(subjectId));
+            var dbResource = getFreshNode(URI.create(resourceId));
+            var dbTopic = getFreshNode(URI.create(topicId));
+            var dbSuject = getFreshNode(URI.create(subjectId));
             assertEquals(dbResource.getQualityEvaluationGrade(), Optional.of(Grade.Five));
             var expectedFive = Optional.of(new GradeAverage(5, 1));
             assertEquals(dbSuject.getChildQualityEvaluationAverage(), expectedFive);
@@ -1245,9 +1245,9 @@ public class NodesTest extends RestTest {
 
         { // Remove quality evaluation on resource and check that average on subject & topic is removed
             testUtils.updateResourceRawInput("/v1/nodes/" + resourceId, "{\"qualityEvaluation\": null}");
-            var dbResource = nodeRepository.getByPublicId(URI.create(resourceId));
-            var dbTopic = nodeRepository.getByPublicId(URI.create(topicId));
-            var dbSuject = nodeRepository.getByPublicId(URI.create(subjectId));
+            var dbResource = getFreshNode(URI.create(resourceId));
+            var dbTopic = getFreshNode(URI.create(topicId));
+            var dbSuject = getFreshNode(URI.create(subjectId));
             assertEquals(dbResource.getQualityEvaluationGrade(), Optional.empty());
             var actualSubject = dbSuject.getChildQualityEvaluationAverage();
             assertEquals(actualSubject, Optional.empty());
@@ -1274,17 +1274,73 @@ public class NodesTest extends RestTest {
                                                 rc -> rc.name("R1").publicId(resourceId))));
 
         testUtils.updateResourceRawInput("/v1/nodes/" + resourceId, "{\"qualityEvaluation\": {\"grade\": 2}}");
-        var dbTopic = nodeRepository.getByPublicId(URI.create(topicId));
-        var dbSubject = nodeRepository.getByPublicId(URI.create(subjectId));
+        var dbTopic = getFreshNode(URI.create(topicId));
+        var dbSubject = getFreshNode(URI.create(subjectId));
         assertTrue(dbTopic.getChildQualityEvaluationAverage().isPresent());
         assertTrue(dbSubject.getChildQualityEvaluationAverage().isPresent());
 
         testUtils.deleteResource("/v1/nodes/" + resourceId);
 
-        var dbTopicAfter = nodeRepository.getByPublicId(URI.create(topicId));
-        var dbSubjectAfter = nodeRepository.getByPublicId(URI.create(subjectId));
+        var dbTopicAfter = getFreshNode(URI.create(topicId));
+        var dbSubjectAfter = getFreshNode(URI.create(subjectId));
         assertTrue(dbTopicAfter.getChildQualityEvaluationAverage().isEmpty());
         assertTrue(dbSubjectAfter.getChildQualityEvaluationAverage().isEmpty());
+    }
+
+    @Test
+    public void updating_reused_resource_quality_evaluation_counts_each_branch_path() throws Exception {
+        var subjectId = "urn:subject:1";
+        var firstTopicId = "urn:topic:1";
+        var secondTopicId = "urn:topic:2";
+        var resourceId = "urn:resource:1";
+        var resource = builder.node(NodeType.RESOURCE, n -> n.name("R1").publicId(resourceId));
+
+        builder.node(
+                NodeType.SUBJECT,
+                n -> n.name("S1")
+                        .publicId(subjectId)
+                        .child(
+                                NodeType.TOPIC,
+                                t -> t.name("T1").publicId(firstTopicId).child(resource))
+                        .child(
+                                NodeType.TOPIC,
+                                t -> t.name("T2").publicId(secondTopicId).child(resource)));
+
+        testUtils.updateResourceRawInput("/v1/nodes/" + resourceId, "{\"qualityEvaluation\": {\"grade\": 5}}");
+
+        assertEquals(
+                Optional.of(new GradeAverage(10, 2)),
+                getFreshNode(URI.create(subjectId)).getChildQualityEvaluationAverage());
+        assertEquals(
+                Optional.of(new GradeAverage(5, 1)),
+                getFreshNode(URI.create(firstTopicId)).getChildQualityEvaluationAverage());
+        assertEquals(
+                Optional.of(new GradeAverage(5, 1)),
+                getFreshNode(URI.create(secondTopicId)).getChildQualityEvaluationAverage());
+
+        testUtils.updateResourceRawInput("/v1/nodes/" + resourceId, "{\"qualityEvaluation\": {\"grade\": 3}}");
+
+        assertEquals(
+                Optional.of(new GradeAverage(6, 2)),
+                getFreshNode(URI.create(subjectId)).getChildQualityEvaluationAverage());
+        assertEquals(
+                Optional.of(new GradeAverage(3, 1)),
+                getFreshNode(URI.create(firstTopicId)).getChildQualityEvaluationAverage());
+        assertEquals(
+                Optional.of(new GradeAverage(3, 1)),
+                getFreshNode(URI.create(secondTopicId)).getChildQualityEvaluationAverage());
+
+        testUtils.updateResourceRawInput("/v1/nodes/" + resourceId, "{\"qualityEvaluation\": null}");
+
+        assertTrue(getFreshNode(URI.create(subjectId))
+                .getChildQualityEvaluationAverage()
+                .isEmpty());
+        assertTrue(getFreshNode(URI.create(firstTopicId))
+                .getChildQualityEvaluationAverage()
+                .isEmpty());
+        assertTrue(getFreshNode(URI.create(secondTopicId))
+                .getChildQualityEvaluationAverage()
+                .isEmpty());
     }
 
     @Test
@@ -1348,7 +1404,7 @@ public class NodesTest extends RestTest {
             testUtils.createResource("/v1/node-resources/", connectBody3);
         }
 
-        var topic2 = nodeRepository.getByPublicId(URI.create("urn:topic:2"));
+        var topic2 = getFreshNode(URI.create("urn:topic:2"));
         assertEquals(3, topic2.getChildNodes().size());
         assertTrue(topic2.getChildQualityEvaluationAverage().isPresent());
         assertEquals(3, topic2.getChildQualityEvaluationAverage().get().getCount());
@@ -1356,7 +1412,7 @@ public class NodesTest extends RestTest {
                 3.3333333333333335,
                 topic2.getChildQualityEvaluationAverage().get().getAverageValue());
 
-        var subject1 = nodeRepository.getByPublicId(URI.create("urn:subject:1"));
+        var subject1 = getFreshNode(URI.create("urn:subject:1"));
         assertTrue(subject1.getChildQualityEvaluationAverage().isPresent());
         assertEquals(6, subject1.getChildQualityEvaluationAverage().get().getCount());
         assertEquals(
@@ -1394,7 +1450,7 @@ public class NodesTest extends RestTest {
         builder.node(NodeType.SUBJECT, s2 -> s2.name("S2").publicId("urn:subject:2"));
 
         s1Node.updateEntireAverageTree();
-        var topic1 = nodeRepository.getByPublicId(URI.create("urn:topic:1"));
+        var topic1 = getFreshNode(URI.create("urn:topic:1"));
         assertEquals(3, topic1.getChildNodes().size());
         topic1.updateEntireAverageTree();
 
@@ -1404,17 +1460,17 @@ public class NodesTest extends RestTest {
                 3.3333333333333335,
                 topic1.getChildQualityEvaluationAverage().get().getAverageValue());
 
-        var subject1 = nodeRepository.getByPublicId(URI.create("urn:subject:1"));
+        var subject1 = getFreshNode(URI.create("urn:subject:1"));
         assertTrue(subject1.getChildQualityEvaluationAverage().isPresent());
         assertEquals(3, subject1.getChildQualityEvaluationAverage().get().getCount());
         assertEquals(
                 3.3333333333333335,
                 subject1.getChildQualityEvaluationAverage().get().getAverageValue());
 
-        var subject2 = nodeRepository.getByPublicId(URI.create("urn:subject:2"));
+        var subject2 = getFreshNode(URI.create("urn:subject:2"));
         assertFalse(subject2.getChildQualityEvaluationAverage().isPresent());
 
-        var topic = nodeRepository.getByPublicId(URI.create("urn:topic:1"));
+        var topic = getFreshNode(URI.create("urn:topic:1"));
         assertEquals(1, topic.getParentConnections().size());
         assertTrue(topic.getParentConnections().stream().findFirst().isPresent());
         var connectionId =
@@ -1428,17 +1484,18 @@ public class NodesTest extends RestTest {
 
         testUtils.createResource("/v1/node-connections/", connectBody);
 
-        assertEquals(3, topic1.getChildNodes().size());
-        assertTrue(topic1.getChildQualityEvaluationAverage().isPresent());
-        assertEquals(3, topic1.getChildQualityEvaluationAverage().get().getCount());
+        var movedTopic = getFreshNode(URI.create("urn:topic:1"));
+        assertEquals(3, movedTopic.getChildNodes().size());
+        assertTrue(movedTopic.getChildQualityEvaluationAverage().isPresent());
+        assertEquals(3, movedTopic.getChildQualityEvaluationAverage().get().getCount());
         assertEquals(
                 3.3333333333333335,
-                topic1.getChildQualityEvaluationAverage().get().getAverageValue());
+                movedTopic.getChildQualityEvaluationAverage().get().getAverageValue());
 
-        var s1 = nodeRepository.getByPublicId(URI.create("urn:subject:1"));
+        var s1 = getFreshNode(URI.create("urn:subject:1"));
         assertFalse(s1.getChildQualityEvaluationAverage().isPresent());
 
-        var s2 = nodeRepository.getByPublicId(URI.create("urn:subject:2"));
+        var s2 = getFreshNode(URI.create("urn:subject:2"));
         assertTrue(s2.getChildQualityEvaluationAverage().isPresent());
         assertEquals(3, s2.getChildQualityEvaluationAverage().get().getCount());
         assertEquals(
@@ -1563,8 +1620,8 @@ public class NodesTest extends RestTest {
         disconnect(t1, t2);
 
         {
-            var node = nodeRepository.findFirstByPublicId(t2.getPublicId());
-            var qe = node.get().getChildQualityEvaluationAverage();
+            var node = getFreshNode(t2.getPublicId());
+            var qe = node.getChildQualityEvaluationAverage();
             assertFalse(qe.isPresent());
         }
 
@@ -1626,8 +1683,7 @@ public class NodesTest extends RestTest {
 
     public List<Integer> getQualityEvaluationGradesOf(List<URI> ids) {
         return ids.stream()
-                .map(id -> nodeRepository
-                        .getByPublicId(id)
+                .map(id -> getFreshNode(id)
                         .getQualityEvaluationGrade()
                         .orElseThrow()
                         .toInt())
@@ -1636,10 +1692,7 @@ public class NodesTest extends RestTest {
 
     public List<GradeAverage> getQEAverageGradesOf(List<URI> ids) {
         return ids.stream()
-                .map(id -> nodeRepository
-                        .getByPublicId(id)
-                        .getChildQualityEvaluationAverage()
-                        .orElse(null))
+                .map(id -> getFreshNode(id).getChildQualityEvaluationAverage().orElse(null))
                 .toList();
     }
 
@@ -2042,7 +2095,7 @@ public class NodesTest extends RestTest {
     }
 
     public void testQualityEvaluationAverage(Node inputNode, int expectedCount, double expectedAverage) {
-        var node = nodeRepository.findFirstByPublicId(inputNode.getPublicId()).orElseThrow();
+        var node = getFreshNode(inputNode.getPublicId());
         var qe = node.getChildQualityEvaluationAverage().orElseThrow();
         assertEquals(expectedCount, qe.getCount());
         assertEquals(expectedAverage, qe.getAverageValue());

--- a/taxonomy-api/src/test/java/no/ndla/taxonomy/rest/v1/RestTest.java
+++ b/taxonomy-api/src/test/java/no/ndla/taxonomy/rest/v1/RestTest.java
@@ -8,6 +8,7 @@
 package no.ndla.taxonomy.rest.v1;
 
 import jakarta.persistence.EntityManager;
+import java.net.URI;
 import no.ndla.taxonomy.TestUtils;
 import no.ndla.taxonomy.domain.*;
 import no.ndla.taxonomy.repositories.*;
@@ -83,5 +84,15 @@ public class RestTest extends AbstractIntegrationTest {
 
     ResourceType newResourceType() {
         return save(new ResourceType());
+    }
+
+    /**
+     * Flushes pending writes and clears the persistence context, then re-loads the node so the
+     * caller observes column values written by bulk SQL updates that bypass managed entities.
+     */
+    protected Node getFreshNode(URI publicId) {
+        entityManager.flush();
+        entityManager.clear();
+        return nodeRepository.getByPublicId(publicId);
     }
 }

--- a/taxonomy-api/src/test/java/no/ndla/taxonomy/service/NodeConnectionServiceImplTest.java
+++ b/taxonomy-api/src/test/java/no/ndla/taxonomy/service/NodeConnectionServiceImplTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.transaction.TestTransaction;
 import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
@@ -74,6 +75,46 @@ public class NodeConnectionServiceImplTest extends AbstractIntegrationTest {
         var average = node.getChildQualityEvaluationAverage().orElseThrow();
         assertEquals(expectedCount, average.getCount());
         assertEquals(expectedAverage, average.getAverageValue());
+    }
+
+    @Test
+    public void draft_note_updates_are_deferred_until_transaction_commit() {
+        final var topic = builder.node(NodeType.TOPIC);
+        final var resource = builder.node(NodeType.RESOURCE);
+
+        service.connectParentChild(topic, resource, Relevance.CORE, null, Optional.of(true), NodeConnectionType.BRANCH);
+
+        verify(draftApiClient, never()).updateNotesWithNewConnection(any(NodeConnection.class));
+
+        TestTransaction.flagForCommit();
+        TestTransaction.end();
+
+        verify(draftApiClient).updateNotesWithNewConnection(any(NodeConnection.class));
+
+        TestTransaction.start();
+        nodeConnectionRepository.deleteAllAndFlush();
+        nodeRepository.deleteAllAndFlush();
+        TestTransaction.flagForCommit();
+        TestTransaction.end();
+        TestTransaction.start();
+    }
+
+    @Test
+    public void disconnect_all_parents_by_id_disconnects_every_parent() {
+        final var firstParent = builder.node(NodeType.TOPIC);
+        final var secondParent = builder.node(NodeType.TOPIC);
+        final var resource = builder.node(NodeType.RESOURCE);
+
+        service.connectParentChild(
+                firstParent, resource, Relevance.CORE, 1, Optional.of(true), NodeConnectionType.BRANCH);
+        service.connectParentChild(
+                secondParent, resource, Relevance.CORE, 1, Optional.of(false), NodeConnectionType.BRANCH);
+
+        service.disconnectAllParents(resource.getPublicId());
+
+        assertTrue(resource.getParentConnections().isEmpty());
+        assertTrue(firstParent.getChildConnections().isEmpty());
+        assertTrue(secondParent.getChildConnections().isEmpty());
     }
 
     @Test

--- a/taxonomy-api/src/test/java/no/ndla/taxonomy/service/NodeConnectionServiceImplTest.java
+++ b/taxonomy-api/src/test/java/no/ndla/taxonomy/service/NodeConnectionServiceImplTest.java
@@ -10,6 +10,7 @@ package no.ndla.taxonomy.service;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import jakarta.persistence.EntityManager;
 import java.util.Optional;
 import java.util.Set;
 import no.ndla.taxonomy.domain.*;
@@ -36,6 +37,9 @@ public class NodeConnectionServiceImplTest extends AbstractIntegrationTest {
     @Autowired
     private NodeRepository nodeRepository;
 
+    @Autowired
+    private EntityManager entityManager;
+
     private ContextUpdaterService contextUpdaterService;
 
     private NodeConnectionServiceImpl service;
@@ -59,6 +63,17 @@ public class NodeConnectionServiceImplTest extends AbstractIntegrationTest {
                 nodeRepository,
                 qualityEvaluationService,
                 draftApiClient);
+    }
+
+    private void refresh(Node node) {
+        entityManager.flush();
+        entityManager.refresh(node);
+    }
+
+    private void assertQualityEvaluationAverage(Node node, double expectedAverage, int expectedCount) {
+        var average = node.getChildQualityEvaluationAverage().orElseThrow();
+        assertEquals(expectedCount, average.getCount());
+        assertEquals(expectedAverage, average.getAverageValue());
     }
 
     @Test
@@ -509,6 +524,67 @@ public class NodeConnectionServiceImplTest extends AbstractIntegrationTest {
     }
 
     @Test
+    public void branch_resource_connections_update_quality_evaluation_for_parent_tree() {
+        final var subject = builder.node(NodeType.SUBJECT);
+        final var topic = builder.node(NodeType.TOPIC);
+        final var resource = builder.node(NodeType.RESOURCE, node -> node.qualityEvaluation(Grade.Five));
+
+        service.connectParentChild(subject, topic, Relevance.CORE, 1, Optional.of(true), NodeConnectionType.BRANCH);
+        var resourceConnection = service.connectParentChild(
+                topic, resource, Relevance.CORE, 1, Optional.of(true), NodeConnectionType.BRANCH);
+
+        refresh(topic);
+        refresh(subject);
+
+        assertQualityEvaluationAverage(topic, 5.0, 1);
+        assertQualityEvaluationAverage(subject, 5.0, 1);
+
+        service.disconnectParentChildConnection(resourceConnection);
+
+        refresh(topic);
+        refresh(subject);
+
+        assertTrue(topic.getChildQualityEvaluationAverage().isEmpty());
+        assertTrue(subject.getChildQualityEvaluationAverage().isEmpty());
+    }
+
+    @Test
+    public void branch_topic_connections_update_quality_evaluation_for_parent_tree() {
+        final var subject = builder.node(NodeType.SUBJECT);
+        final var parentTopic = builder.node(NodeType.TOPIC);
+        final var childTopic = builder.node(NodeType.TOPIC);
+        final var firstResource = builder.node(NodeType.RESOURCE, node -> node.qualityEvaluation(Grade.Five));
+        final var secondResource = builder.node(NodeType.RESOURCE, node -> node.qualityEvaluation(Grade.Three));
+
+        service.connectParentChild(
+                subject, parentTopic, Relevance.CORE, 1, Optional.of(true), NodeConnectionType.BRANCH);
+        service.connectParentChild(
+                childTopic, firstResource, Relevance.CORE, 1, Optional.of(true), NodeConnectionType.BRANCH);
+        service.connectParentChild(
+                childTopic, secondResource, Relevance.CORE, 2, Optional.of(true), NodeConnectionType.BRANCH);
+
+        refresh(childTopic);
+        assertQualityEvaluationAverage(childTopic, 4.0, 2);
+
+        var topicConnection = service.connectParentChild(
+                parentTopic, childTopic, Relevance.CORE, 1, Optional.of(true), NodeConnectionType.BRANCH);
+
+        refresh(parentTopic);
+        refresh(subject);
+
+        assertQualityEvaluationAverage(parentTopic, 4.0, 2);
+        assertQualityEvaluationAverage(subject, 4.0, 2);
+
+        service.disconnectParentChildConnection(topicConnection);
+
+        refresh(parentTopic);
+        refresh(subject);
+
+        assertTrue(parentTopic.getChildQualityEvaluationAverage().isEmpty());
+        assertTrue(subject.getChildQualityEvaluationAverage().isEmpty());
+    }
+
+    @Test
     public void link_connections_do_not_affect_quality_evaluation() {
         final var topic = builder.node(NodeType.TOPIC);
         final var branchResource = builder.node(NodeType.RESOURCE, resource -> resource.qualityEvaluation(Grade.Five));
@@ -517,6 +593,8 @@ public class NodeConnectionServiceImplTest extends AbstractIntegrationTest {
         service.connectParentChild(
                 topic, branchResource, Relevance.CORE, 1, Optional.of(true), NodeConnectionType.BRANCH);
 
+        refresh(topic);
+
         assertTrue(topic.getChildQualityEvaluationAverage().isPresent());
         assertEquals(1, topic.getChildQualityEvaluationAverage().orElseThrow().getCount());
         assertEquals(5, topic.getChildQualityEvaluationAverage().orElseThrow().getAverageValue());
@@ -524,11 +602,15 @@ public class NodeConnectionServiceImplTest extends AbstractIntegrationTest {
         var linkConnection = service.connectParentChild(
                 topic, linkedResource, Relevance.CORE, 2, Optional.of(false), NodeConnectionType.LINK);
 
+        refresh(topic);
+
         assertTrue(topic.getChildQualityEvaluationAverage().isPresent());
         assertEquals(1, topic.getChildQualityEvaluationAverage().orElseThrow().getCount());
         assertEquals(5, topic.getChildQualityEvaluationAverage().orElseThrow().getAverageValue());
 
         service.disconnectParentChildConnection(linkConnection);
+
+        refresh(topic);
 
         assertTrue(topic.getChildQualityEvaluationAverage().isPresent());
         assertEquals(1, topic.getChildQualityEvaluationAverage().orElseThrow().getCount());

--- a/taxonomy-api/src/test/java/no/ndla/taxonomy/service/QualityEvaluationServiceConcurrencyTest.java
+++ b/taxonomy-api/src/test/java/no/ndla/taxonomy/service/QualityEvaluationServiceConcurrencyTest.java
@@ -209,9 +209,9 @@ class QualityEvaluationServiceConcurrencyTest extends AbstractIntegrationTest {
                 await(continueUpdate);
             }
 
-            var oldGrade = qualityEvaluationService.getOldGradeForQualityEvaluationUpdate(node, command);
+            var oldState = qualityEvaluationService.getQualityEvaluationUpdateState(node, command);
             command.apply(node);
-            qualityEvaluationService.updateQualityEvaluationOfParents(node, oldGrade, command);
+            qualityEvaluationService.updateQualityEvaluationOfParents(node, oldState, command);
         });
     }
 

--- a/taxonomy-api/src/test/java/no/ndla/taxonomy/service/QualityEvaluationServiceConcurrencyTest.java
+++ b/taxonomy-api/src/test/java/no/ndla/taxonomy/service/QualityEvaluationServiceConcurrencyTest.java
@@ -84,8 +84,50 @@ class QualityEvaluationServiceConcurrencyTest extends AbstractIntegrationTest {
         var updatedParent = transactionTemplate.execute(status -> nodeRepository.getByPublicId(parentId));
         var average = updatedParent.getChildQualityEvaluationAverage().orElseThrow();
 
-        assertEquals(1, average.getCount()); // Should be 2
-        // assertEquals(4.5, average.getAverageValue());
+        assertEquals(2, average.getCount());
+        assertEquals(4.5, average.getAverageValue());
+    }
+
+    @Test
+    void concurrent_updates_to_sibling_resources_should_accumulate_on_shared_ancestor() throws Exception {
+        var ids = transactionTemplate.execute(status -> {
+            builder.node(
+                    NodeType.TOPIC,
+                    parent -> parent.name("Parent")
+                            .publicId("urn:topic:3")
+                            .child(
+                                    NodeType.RESOURCE,
+                                    child -> child.name("ChildA").publicId("urn:resource:a"))
+                            .child(
+                                    NodeType.RESOURCE,
+                                    child -> child.name("ChildB").publicId("urn:resource:b")));
+            return List.of(URI.create("urn:topic:3"), URI.create("urn:resource:a"), URI.create("urn:resource:b"));
+        });
+        var parentId = ids.get(0);
+        var childAId = ids.get(1);
+        var childBId = ids.get(2);
+
+        var loadedChildren = new CountDownLatch(2);
+        var startUpdates = new CountDownLatch(1);
+
+        try (ExecutorService executor = Executors.newFixedThreadPool(2)) {
+            var updateA = executor.submit(
+                    () -> applyNodeQualityEvaluationUpdate(childAId, Grade.Five, loadedChildren, startUpdates));
+            var updateB = executor.submit(
+                    () -> applyNodeQualityEvaluationUpdate(childBId, Grade.Four, loadedChildren, startUpdates));
+
+            assertTrue(loadedChildren.await(5, TimeUnit.SECONDS));
+            startUpdates.countDown();
+
+            updateA.get(5, TimeUnit.SECONDS);
+            updateB.get(5, TimeUnit.SECONDS);
+        }
+
+        var updatedParent = transactionTemplate.execute(status -> nodeRepository.getByPublicId(parentId));
+        var average = updatedParent.getChildQualityEvaluationAverage().orElseThrow();
+
+        assertEquals(2, average.getCount());
+        assertEquals(4.5, average.getAverageValue());
     }
 
     @Test
@@ -167,9 +209,7 @@ class QualityEvaluationServiceConcurrencyTest extends AbstractIntegrationTest {
                 await(continueUpdate);
             }
 
-            qualityEvaluationService.lockNodeForQualityEvaluationUpdate(node, command);
-
-            var oldGrade = node.getQualityEvaluationGrade();
+            var oldGrade = qualityEvaluationService.getOldGradeForQualityEvaluationUpdate(node, command);
             command.apply(node);
             qualityEvaluationService.updateQualityEvaluationOfParents(node, oldGrade, command);
         });


### PR DESCRIPTION
Denne er en munnfull.

- Låsing var tregt fordi måten vi gjorde det på med hibernate magi gjorde at vi måtte ha en roundtrip til databasen pr node i treet.
- Dette løser jeg her med å bruke rekursive sql cte'er. Disse dealer med at alle nodene oppdateres i en sql query (Ja de er vanskelige å lese).
- Dette gjør at vi _kan_ støte på at postgres sin deadlock detection kan slå inn dersom man oppdaterer søskennoder samtidig.
- Derfor la jeg inn en retry logikk, MEN det gjør at sideeffekter kan retryes, så derfor la jeg inn draft notater oppdatering i en `runAfterCommit` hook.
  - Alternativt kan vi gamble på at dette ikke skjer så ofte, det ville jo bare returnert en feil også kunne man prøvd igjen, men det blir jo litt dårligere brukeropplevelse for noe som er en teknisk begrensning.

Ja det er mye AI her (jeg syns spring er sykt vanskelig). 
Tror jeg har sånn halvveis kontroll nå, men jeg er helt enig i at lesbarheten her er ganske røff. Gjerne kom med forslag.
Har prøvd å få inn regressjonstester på det jeg tror kan bli lett å brekke i fremtiden der ting kan være litt klønete hengt sammen.

Det positive: oppdatering av kvalitetsvurdering i en dyp node på min lokale maskin gikk fra ~25 sekunder til ~200-300ms (125-80x). 