### PR TITLE
feat(image-api): send `Cache-Control` header in `RawController`

### DIFF
--- a/image-api/src/main/scala/no/ndla/imageapi/ImageApiProperties.scala
+++ b/image-api/src/main/scala/no/ndla/imageapi/ImageApiProperties.scala
@@ -34,8 +34,9 @@ class ImageApiProperties extends BaseProps with DatabaseProps with StrictLogging
 
   val ValidMimeTypes: Seq[ImageContentType] = ImageContentType.values
 
-  val IsoMappingCacheAgeInMs: Int     = 1000 * 60 * 60 // 1 hour caching
-  val LicenseMappingCacheAgeInMs: Int = 1000 * 60 * 60 // 1 hour caching
+  val IsoMappingCacheAgeInMs: Int       = 1000 * 60 * 60 // 1 hour caching
+  val LicenseMappingCacheAgeInMs: Int   = 1000 * 60 * 60 // 1 hour caching
+  val RawControllerCacheControl: String = "max-age=31536000, stale-while-revalidate=86400, stale-if-error=86400"
 
   val MaxImageFileSizeBytes: Int    = 1024 * 1024 * 40 // 40 MiB
   val ImageScalingUltraMinSize: Int = propOrElse("IMAGE_SCALING_ULTRA_MIN_SIZE", "640").toInt

--- a/image-api/src/main/scala/no/ndla/imageapi/controller/ImageResponse.scala
+++ b/image-api/src/main/scala/no/ndla/imageapi/controller/ImageResponse.scala
@@ -1,0 +1,26 @@
+/*
+ * Part of NDLA image-api
+ * Copyright (C) 2026 NDLA
+ *
+ * See LICENSE
+ *
+ */
+
+package no.ndla.imageapi.controller
+
+import no.ndla.imageapi.Props
+import sttp.model.{HeaderNames, StatusCode}
+import sttp.tapir.*
+
+import java.io.InputStream
+
+case class ImageResponse(inputStream: InputStream, contentType: String, contentLength: String)
+
+object ImageResponse {
+  def endpointOutput(using props: Props): EndpointOutput[ImageResponse] = statusCode(StatusCode.Ok)
+    .and(inputStreamBody)
+    .and(header[String](HeaderNames.ContentType))
+    .and(header[String](HeaderNames.ContentLength))
+    .and(header(HeaderNames.CacheControl, props.RawControllerCacheControl))
+    .mapTo[ImageResponse]
+}

--- a/image-api/src/main/scala/no/ndla/imageapi/controller/RawController.scala
+++ b/image-api/src/main/scala/no/ndla/imageapi/controller/RawController.scala
@@ -10,15 +10,15 @@ package no.ndla.imageapi.controller
 
 import cats.implicits.catsSyntaxEitherId
 import no.ndla.common.errors.{MissingBucketKeyException, ValidationException, ValidationMessage}
+import no.ndla.imageapi.Props
 import no.ndla.imageapi.model.domain.{ImageStream, ProcessableImage}
 import no.ndla.imageapi.service.*
 import no.ndla.network.clients.MyNDLAApiClient
-import no.ndla.network.tapir.TapirUtil.errorOutputsFor
 import no.ndla.network.tapir.*
+import no.ndla.network.tapir.TapirUtil.errorOutputsFor
 import sttp.tapir.*
 import sttp.tapir.server.ServerEndpoint
 
-import java.io.InputStream
 import scala.util.{Failure, Success, Try}
 
 class RawController(using
@@ -28,6 +28,7 @@ class RawController(using
     errorHandling: ErrorHandling,
     readService: ReadService,
     myNDLAApiClient: MyNDLAApiClient,
+    props: Props,
 ) extends TapirController {
   import errorHandling.*
   import errorHelpers.*
@@ -37,14 +38,6 @@ class RawController(using
 
   override val endpoints: List[ServerEndpoint[Any, Eff]] = List(getImageFileById, getImageFile)
 
-  private def toImageResponse(image: ImageStream): Either[AllErrors, (DynamicHeaders, InputStream)] = {
-    val headers = DynamicHeaders.fromValues(
-      "Content-Type"   -> image.contentType.toString,
-      "Content-Length" -> image.contentLength.toString,
-    )
-    Right(headers -> image.stream)
-  }
-
   def getImageFile: ServerEndpoint[Any, Eff] = endpoint
     .get
     .summary("Fetch an image with options to resize and crop")
@@ -52,14 +45,8 @@ class RawController(using
     .in(path[String]("image_name").description("The name of the image"))
     .in(EndpointInput.derived[ImageParams])
     .errorOut(errorOutputsFor(404))
-    .out(EndpointOutput.derived[DynamicHeaders])
-    .out(inputStreamBody)
-    .serverLogicPure { case (filePath, imageParams) =>
-      getRawImage(filePath, imageParams) match {
-        case Failure(ex)  => returnLeftError(ex)
-        case Success(img) => toImageResponse(img)
-      }
-    }
+    .out(ImageResponse.endpointOutput)
+    .serverLogicPure(getImageResponse)
 
   def getImageFileById: ServerEndpoint[Any, Eff] = endpoint
     .get
@@ -68,17 +55,18 @@ class RawController(using
     .in("id" / path[Long]("image_id").description("The ID of the image"))
     .in(EndpointInput.derived[ImageParams])
     .errorOut(errorOutputsFor(404))
-    .out(EndpointOutput.derived[DynamicHeaders])
-    .out(inputStreamBody)
+    .out(ImageResponse.endpointOutput)
     .serverLogicPure { case (imageId, imageParams) =>
       readService.getImageFileName(imageId, imageParams.language) match {
-        case Success(Some(fileName)) => getRawImage(fileName, imageParams) match {
-            case Failure(ex)  => returnLeftError(ex)
-            case Success(img) => toImageResponse(img)
-          }
-        case Success(None) => notFoundWithMsg(s"Image with id $imageId not found").asLeft
-        case Failure(ex)   => returnLeftError(ex)
+        case Success(Some(fileName)) => getImageResponse(fileName, imageParams)
+        case Success(None)           => notFoundWithMsg(s"Image with id $imageId not found").asLeft
+        case Failure(ex)             => returnLeftError(ex)
       }
+    }
+
+  private def getImageResponse(fileName: String, imageParams: ImageParams): Try[ImageResponse] =
+    getRawImage(fileName, imageParams).map { imageStream =>
+      ImageResponse(imageStream.stream, imageStream.contentType.toString, imageStream.contentLength.toString)
     }
 
   private def getRawImage(imageName: String, imageParams: ImageParams): Try[ImageStream] = {

--- a/image-api/src/test/scala/no/ndla/imageapi/controller/RawControllerTest.scala
+++ b/image-api/src/test/scala/no/ndla/imageapi/controller/RawControllerTest.scala
@@ -43,7 +43,7 @@ class RawControllerTest extends UnitSuite with TestEnvironment with TapirControl
   override def beforeEach(): Unit = {
     reset(clock)
     when(imageRepository.withId(id)).thenReturn(Success(Some(TestData.bjorn)))
-    when(imageStorage.get(any[String])).thenReturn(Success(TestData.ndlaLogoImageStream))
+    when(imageStorage.get(any[String])).thenAnswer(_ => Success(TestData.ndlaLogoImageStream))
     when(readService.getImageFileName(id, None)).thenReturn(Success(Some(TestData.bjorn.images.head.fileName)))
     when(clock.now()).thenCallRealMethod()
   }
@@ -274,5 +274,15 @@ class RawControllerTest extends UnitSuite with TestEnvironment with TapirControl
     val res = simpleHttpClient.send(req.get(uri"http://localhost:$serverPort/image-api/raw/$fileNameWithNonAsciiChars"))
     res.code.code should equal(200)
     res.body should equal(ccLogoSvgImageStream.stream.readAllBytes())
+  }
+
+  test("That GET /image.jpg | /id/1 sets Cache-Control headers") {
+    val res1 = simpleHttpClient.send(req.get(uri"http://localhost:$serverPort/image-api/raw/$imageName"))
+    val res2 = simpleHttpClient.send(req.get(uri"http://localhost:$serverPort/image-api/raw/id/$id"))
+
+    res1.code.code should be(200)
+    res2.code.code should be(200)
+    res1.headers.find(_.is("cache-control")).get.value should be(props.RawControllerCacheControl)
+    res2.headers.find(_.is("cache-control")).get.value should be(props.RawControllerCacheControl)
   }
 }


### PR DESCRIPTION
Legger til `Cache-Control` header på bilder fra `RawController` for å instruere CloudFront til å ta vare på bildene i 1 år, siden vi uansett har manuell invalidering når bilder endres i ED.

Legger også på `stale-while-revalidate` for at CloudFront skal kunne bruke bilder i cachen selv om de har utløpt, og henter nye bilder fra image-api i bakgrunnen.

`stale-if-error` lar CloudFront sende et cache'et bilde selv om image-api svarer med feil.