### PR TITLE
fix(taxonomy-api): serialize quality evaluation updates with advisory lock

### DIFF
--- a/taxonomy-api/src/main/java/no/ndla/taxonomy/domain/Node.java
+++ b/taxonomy-api/src/main/java/no/ndla/taxonomy/domain/Node.java
@@ -162,6 +162,17 @@ public class Node extends DomainObject implements EntityWithMetadata {
         return Optional.of(gradeAverage);
     }
 
+    public void setChildQualityEvaluationAverage(int averageSum, int count) {
+        if (count <= 0 || averageSum <= 0) {
+            this.childQualityEvaluationSum = 0;
+            this.childQualityEvaluationCount = 0;
+            return;
+        }
+
+        this.childQualityEvaluationSum = averageSum;
+        this.childQualityEvaluationCount = count;
+    }
+
     public void addGradeAverageTreeToAverageCalculation(GradeAverage newGradeAverage) {
         var childAvg = getChildQualityEvaluationAverage();
         if (childAvg.isEmpty()) {

--- a/taxonomy-api/src/main/java/no/ndla/taxonomy/rest/v1/CrudController.java
+++ b/taxonomy-api/src/main/java/no/ndla/taxonomy/rest/v1/CrudController.java
@@ -19,7 +19,6 @@ import no.ndla.taxonomy.domain.exceptions.DuplicateIdException;
 import no.ndla.taxonomy.repositories.TaxonomyRepository;
 import no.ndla.taxonomy.rest.v1.responses.Created201ApiResponse;
 import no.ndla.taxonomy.service.*;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -35,8 +34,6 @@ public abstract class CrudController<T extends DomainEntity> {
     protected ContextUpdaterService contextUpdaterService;
     protected NodeService nodeService;
     protected QualityEvaluationService qualityEvaluationService;
-
-    @Autowired
     protected ResourceTypeService resourceTypeService;
 
     private static final Map<Class<?>, String> locations = new HashMap<>();
@@ -55,13 +52,6 @@ public abstract class CrudController<T extends DomainEntity> {
         this.resourceTypeService = resourceTypeService;
     }
 
-    protected CrudController(TaxonomyRepository<T> repository) {
-        this.repository = repository;
-    }
-
-    /*
-     * Looks like this method is only used by ResourceTypes.java. All other subclasses define their own deleteEntity method.
-     */
     @DeleteMapping("/{id}")
     @Operation(
             summary = "Deletes a single entity by id",
@@ -69,29 +59,7 @@ public abstract class CrudController<T extends DomainEntity> {
     @PreAuthorize("hasAuthority('TAXONOMY_WRITE')")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @Transactional
-    protected void deleteEntity(@PathVariable("id") URI id) {
-        Optional<Grade> oldGrade = Optional.empty();
-        Optional<Collection<Node>> parents = Optional.empty();
-
-        if (nodeService != null) {
-            var existingNode = nodeService.getMaybeNode(id);
-            oldGrade = existingNode.flatMap(Node::getQualityEvaluationGrade);
-            parents = Optional.of(existingNode.map(Node::getParentNodes).orElse(List.of()));
-        }
-
-        var entity = repository.getByPublicId(id);
-        repository.delete(entity);
-        repository.flush();
-
-        if (parents.isPresent()) {
-            var p = parents.get();
-            qualityEvaluationService.updateQualityEvaluationOfRecursive(p, oldGrade, Optional.empty());
-        }
-
-        if (entity instanceof ResourceType && resourceTypeService != null) {
-            resourceTypeService.updateOrderAfterDelete();
-        }
-    }
+    protected abstract void deleteEntity(@PathVariable("id") URI id);
 
     protected Optional<Grade> getOldGrade(T entity) {
         if (entity instanceof Node node) {
@@ -106,12 +74,11 @@ public abstract class CrudController<T extends DomainEntity> {
     @PreAuthorize("hasAuthority('TAXONOMY_WRITE')")
     @Transactional
     protected T updateEntity(URI id, UpdatableDto<T> command) {
+        var qualityEvaluationUpdateLocked =
+                qualityEvaluationService != null && qualityEvaluationService.lockQualityEvaluationIfNeeded(command);
+
         T entity = repository.getByPublicId(id);
         validator.validate(id, entity);
-
-        // if (entity instanceof Node node && qualityEvaluationService != null) {
-        //     qualityEvaluationService.lockNodeForQualityEvaluationUpdate(node, command);
-        // }
 
         var oldGrade = getOldGrade(entity);
 
@@ -119,8 +86,9 @@ public abstract class CrudController<T extends DomainEntity> {
 
         if (entity instanceof Node node) {
             if (contextUpdaterService != null) contextUpdaterService.updateContexts(node);
-            if (qualityEvaluationService != null)
-                qualityEvaluationService.updateQualityEvaluationOfParents(node, oldGrade, command);
+            if (qualityEvaluationUpdateLocked) {
+                qualityEvaluationService.updateQualityEvaluationOfParentsFromFreshlyLoadedNode(node, oldGrade, command);
+            }
         }
 
         if (entity instanceof ResourceType resourceType && resourceTypeService != null) {
@@ -138,6 +106,9 @@ public abstract class CrudController<T extends DomainEntity> {
     @Transactional
     protected ResponseEntity<Void> createEntity(T entity, UpdatableDto<T> command) {
         try {
+            var qualityEvaluationUpdateLocked =
+                    qualityEvaluationService != null && qualityEvaluationService.lockQualityEvaluationIfNeeded(command);
+
             command.getId().ifPresent(id -> {
                 validator.validate(id, entity);
                 entity.setPublicId(id);
@@ -150,8 +121,10 @@ public abstract class CrudController<T extends DomainEntity> {
 
             if (entity instanceof Node node) {
                 if (contextUpdaterService != null) contextUpdaterService.updateContexts(node);
-                if (qualityEvaluationService != null)
-                    qualityEvaluationService.updateQualityEvaluationOfParents(node, oldGrade, command);
+                if (qualityEvaluationUpdateLocked) {
+                    qualityEvaluationService.updateQualityEvaluationOfParentsFromFreshlyLoadedNode(
+                            node, oldGrade, command);
+                }
             }
 
             if (entity instanceof ResourceType resourceType && resourceTypeService != null) {

--- a/taxonomy-api/src/main/java/no/ndla/taxonomy/rest/v1/ResourceTypes.java
+++ b/taxonomy-api/src/main/java/no/ndla/taxonomy/rest/v1/ResourceTypes.java
@@ -19,6 +19,7 @@ import no.ndla.taxonomy.repositories.ResourceTypeRepository;
 import no.ndla.taxonomy.rest.v1.dtos.ResourceTypeDTO;
 import no.ndla.taxonomy.rest.v1.dtos.ResourceTypePUT;
 import no.ndla.taxonomy.rest.v1.responses.Created201ApiResponse;
+import no.ndla.taxonomy.service.ResourceTypeService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -31,8 +32,8 @@ public class ResourceTypes extends CrudController<ResourceType> {
 
     private final ResourceTypeRepository resourceTypeRepository;
 
-    public ResourceTypes(ResourceTypeRepository resourceTypeRepository) {
-        super(resourceTypeRepository);
+    public ResourceTypes(ResourceTypeRepository resourceTypeRepository, ResourceTypeService resourceTypeService) {
+        super(resourceTypeRepository, null, null, null, resourceTypeService);
 
         this.resourceTypeRepository = resourceTypeRepository;
     }
@@ -129,5 +130,22 @@ public class ResourceTypes extends CrudController<ResourceType> {
         return resourceTypeRepository.findAllByParentPublicIdIncludingTranslationsAndFirstLevelSubtypes(id).stream()
                 .map(resourceType -> new ResourceTypeDTO(resourceType, language, 100))
                 .collect(Collectors.toList());
+    }
+
+    @DeleteMapping("/{id}")
+    @Operation(
+            summary = "Deletes a single entity by id",
+            security = {@SecurityRequirement(name = "oauth")})
+    @PreAuthorize("hasAuthority('TAXONOMY_WRITE')")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @Transactional
+    protected void deleteEntity(@PathVariable("id") URI id) {
+        var entity = repository.getByPublicId(id);
+        repository.delete(entity);
+        repository.flush();
+
+        if (resourceTypeService != null) {
+            resourceTypeService.updateOrderAfterDelete();
+        }
     }
 }

--- a/taxonomy-api/src/main/java/no/ndla/taxonomy/rest/v1/Versions.java
+++ b/taxonomy-api/src/main/java/no/ndla/taxonomy/rest/v1/Versions.java
@@ -35,7 +35,7 @@ public class Versions extends CrudController<Version> {
     private final VersionService versionService;
 
     public Versions(VersionService versionService, VersionRepository versionRepository) {
-        super(versionRepository);
+        super(versionRepository, null, null, null, null);
         this.versionService = versionService;
         this.versionRepository = versionRepository;
     }

--- a/taxonomy-api/src/main/java/no/ndla/taxonomy/service/NodeConnectionServiceImpl.java
+++ b/taxonomy-api/src/main/java/no/ndla/taxonomy/service/NodeConnectionServiceImpl.java
@@ -100,6 +100,12 @@ public class NodeConnectionServiceImpl implements NodeConnectionService {
             Integer rank,
             Optional<Boolean> isPrimary,
             NodeConnectionType connectionType) {
+        // Acquire the QE lock before any lazy-loaded collection access on parent/child/ancestors.
+        // The loop-detection and rank logic below initializes parent.parentConnections; if the
+        // lock were taken later (inside updateQualityEvaluationOfNewConnection), the QE recursion
+        // could walk a stale tree committed by a concurrent QE-holding transaction.
+        qualityEvaluationService.lockForConnectionChange(connectionType);
+
         if (!child.getParentConnections().isEmpty()) {
             if (connectionType == NodeConnectionType.BRANCH && child.getNodeType() == NodeType.TOPIC)
                 throw new DuplicateConnectionException();

--- a/taxonomy-api/src/main/java/no/ndla/taxonomy/service/QualityEvaluationService.java
+++ b/taxonomy-api/src/main/java/no/ndla/taxonomy/service/QualityEvaluationService.java
@@ -8,13 +8,9 @@
 package no.ndla.taxonomy.service;
 
 import jakarta.persistence.EntityManager;
-import jakarta.persistence.LockModeType;
 import java.net.URI;
 import java.util.Collection;
-import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import no.ndla.taxonomy.domain.*;
 import no.ndla.taxonomy.repositories.NodeRepository;
@@ -22,11 +18,27 @@ import no.ndla.taxonomy.rest.v1.commands.NodePostPut;
 import no.ndla.taxonomy.service.dtos.QualityEvaluationDTO;
 import no.ndla.taxonomy.service.exceptions.NotFoundServiceException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional(readOnly = true)
 @Service
 public class QualityEvaluationService {
+    private static final String QUALITY_EVALUATION_ADVISORY_LOCK_QUERY = """
+            SELECT pg_advisory_xact_lock(
+                hashtext(cast(current_schema() as text)),
+                hashtext('taxonomy_quality_evaluation')
+            )
+            """;
+    private static final String NODE_QUALITY_EVALUATION_SNAPSHOT_QUERY = """
+            SELECT quality_evaluation,
+                   quality_evaluation_comment,
+                   child_quality_evaluation_sum,
+                   child_quality_evaluation_count
+            FROM node
+            WHERE id = :nodeId
+            """;
+
     private final NodeRepository nodeRepository;
     private final EntityManager entityManager;
 
@@ -48,22 +60,37 @@ public class QualityEvaluationService {
     }
 
     /**
-     * Acquires a pessimistic lock on the node and refreshes it from the database, ensuring
-     * that the subsequent getOldGrade/apply/updateParents sequence sees the latest persisted state.
+     * Serializes quality evaluation updates before loading the node, ensuring that the subsequent
+     * getOldGrade/apply/updateParents sequence sees the latest persisted state.
      * Must be called within the same transaction as the update (e.g. from CrudController.updateEntity).
      */
-    @Transactional
-    public void lockNodeForQualityEvaluationUpdate(Node node, UpdatableDto<?> command) {
+    @Transactional(propagation = Propagation.MANDATORY)
+    public boolean lockQualityEvaluationIfNeeded(UpdatableDto<?> command) {
         if (getQualityEvaluationCommand(command).isEmpty()) {
-            return;
+            return false;
         }
 
-        entityManager.flush();
-        lockAndRefresh(node);
+        acquireQualityEvaluationAdvisoryLock();
+        return true;
     }
 
-    @Transactional
-    public void updateQualityEvaluationOfParents(Node node, Optional<Grade> oldGrade, UpdatableDto<?> command) {
+    /**
+     * Acquires the quality evaluation lock before any parent-graph access happens for a connection
+     * mutation. Must be called within the same transaction as the mutation, before any code that
+     * lazily initializes {@code parentConnections} on the parent or its ancestors. Otherwise the
+     * subsequent QE recursion may walk a stale parent tree (TOCTOU between entity load and lock).
+     */
+    @Transactional(propagation = Propagation.MANDATORY)
+    public void lockForConnectionChange(NodeConnectionType connectionType) {
+        if (connectionType == NodeConnectionType.LINK) {
+            return;
+        }
+        acquireQualityEvaluationAdvisoryLock();
+    }
+
+    @Transactional(propagation = Propagation.MANDATORY)
+    public void updateQualityEvaluationOfParentsFromFreshlyLoadedNode(
+            Node node, Optional<Grade> oldGrade, UpdatableDto<?> command) {
         var nodeCommand = getQualityEvaluationCommand(command);
         if (nodeCommand.isEmpty()) {
             return;
@@ -72,10 +99,10 @@ public class QualityEvaluationService {
         var newGrade = nodeCommand.get().qualityEvaluation.getValue().map(QualityEvaluationDTO::getGrade);
 
         updateQualityEvaluationOfParents(
-                node.getNodeType(), node.getParentNodesForQualityEvaluation(), oldGrade, newGrade);
+                node.getNodeType(), node.getParentNodesForQualityEvaluation(), oldGrade, newGrade, false);
     }
 
-    @Transactional
+    @Transactional(propagation = Propagation.MANDATORY)
     public void updateQualityEvaluationOfNewConnection(NodeConnection connection) {
         if (connection.getConnectionType() == NodeConnectionType.LINK) {
             return;
@@ -87,33 +114,32 @@ public class QualityEvaluationService {
             return;
         }
 
-        // Lock the parent tree once upfront to avoid double lock+refresh discarding changes.
-        // var allNodes = lockParentTree(List.of(parent));
-        // lockAndRefresh(child);
+        acquireQualityEvaluationAdvisoryLock();
+        entityManager.flush();
+        var childSnapshot = getNodeQualityEvaluationSnapshot(child);
 
         // Update parents quality evaluation average with the newly linked one.
-        updateQualityEvaluationOfParents(
-                child.getNodeType(), List.of(parent), Optional.empty(), child.getQualityEvaluationGrade());
+        updateQualityEvaluationOfParents(child.getNodeType(), List.of(parent), Optional.empty(), childSnapshot.grade());
 
-        child.getChildQualityEvaluationAverage().ifPresent(childAverage -> {
-            addGradeAverageTreeToParents(parent, childAverage);
-        });
-
-        // nodeRepository.saveAll(allNodes);
+        childSnapshot
+                .childQualityEvaluationAverage()
+                .ifPresent(childAverage -> addGradeAverageTreeToParents(parent, childAverage));
     }
 
     private void addGradeAverageTreeToParents(Node node, GradeAverage averageToAdd) {
+        synchronizeChildQualityEvaluationAverage(node);
         node.addGradeAverageTreeToAverageCalculation(averageToAdd);
         node.getParentNodesForQualityEvaluation().forEach(parent -> addGradeAverageTreeToParents(parent, averageToAdd));
     }
 
     private void removeGradeAverageTreeFromParents(Node node, GradeAverage averageToRemove) {
+        synchronizeChildQualityEvaluationAverage(node);
         node.removeGradeAverageTreeFromAverageCalculation(averageToRemove);
         node.getParentNodesForQualityEvaluation()
                 .forEach(parent -> removeGradeAverageTreeFromParents(parent, averageToRemove));
     }
 
-    @Transactional
+    @Transactional(propagation = Propagation.MANDATORY)
     public void removeQualityEvaluationOfDeletedConnection(NodeConnection connectionToDelete) {
         if (connectionToDelete.getConnectionType() == NodeConnectionType.LINK) return;
 
@@ -124,23 +150,32 @@ public class QualityEvaluationService {
         var child = connectionToDelete.getChild().get();
         var parent = connectionToDelete.getParent().get();
 
+        acquireQualityEvaluationAdvisoryLock();
+        entityManager.flush();
+        var childSnapshot = getNodeQualityEvaluationSnapshot(child);
+
         if (shouldBeIncludedInQualityEvaluationAverage(child.getNodeType())) {
             updateQualityEvaluationOfParents(
-                    child.getNodeType(), List.of(parent), child.getQualityEvaluationGrade(), Optional.empty());
+                    child.getNodeType(), List.of(parent), childSnapshot.grade(), Optional.empty());
             return;
         }
 
-        if (child.getChildQualityEvaluationAverage().isEmpty()) return;
-        var childAverage = child.getChildQualityEvaluationAverage().get();
-
-        // var allNodes = lockParentTree(List.of(parent));
-        removeGradeAverageTreeFromParents(parent, childAverage);
-        // nodeRepository.saveAll(allNodes);
+        childSnapshot
+                .childQualityEvaluationAverage()
+                .ifPresent(childAverage -> removeGradeAverageTreeFromParents(parent, childAverage));
     }
 
-    @Transactional
     protected void updateQualityEvaluationOfParents(
             NodeType nodeType, Collection<Node> parentNodes, Optional<Grade> oldGrade, Optional<Grade> newGrade) {
+        updateQualityEvaluationOfParents(nodeType, parentNodes, oldGrade, newGrade, true);
+    }
+
+    private void updateQualityEvaluationOfParents(
+            NodeType nodeType,
+            Collection<Node> parentNodes,
+            Optional<Grade> oldGrade,
+            Optional<Grade> newGrade,
+            boolean synchronizeBeforeUpdate) {
         if (!shouldBeIncludedInQualityEvaluationAverage(nodeType)) {
             return;
         }
@@ -148,65 +183,79 @@ public class QualityEvaluationService {
             return;
         }
 
-        updateQualityEvaluationOfRecursive(parentNodes, oldGrade, newGrade);
+        updateQualityEvaluationOfRecursiveUnlocked(parentNodes, oldGrade, newGrade, synchronizeBeforeUpdate);
     }
 
     @Transactional
     public void updateQualityEvaluationOfRecursive(
             Collection<Node> parents, Optional<Grade> oldGrade, Optional<Grade> newGrade) {
-        // var allNodes = lockParentTree(parents);
-        updateQualityEvaluationOfRecursiveUnlocked(parents, oldGrade, newGrade);
-        // nodeRepository.saveAll(allNodes);
+        acquireQualityEvaluationAdvisoryLock();
+        entityManager.flush();
+        updateQualityEvaluationOfRecursiveUnlocked(parents, oldGrade, newGrade, true);
     }
 
     private void updateQualityEvaluationOfRecursiveUnlocked(
-            Collection<Node> parents, Optional<Grade> oldGrade, Optional<Grade> newGrade) {
-        parents.forEach(p -> {
-            p.updateChildQualityEvaluationAverage(oldGrade, newGrade);
-            var parentsParents = p.getParentNodesForQualityEvaluation();
-            updateQualityEvaluationOfRecursiveUnlocked(parentsParents, oldGrade, newGrade);
-        });
-    }
-
-    private Collection<Node> lockParentTree(Collection<Node> parents) {
-        // Flush pending changes before locking so that refresh does not discard in-memory mutations
-        // made earlier in this transaction (e.g. command.apply on the child node).
-        entityManager.flush();
-        var allNodes = collectParentTree(parents);
-        // Lock in consistent ID order to prevent deadlocks between concurrent transactions.
-        allNodes.stream().sorted(Comparator.comparing(Node::getId)).forEach(this::lockAndRefresh);
-        return allNodes;
-    }
-
-    /**
-     * Acquires a pessimistic write lock and refreshes the entity from the database.
-     * WARNING: refresh overwrites any in-memory changes not yet flushed — call flush() first
-     * if the entity (or related entities) may have been modified in this transaction.
-     */
-    private void lockAndRefresh(Node node) {
-        entityManager.lock(node, LockModeType.PESSIMISTIC_WRITE);
-        entityManager.refresh(node);
-    }
-
-    private Collection<Node> collectParentTree(Collection<Node> parents) {
-        Map<Integer, Node> nodesById = new HashMap<>();
-        collectParentTree(parents, nodesById);
-        return nodesById.values();
-    }
-
-    private void collectParentTree(Collection<Node> parents, Map<Integer, Node> nodesById) {
+            Collection<Node> parents,
+            Optional<Grade> oldGrade,
+            Optional<Grade> newGrade,
+            boolean synchronizeBeforeUpdate) {
         parents.forEach(parent -> {
-            if (parent == null || nodesById.containsKey(parent.getId())) {
-                return;
+            if (synchronizeBeforeUpdate) {
+                synchronizeChildQualityEvaluationAverage(parent);
             }
-
-            nodesById.put(parent.getId(), parent);
-            collectParentTree(parent.getParentNodesForQualityEvaluation(), nodesById);
+            parent.updateChildQualityEvaluationAverage(oldGrade, newGrade);
+            updateQualityEvaluationOfRecursiveUnlocked(
+                    parent.getParentNodesForQualityEvaluation(), oldGrade, newGrade, synchronizeBeforeUpdate);
         });
     }
+
+    private void acquireQualityEvaluationAdvisoryLock() {
+        entityManager.createNativeQuery(QUALITY_EVALUATION_ADVISORY_LOCK_QUERY).getSingleResult();
+    }
+
+    private void synchronizeChildQualityEvaluationAverage(Node node) {
+        var snapshot = getNodeQualityEvaluationSnapshot(node);
+        var childAverage = snapshot.childQualityEvaluationAverage();
+        node.setChildQualityEvaluationAverage(
+                childAverage.map(GradeAverage::getAverageSum).orElse(0),
+                childAverage.map(GradeAverage::getCount).orElse(0));
+    }
+
+    private QualityEvaluationSnapshot getNodeQualityEvaluationSnapshot(Node node) {
+        // Flush pending JPA writes so the native query sees in-tx mutations. Required because
+        // multi-parent traversals can revisit the same ancestor via different chains, and each
+        // visit re-reads the snapshot before applying its delta.
+        entityManager.flush();
+        var row = (Object[]) entityManager
+                .createNativeQuery(NODE_QUALITY_EVALUATION_SNAPSHOT_QUERY)
+                .setParameter("nodeId", node.getId())
+                .getSingleResult();
+
+        var grade = Optional.ofNullable(row[0])
+                .map(Number.class::cast)
+                .map(Number::intValue)
+                .map(Grade::fromInt);
+        var comment = Optional.ofNullable((String) row[1]);
+        var sum = Optional.ofNullable(row[2])
+                .map(Number.class::cast)
+                .map(Number::intValue)
+                .orElse(0);
+        var count = Optional.ofNullable(row[3])
+                .map(Number.class::cast)
+                .map(Number::intValue)
+                .orElse(0);
+        var childAverage =
+                count == 0 || sum == 0 ? Optional.<GradeAverage>empty() : Optional.of(new GradeAverage(sum, count));
+
+        return new QualityEvaluationSnapshot(grade, comment, childAverage);
+    }
+
+    private record QualityEvaluationSnapshot(
+            Optional<Grade> grade, Optional<String> comment, Optional<GradeAverage> childQualityEvaluationAverage) {}
 
     @Transactional
     public void updateEntireAverageTreeForNode(URI publicId) {
+        acquireQualityEvaluationAdvisoryLock();
         var node = nodeRepository
                 .findFirstByPublicId(publicId)
                 .orElseThrow(() -> new NotFoundServiceException("Node was not found"));
@@ -216,6 +265,7 @@ public class QualityEvaluationService {
 
     @Transactional
     public void updateQualityEvaluationOfAllNodes() {
+        acquireQualityEvaluationAdvisoryLock();
         nodeRepository.wipeQualityEvaluationAverages();
         var nodeStream = nodeRepository.findNodesWithQualityEvaluation();
         nodeStream.forEach(node -> updateQualityEvaluationOfParents(

--- a/taxonomy-api/src/test/java/no/ndla/taxonomy/service/QualityEvaluationServiceConcurrencyTest.java
+++ b/taxonomy-api/src/test/java/no/ndla/taxonomy/service/QualityEvaluationServiceConcurrencyTest.java
@@ -9,6 +9,7 @@ package no.ndla.taxonomy.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
 
 import java.net.URI;
 import java.util.List;
@@ -20,8 +21,12 @@ import java.util.concurrent.TimeUnit;
 import no.ndla.taxonomy.domain.Builder;
 import no.ndla.taxonomy.domain.Grade;
 import no.ndla.taxonomy.domain.Node;
+import no.ndla.taxonomy.domain.NodeConnectionType;
 import no.ndla.taxonomy.domain.NodeType;
+import no.ndla.taxonomy.domain.Relevance;
 import no.ndla.taxonomy.domain.UpdateOrDelete;
+import no.ndla.taxonomy.integration.DraftApiClient;
+import no.ndla.taxonomy.repositories.NodeConnectionRepository;
 import no.ndla.taxonomy.repositories.NodeRepository;
 import no.ndla.taxonomy.rest.v1.commands.NodePostPut;
 import no.ndla.taxonomy.service.dtos.QualityEvaluationDTO;
@@ -41,6 +46,9 @@ class QualityEvaluationServiceConcurrencyTest extends AbstractIntegrationTest {
     private NodeRepository nodeRepository;
 
     @Autowired
+    private NodeConnectionRepository nodeConnectionRepository;
+
+    @Autowired
     private QualityEvaluationService qualityEvaluationService;
 
     @Autowired
@@ -50,10 +58,17 @@ class QualityEvaluationServiceConcurrencyTest extends AbstractIntegrationTest {
     private PlatformTransactionManager transactionManager;
 
     private TransactionTemplate transactionTemplate;
+    private NodeConnectionServiceImpl connectionService;
 
     @BeforeEach
     void setUp() {
         transactionTemplate = new TransactionTemplate(transactionManager);
+        connectionService = new NodeConnectionServiceImpl(
+                nodeConnectionRepository,
+                mock(ContextUpdaterService.class),
+                nodeRepository,
+                qualityEvaluationService,
+                mock(DraftApiClient.class));
         nodeRepository.deleteAllAndFlush();
     }
 
@@ -84,12 +99,90 @@ class QualityEvaluationServiceConcurrencyTest extends AbstractIntegrationTest {
         var updatedParent = transactionTemplate.execute(status -> nodeRepository.getByPublicId(parentId));
         var average = updatedParent.getChildQualityEvaluationAverage().orElseThrow();
 
-        assertEquals(1, average.getCount()); // Should be 2
-        // assertEquals(4.5, average.getAverageValue());
+        assertEquals(2, average.getCount());
+        assertEquals(4.5, average.getAverageValue());
     }
 
     @Test
-    void concurrent_updates_to_same_child_should_refresh_old_grade_before_updating_parents() throws Exception {
+    void concurrent_branch_connections_to_same_parent_should_not_lose_quality_evaluation_deltas() throws Exception {
+        var ids = transactionTemplate.execute(status -> {
+            var parent =
+                    builder.node(NodeType.TOPIC, node -> node.name("Parent").publicId("urn:topic:3"));
+            var firstChild = builder.node(
+                    NodeType.RESOURCE,
+                    node -> node.name("First child").publicId("urn:resource:3").qualityEvaluation(Grade.Five));
+            var secondChild = builder.node(
+                    NodeType.RESOURCE,
+                    node -> node.name("Second child").publicId("urn:resource:4").qualityEvaluation(Grade.Four));
+
+            return List.of(parent.getPublicId(), firstChild.getPublicId(), secondChild.getPublicId());
+        });
+        var parentId = ids.get(0);
+
+        var loadedParent = new CountDownLatch(2);
+        var startConnections = new CountDownLatch(1);
+
+        try (ExecutorService executor = Executors.newFixedThreadPool(2)) {
+            var firstConnection =
+                    executor.submit(() -> connectChild(parentId, ids.get(1), loadedParent, startConnections));
+            var secondConnection =
+                    executor.submit(() -> connectChild(parentId, ids.get(2), loadedParent, startConnections));
+
+            assertTrue(loadedParent.await(5, TimeUnit.SECONDS));
+            startConnections.countDown();
+
+            firstConnection.get(5, TimeUnit.SECONDS);
+            secondConnection.get(5, TimeUnit.SECONDS);
+        }
+
+        var updatedParent = transactionTemplate.execute(status -> nodeRepository.getByPublicId(parentId));
+        var average = updatedParent.getChildQualityEvaluationAverage().orElseThrow();
+
+        assertEquals(2, average.getCount());
+        assertEquals(4.5, average.getAverageValue());
+    }
+
+    @Test
+    void concurrent_branch_connection_deletes_from_same_parent_should_not_lose_quality_evaluation_deltas()
+            throws Exception {
+        var ids = transactionTemplate.execute(status -> {
+            var parent = builder.node(
+                    NodeType.TOPIC,
+                    node -> node.name("Parent")
+                            .publicId("urn:topic:4")
+                            .resource(resource -> resource.name("First child")
+                                    .publicId("urn:resource:5")
+                                    .qualityEvaluation(Grade.Five))
+                            .resource(resource -> resource.name("Second child")
+                                    .publicId("urn:resource:6")
+                                    .qualityEvaluation(Grade.Four)));
+
+            return List.of(parent.getPublicId(), URI.create("urn:resource:5"), URI.create("urn:resource:6"));
+        });
+        var parentId = ids.get(0);
+        qualityEvaluationService.updateEntireAverageTreeForNode(parentId);
+
+        var loadedParent = new CountDownLatch(2);
+        var startDeletes = new CountDownLatch(1);
+
+        try (ExecutorService executor = Executors.newFixedThreadPool(2)) {
+            var firstDelete = executor.submit(() -> disconnectChild(parentId, ids.get(1), loadedParent, startDeletes));
+            var secondDelete = executor.submit(() -> disconnectChild(parentId, ids.get(2), loadedParent, startDeletes));
+
+            assertTrue(loadedParent.await(5, TimeUnit.SECONDS));
+            startDeletes.countDown();
+
+            firstDelete.get(5, TimeUnit.SECONDS);
+            secondDelete.get(5, TimeUnit.SECONDS);
+        }
+
+        var updatedParent = transactionTemplate.execute(status -> nodeRepository.getByPublicId(parentId));
+
+        assertTrue(updatedParent.getChildQualityEvaluationAverage().isEmpty());
+    }
+
+    @Test
+    void concurrent_updates_to_same_child_should_load_old_grade_after_waiting_for_lock() throws Exception {
         var ids = transactionTemplate.execute(status -> {
             builder.node(
                     NodeType.TOPIC,
@@ -108,24 +201,23 @@ class QualityEvaluationServiceConcurrencyTest extends AbstractIntegrationTest {
 
         qualityEvaluationService.updateEntireAverageTreeForNode(parentId);
 
-        // Sequence: background thread loads the child (stale read), then pauses.
-        // Main thread updates child grade Three->Four and commits.
-        // Background thread resumes with stale state — the lock+refresh should
-        // make it see grade Four (not Three) as the old grade before applying Five.
-        var staleChildLoaded = new CountDownLatch(1);
-        var continueStaleUpdate = new CountDownLatch(1);
+        var firstUpdateLoadedChild = new CountDownLatch(1);
+        var continueFirstUpdate = new CountDownLatch(1);
+        var secondUpdateReadyForLock = new CountDownLatch(1);
 
-        try (ExecutorService executor = Executors.newSingleThreadExecutor()) {
+        try (ExecutorService executor = Executors.newFixedThreadPool(2)) {
+            var firstUpdate = executor.submit(() -> applyNodeQualityEvaluationUpdate(
+                    childId, Grade.Five, null, firstUpdateLoadedChild, continueFirstUpdate));
+
+            assertTrue(firstUpdateLoadedChild.await(5, TimeUnit.SECONDS));
+
             var secondUpdate = executor.submit(
-                    () -> applyNodeQualityEvaluationUpdate(childId, Grade.Five, staleChildLoaded, continueStaleUpdate));
+                    () -> applyNodeQualityEvaluationUpdate(childId, Grade.Four, secondUpdateReadyForLock, null, null));
 
-            assertTrue(staleChildLoaded.await(5, TimeUnit.SECONDS));
+            assertTrue(secondUpdateReadyForLock.await(5, TimeUnit.SECONDS));
+            continueFirstUpdate.countDown();
 
-            // First update commits Three->Four while the background thread is paused.
-            applyNodeQualityEvaluationUpdate(childId, Grade.Four);
-
-            // Unblock background thread — it should refresh and see Four as old grade.
-            continueStaleUpdate.countDown();
+            firstUpdate.get(5, TimeUnit.SECONDS);
             secondUpdate.get(5, TimeUnit.SECONDS);
         }
 
@@ -133,7 +225,7 @@ class QualityEvaluationServiceConcurrencyTest extends AbstractIntegrationTest {
         var average = updatedParent.getChildQualityEvaluationAverage().orElseThrow();
 
         assertEquals(1, average.getCount());
-        assertEquals(5.0, average.getAverageValue());
+        assertEquals(4.0, average.getAverageValue());
     }
 
     private void applyQualityDelta(
@@ -148,18 +240,50 @@ class QualityEvaluationServiceConcurrencyTest extends AbstractIntegrationTest {
         });
     }
 
+    private void connectChild(URI parentId, URI childId, CountDownLatch loadedParent, CountDownLatch startConnections) {
+        var template = new TransactionTemplate(transactionManager);
+        template.executeWithoutResult(status -> {
+            Node parent = nodeRepository.getByPublicId(parentId);
+            Node child = nodeRepository.getByPublicId(childId);
+            loadedParent.countDown();
+            await(startConnections);
+            connectionService.connectParentChild(
+                    parent, child, Relevance.CORE, null, Optional.empty(), NodeConnectionType.BRANCH);
+        });
+    }
+
+    private void disconnectChild(URI parentId, URI childId, CountDownLatch loadedParent, CountDownLatch startDeletes) {
+        var template = new TransactionTemplate(transactionManager);
+        template.executeWithoutResult(status -> {
+            Node parent = nodeRepository.getByPublicId(parentId);
+            Node child = nodeRepository.getByPublicId(childId);
+            loadedParent.countDown();
+            await(startDeletes);
+            connectionService.disconnectParentChild(parent, child);
+        });
+    }
+
     private void applyNodeQualityEvaluationUpdate(URI nodeId, Grade grade) {
-        applyNodeQualityEvaluationUpdate(nodeId, grade, null, null);
+        applyNodeQualityEvaluationUpdate(nodeId, grade, null, null, null);
     }
 
     private void applyNodeQualityEvaluationUpdate(
-            URI nodeId, Grade grade, CountDownLatch loadedNode, CountDownLatch continueUpdate) {
+            URI nodeId,
+            Grade grade,
+            CountDownLatch readyForLock,
+            CountDownLatch loadedNode,
+            CountDownLatch continueUpdate) {
         var template = new TransactionTemplate(transactionManager);
         template.executeWithoutResult(status -> {
-            Node node = nodeRepository.getByPublicId(nodeId);
             var command = new NodePostPut();
             command.qualityEvaluation = UpdateOrDelete.Update(new QualityEvaluationDTO(grade, Optional.empty()));
 
+            if (readyForLock != null) {
+                readyForLock.countDown();
+            }
+            qualityEvaluationService.lockQualityEvaluationIfNeeded(command);
+
+            var node = nodeRepository.getByPublicId(nodeId);
             if (loadedNode != null) {
                 loadedNode.countDown();
             }
@@ -167,11 +291,9 @@ class QualityEvaluationServiceConcurrencyTest extends AbstractIntegrationTest {
                 await(continueUpdate);
             }
 
-            qualityEvaluationService.lockNodeForQualityEvaluationUpdate(node, command);
-
             var oldGrade = node.getQualityEvaluationGrade();
             command.apply(node);
-            qualityEvaluationService.updateQualityEvaluationOfParents(node, oldGrade, command);
+            qualityEvaluationService.updateQualityEvaluationOfParentsFromFreshlyLoadedNode(node, oldGrade, command);
         });
     }
 


### PR DESCRIPTION
Erstatter https://github.com/NDLANO/backend/pull/932

Dette burde speede opp låsingen av kvalitetsvurdering relativt drastisk.

Erstatter pessimistisk låsing + `entityManager.refresh()` med en transaksjons-scoped advisory lock i Postgres for å serialisere oppdateringer av kvalitetsvudering.

Den gamle løsningen mistet endringer ved samtidige oppdateringer av noder med samme forelder fordi:

- `oldGrade` ble lest før låsen ble tatt, så to parallelle
  oppdateringer kunne begge se samme utgangspunkt.
- Parent-grafen ble traversert med potensielt utdaterte `child_quality_evaluation_sum/count` fra bibernate cache, slik at to traverseringer overskrev hverandres endring.

Denne PR'en endrer:


- Advisory lock låsen tas i `CrudController.updateEntity`/
  `createEntity` _før_ entiteten lastes, og i
  `NodeConnectionServiceImpl.connectParentChild` _før_ parent-grafen lastes.
- Synkronisering per node: ny `synchronizeChildQualityEvaluationAverage`
  leser `sum`/`count` på nytt via native query for hver forelder
  som besøkes under traverseringen, slik at utregningen alltid
  bruker commita data.
- Connection-mutasjoner: `updateQualityEvaluationOfNewConnection`
  og `removeQualityEvaluationOfDeletedConnection` låser og
  henter et fersk snapshot av barnet via native query istedenfor å
  stole på in-memory hibernate magien.
- `CrudController.deleteEntity` er nå abstrakt — den gamle
  default-implementasjonen ble bare brukt av `ResourceTypes`, og
  noden-sletting går uansett gjennom `nodeService.delete` som
  håndterer kvalitetsvurdering-oppdatering via connection-disconnect.
  - Litt beside the point, men følte jeg var nære nok til å endre akkurat denne.
  - Vi bør nok ta en ordentlig gjennomgang av hva som arver fra `CurdController` og rydde i disse "multi" funksjonene som baserer seg på å null-sjekke hvorvidt services har blitt lastet for å bestemme funksjonalitet. Det er veldig lett for at dette feiler stille fremfor å kræsje og bli oppdaget.


Ytelsen er _nesten_ like god som [denne](https://github.com/NDLANO/backend/pull/932) (på min maskin i alle fall), men veldig mye chillere å lese om du spør meg (Fortsatt spring da hehe).