### PR TITLE
fix(build): merge ServiceLoader metadata in assembly jars

### DIFF
--- a/modules/DockerComponent.mill
+++ b/modules/DockerComponent.mill
@@ -10,7 +10,7 @@ trait DockerComponent extends JavaModule, DockerModule {
       Assembly.Rule.Exclude("META-INF/FastDoubleParser-NOTICE"),
       Assembly.Rule.ExcludePattern(".*/module-info.class"),
       Assembly.Rule.ExcludePattern(".*/io.netty.versions.properties"),
-      Assembly.Rule.Append("META-INF/services/org.flywaydb.core.extensibility.Plugin", "\n"),
+      Assembly.Rule.AppendPattern("META-INF/services/.*", "\n"),
       Assembly.Rule.Append("mime.types", "\n"),
     )
   }


### PR DESCRIPTION
Docker images run fat assembly jars, where duplicate META-INF/services
files were previously overwritten unless explicitly merged. This caused
Jackson module discovery to miss modules such as Jdk8Module in taxonomy-api,
breaking JSONB deserialization for fields containing Optional values.

Merge all ServiceLoader provider files so Docker runtime behavior matches
classpath-based local execution.
