### PR TITLE
feat(image-api): add `download` param in `RawController`

### DIFF
--- a/image-api/src/main/scala/no/ndla/imageapi/controller/ImageParams.scala
+++ b/image-api/src/main/scala/no/ndla/imageapi/controller/ImageParams.scala
@@ -47,7 +47,10 @@ case class ImageParams(
   ratio: Option[Double],
   @query
   @description("The wanted aspect ratio, defined as width/height. To be used together with the focal parameters. If used the width and height is ignored and derived from the aspect ratio instead.")
-  language: Option[String]
+  language: Option[String],
+  @query
+  @description("Whether the image should be downloaded or not. Only the presence of this parameter is needed.")
+  download: Option[String],
 )
 // format: on
 
@@ -65,5 +68,6 @@ object ImageParams {
     focalY = None,
     ratio = None,
     language = None,
+    download = None,
   )
 }

--- a/image-api/src/main/scala/no/ndla/imageapi/controller/ImageResponse.scala
+++ b/image-api/src/main/scala/no/ndla/imageapi/controller/ImageResponse.scala
@@ -14,13 +14,19 @@ import sttp.tapir.*
 
 import java.io.InputStream
 
-case class ImageResponse(inputStream: InputStream, contentType: String, contentLength: String)
+case class ImageResponse(
+    inputStream: InputStream,
+    contentType: String,
+    contentLength: String,
+    contentDisposition: Option[String],
+)
 
 object ImageResponse {
   def endpointOutput(using props: Props): EndpointOutput[ImageResponse] = statusCode(StatusCode.Ok)
     .and(inputStreamBody)
     .and(header[String](HeaderNames.ContentType))
     .and(header[String](HeaderNames.ContentLength))
+    .and(header[Option[String]](HeaderNames.ContentDisposition))
     .and(header(HeaderNames.CacheControl, props.RawControllerCacheControl))
     .mapTo[ImageResponse]
 }

--- a/image-api/src/main/scala/no/ndla/imageapi/controller/RawController.scala
+++ b/image-api/src/main/scala/no/ndla/imageapi/controller/RawController.scala
@@ -76,12 +76,18 @@ class RawController(using
     .serverLogicPure { (fileName, variantName) =>
       imageStorage
         .getRaw(s"$fileName/$variantName")
-        .map(s3Object => ImageResponse(s3Object.stream, s3Object.contentType, s3Object.contentLength.toString))
+        .map(s3Object => ImageResponse(s3Object.stream, s3Object.contentType, s3Object.contentLength.toString, None))
     }
 
   private def getImageResponse(fileName: String, imageParams: ImageParams): Try[ImageResponse] =
     getRawImage(fileName, imageParams).map { imageStream =>
-      ImageResponse(imageStream.stream, imageStream.contentType.toString, imageStream.contentLength.toString)
+      val contentDisposition = imageParams.download.map(_ => "attachment")
+      ImageResponse(
+        imageStream.stream,
+        imageStream.contentType.toString,
+        imageStream.contentLength.toString,
+        contentDisposition,
+      )
     }
 
   private def getRawImage(imageName: String, imageParams: ImageParams): Try[ImageStream] = {

--- a/image-api/src/test/scala/no/ndla/imageapi/controller/RawControllerTest.scala
+++ b/image-api/src/test/scala/no/ndla/imageapi/controller/RawControllerTest.scala
@@ -296,4 +296,17 @@ class RawControllerTest extends UnitSuite with TestEnvironment with TapirControl
     res.code.code should be(200)
     res.body should be(TestData.ndlaLogoImageS3Object.stream.readAllBytes())
   }
+
+  test("that GET /image.jpeg?download | /id/1?download sets Content-Disposition") {
+    when(imageStorage.get(any[String])).thenReturn(Success(ndlaLogoGifImageStream))
+    val res1 = simpleHttpClient.send(req.get(uri"http://localhost:$serverPort/image-api/raw/image.jpg?download"))
+
+    when(imageStorage.get(any[String])).thenReturn(Success(ndlaLogoGifImageStream))
+    val res2 = simpleHttpClient.send(req.get(uri"http://localhost:$serverPort/image-api/raw/id/1?download"))
+
+    res1.code.code should be(200)
+    res2.code.code should be(200)
+    res1.headers.find(_.is("content-disposition")).get.value should be("attachment")
+    res2.headers.find(_.is("content-disposition")).get.value should be("attachment")
+  }
 }


### PR DESCRIPTION
Legger til `download` parameter som setter `Content-Disposition: attachment` for å kunne laste ned bilder.

Hadde allerede gjort dette i en branch så lagde en PR på det, men vi kan egentlig bruke kgateway til dette hvis vi har lyst.