### PR TITLE
feat(image-api): add redirect to S3 and download param in `RawController`

### DIFF
--- a/common/src/main/scala/no/ndla/common/aws/NdlaS3Client.scala
+++ b/common/src/main/scala/no/ndla/common/aws/NdlaS3Client.scala
@@ -62,6 +62,11 @@ class NdlaS3Client(bucket: String, region: Option[String]) {
       }
   }
 
+  def getUrl(key: String): Try[String] = Try {
+    val gur = GetUrlRequest.builder().bucket(bucket).key(key).build()
+    client.utilities().getUrl(gur).toString
+  }
+
   def deleteObject(key: String): Try[DeleteObjectResponse] = Try.throwIfInterrupted {
     val dor = DeleteObjectRequest.builder().key(key).bucket(bucket).build()
     client.deleteObject(dor)

--- a/image-api/src/main/scala/no/ndla/imageapi/controller/ImageParams.scala
+++ b/image-api/src/main/scala/no/ndla/imageapi/controller/ImageParams.scala
@@ -47,9 +47,14 @@ case class ImageParams(
   ratio: Option[Double],
   @query
   @description("The wanted aspect ratio, defined as width/height. To be used together with the focal parameters. If used the width and height is ignored and derived from the aspect ratio instead.")
-  language: Option[String]
-)
+  language: Option[String],
+  @query
+  @description("Whether the image should be downloaded or not. Only the presence of this parameter is needed.")
+  download: Option[String],
 // format: on
+) {
+  def isEmpty: Boolean = this == ImageParams.empty
+}
 
 object ImageParams {
   def empty: ImageParams = ImageParams(
@@ -65,5 +70,6 @@ object ImageParams {
     focalY = None,
     ratio = None,
     language = None,
+    download = None,
   )
 }

--- a/image-api/src/main/scala/no/ndla/imageapi/controller/ImageResponse.scala
+++ b/image-api/src/main/scala/no/ndla/imageapi/controller/ImageResponse.scala
@@ -1,0 +1,39 @@
+/*
+ * Part of NDLA image-api
+ * Copyright (C) 2026 NDLA
+ *
+ * See LICENSE
+ *
+ */
+
+package no.ndla.imageapi.controller
+
+import sttp.model.{HeaderNames, StatusCode}
+import sttp.tapir.*
+
+import java.io.InputStream
+
+sealed trait ImageResponse
+
+object ImageResponse {
+  case class Stream(
+      inputStream: InputStream,
+      contentType: String,
+      contentLength: String,
+      contentDisposition: Option[String],
+  ) extends ImageResponse
+
+  case class Redirect(url: String) extends ImageResponse
+
+  val endpointOutput: EndpointOutput.OneOf[ImageResponse, ImageResponse] = oneOf(
+    oneOfVariant(
+      statusCode(StatusCode.Ok)
+        .and(inputStreamBody)
+        .and(header[String](HeaderNames.ContentType))
+        .and(header[String](HeaderNames.ContentLength))
+        .and(header[Option[String]](HeaderNames.ContentDisposition))
+        .mapTo[Stream]
+    ),
+    oneOfVariant(statusCode(StatusCode.Found).and(header[String](HeaderNames.Location)).mapTo[Redirect]),
+  )
+}

--- a/image-api/src/main/scala/no/ndla/imageapi/controller/RawController.scala
+++ b/image-api/src/main/scala/no/ndla/imageapi/controller/RawController.scala
@@ -13,12 +13,11 @@ import no.ndla.common.errors.{MissingBucketKeyException, ValidationException, Va
 import no.ndla.imageapi.model.domain.{ImageStream, ProcessableImage}
 import no.ndla.imageapi.service.*
 import no.ndla.network.clients.MyNDLAApiClient
-import no.ndla.network.tapir.TapirUtil.errorOutputsFor
 import no.ndla.network.tapir.*
+import no.ndla.network.tapir.TapirUtil.errorOutputsFor
 import sttp.tapir.*
 import sttp.tapir.server.ServerEndpoint
 
-import java.io.InputStream
 import scala.util.{Failure, Success, Try}
 
 class RawController(using
@@ -37,14 +36,6 @@ class RawController(using
 
   override val endpoints: List[ServerEndpoint[Any, Eff]] = List(getImageFileById, getImageFile)
 
-  private def toImageResponse(image: ImageStream): Either[AllErrors, (DynamicHeaders, InputStream)] = {
-    val headers = DynamicHeaders.fromValues(
-      "Content-Type"   -> image.contentType.toString,
-      "Content-Length" -> image.contentLength.toString,
-    )
-    Right(headers -> image.stream)
-  }
-
   def getImageFile: ServerEndpoint[Any, Eff] = endpoint
     .get
     .summary("Fetch an image with options to resize and crop")
@@ -52,14 +43,8 @@ class RawController(using
     .in(path[String]("image_name").description("The name of the image"))
     .in(EndpointInput.derived[ImageParams])
     .errorOut(errorOutputsFor(404))
-    .out(EndpointOutput.derived[DynamicHeaders])
-    .out(inputStreamBody)
-    .serverLogicPure { case (filePath, imageParams) =>
-      getRawImage(filePath, imageParams) match {
-        case Failure(ex)  => returnLeftError(ex)
-        case Success(img) => toImageResponse(img)
-      }
-    }
+    .out(ImageResponse.endpointOutput)
+    .serverLogicPure(getImageResponse)
 
   def getImageFileById: ServerEndpoint[Any, Eff] = endpoint
     .get
@@ -68,16 +53,27 @@ class RawController(using
     .in("id" / path[Long]("image_id").description("The ID of the image"))
     .in(EndpointInput.derived[ImageParams])
     .errorOut(errorOutputsFor(404))
-    .out(EndpointOutput.derived[DynamicHeaders])
-    .out(inputStreamBody)
+    .out(ImageResponse.endpointOutput)
     .serverLogicPure { case (imageId, imageParams) =>
       readService.getImageFileName(imageId, imageParams.language) match {
-        case Success(Some(fileName)) => getRawImage(fileName, imageParams) match {
-            case Failure(ex)  => returnLeftError(ex)
-            case Success(img) => toImageResponse(img)
-          }
-        case Success(None) => notFoundWithMsg(s"Image with id $imageId not found").asLeft
-        case Failure(ex)   => returnLeftError(ex)
+        case Success(Some(fileName)) => getImageResponse(fileName, imageParams)
+        case Success(None)           => notFoundWithMsg(s"Image with id $imageId not found").asLeft
+        case Failure(ex)             => returnLeftError(ex)
+      }
+    }
+
+  private def getImageResponse(fileName: String, imageParams: ImageParams): Try[ImageResponse] =
+    if (imageParams.isEmpty) {
+      imageStorage.getUrl(fileName).map(ImageResponse.Redirect.apply)
+    } else {
+      getRawImage(fileName, imageParams).map { imageStream =>
+        val contentDisposition = imageParams.download.map(_ => "attachment")
+        ImageResponse.Stream(
+          imageStream.stream,
+          imageStream.contentType.toString,
+          imageStream.contentLength.toString,
+          contentDisposition,
+        )
       }
     }
 

--- a/image-api/src/main/scala/no/ndla/imageapi/service/ImageStorageService.scala
+++ b/image-api/src/main/scala/no/ndla/imageapi/service/ImageStorageService.scala
@@ -52,6 +52,8 @@ class ImageStorageService(using
 
   def getRaw(bucketKey: String): Try[NdlaS3Object] = s3Client.getObject(bucketKey)
 
+  def getUrl(bucketKey: String): Try[String] = s3Client.getUrl(bucketKey)
+
   def uploadFromStream(
       storageKey: String,
       stream: InputStream,

--- a/image-api/src/test/scala/no/ndla/imageapi/controller/RawControllerTest.scala
+++ b/image-api/src/test/scala/no/ndla/imageapi/controller/RawControllerTest.scala
@@ -48,18 +48,10 @@ class RawControllerTest extends UnitSuite with TestEnvironment with TapirControl
     when(clock.now()).thenCallRealMethod()
   }
 
-  test("That GET /image.jpg returns 200 if image was found") {
-    val res = simpleHttpClient.send(req.get(uri"http://localhost:$serverPort/image-api/raw/$imageName"))
-    res.code.code should be(200)
-
-    val image = ImageIO.read(new ByteArrayInputStream(res.body))
-    image.getWidth should equal(189)
-    image.getHeight should equal(60)
-  }
-
-  test("That GET /image.jpg returns 404 if image was not found") {
+  test("That GET /image.jpg with image params returns 404 if image was not found") {
     when(imageStorage.get(any[String])).thenReturn(Failure(new ImageNotFoundException("Image not found")))
-    val res = simpleHttpClient.send[Array[Byte]](req.get(uri"http://localhost:$serverPort/image-api/raw/$imageName"))
+    val res =
+      simpleHttpClient.send[Array[Byte]](req.get(uri"http://localhost:$serverPort/image-api/raw/$imageName?width=100"))
     res.code.code should be(404)
   }
 
@@ -109,17 +101,9 @@ class RawControllerTest extends UnitSuite with TestEnvironment with TapirControl
     image.getHeight should equal(15)
   }
 
-  test("GET /id/1 returns 200 if the image was found") {
-    val res = simpleHttpClient.send(req.get(uri"http://localhost:$serverPort/image-api/raw/id/$id"))
-    res.code.code should be(200)
-    val image = ImageIO.read(new ByteArrayInputStream(res.body))
-    image.getWidth should equal(189)
-    image.getHeight should equal(60)
-  }
-
-  test("That GET /id/1 returns 404 if image was not found") {
+  test("That GET /id/1 with image params returns 404 if image was not found") {
     when(imageStorage.get(any[String])).thenReturn(Failure(new ImageNotFoundException("Image not found")))
-    val res = simpleHttpClient.send(req.get(uri"http://localhost:$serverPort/image-api/raw/id/$id"))
+    val res = simpleHttpClient.send(req.get(uri"http://localhost:$serverPort/image-api/raw/id/$id?width=100"))
     res.code.code should be(404)
   }
 
@@ -271,8 +255,47 @@ class RawControllerTest extends UnitSuite with TestEnvironment with TapirControl
   test("that image is found by filename with non-ASCII characters") {
     val fileNameWithNonAsciiChars = "file æøå.svg"
     when(imageStorage.get(eqTo(fileNameWithNonAsciiChars))).thenReturn(Success(ccLogoSvgImageStream))
-    val res = simpleHttpClient.send(req.get(uri"http://localhost:$serverPort/image-api/raw/$fileNameWithNonAsciiChars"))
+    val res = simpleHttpClient.send(
+      req.get(uri"http://localhost:$serverPort/image-api/raw/$fileNameWithNonAsciiChars?width=420")
+    )
     res.code.code should equal(200)
     res.body should equal(ccLogoSvgImageStream.stream.readAllBytes())
+  }
+
+  test("that GET /image.jpg without image params returns a redirect") {
+    val s3Url = "https://s3.eu-west-1.amazonaws.com/test.images.2.ndla/image.jpg"
+    when(imageStorage.getUrl(eqTo("image.jpg"))).thenReturn(Success(s3Url))
+
+    val res =
+      simpleHttpClient.send(req.get(uri"http://localhost:$serverPort/image-api/raw/image.jpg").followRedirects(false))
+
+    res.code.code should be(302)
+    val location = res.headers.find(_.is("location")).get
+    location.value should be(s3Url)
+  }
+
+  test("that GET /id/1 without image params returns a redirect") {
+    val s3Url = s"https://s3.eu-west-1.amazonaws.com/test.images.2.ndla/${TestData.bjorn.images.head.fileName}"
+    when(imageStorage.getUrl(any)).thenReturn(Success(s3Url))
+
+    val res =
+      simpleHttpClient.send(req.get(uri"http://localhost:$serverPort/image-api/raw/image.jpg").followRedirects(false))
+
+    res.code.code should be(302)
+    val location = res.headers.find(_.is("location")).get
+    location.value should be(s3Url)
+  }
+
+  test("that GET /image.jpeg?download | /id/1?download sets Content-Disposition") {
+    when(imageStorage.get(any[String])).thenReturn(Success(ndlaLogoGifImageStream))
+    val res1 = simpleHttpClient.send(req.get(uri"http://localhost:$serverPort/image-api/raw/image.jpg?download"))
+
+    when(imageStorage.get(any[String])).thenReturn(Success(ndlaLogoGifImageStream))
+    val res2 = simpleHttpClient.send(req.get(uri"http://localhost:$serverPort/image-api/raw/id/1?download"))
+
+    res1.code.code should be(200)
+    res2.code.code should be(200)
+    res1.headers.find(_.is("content-disposition")).get.value should be("attachment")
+    res2.headers.find(_.is("content-disposition")).get.value should be("attachment")
   }
 }


### PR DESCRIPTION
* Redirect til S3 dersom en request ikke har noen bildeparametere
  * Har brukt `302 Found` som respons, men er det bedre med `301 Moved Permanently`?
* Støtte for `download` query parameter, som setter `Content-Disposition: attachment` på respons