### PR TITLE
fix(taxonomy-api): add programme to `nodeTypeMapping` for urls

### DIFF
--- a/taxonomy-api/src/main/java/no/ndla/taxonomy/util/PrettyUrlUtil.java
+++ b/taxonomy-api/src/main/java/no/ndla/taxonomy/util/PrettyUrlUtil.java
@@ -53,7 +53,8 @@ public class PrettyUrlUtil {
             case SUBJECT -> "/f";
             case TOPIC, CASE -> "/e";
             case RESOURCE -> "/r";
-            default -> "";
+            case PROGRAMME -> "/utdanning";
+            case NODE -> "";
         };
     }
 


### PR DESCRIPTION
Så i matomo magien til guttorm at `/utdanning` manglet fra custom url'er.
Dette fikser det :^)
