### PR TITLE
feat(image-api): support image variants in `RawController`

### DIFF
--- a/image-api/src/main/scala/no/ndla/imageapi/controller/RawController.scala
+++ b/image-api/src/main/scala/no/ndla/imageapi/controller/RawController.scala
@@ -36,19 +36,10 @@ class RawController(using
   override val prefix: EndpointInput[Unit] = "image-api" / serviceName
   override val enableSwagger: Boolean      = true
 
-  override val endpoints: List[ServerEndpoint[Any, Eff]] = List(getImageFileById, getImageFile)
+  override val endpoints: List[ServerEndpoint[Any, Eff]] =
+    List(getImageById, getImageByFileName, getImageVariantByFileName)
 
-  def getImageFile: ServerEndpoint[Any, Eff] = endpoint
-    .get
-    .summary("Fetch an image with options to resize and crop")
-    .description("Fetches a image with options to resize and crop")
-    .in(path[String]("image_name").description("The name of the image"))
-    .in(EndpointInput.derived[ImageParams])
-    .errorOut(errorOutputsFor(404))
-    .out(ImageResponse.endpointOutput)
-    .serverLogicPure(getImageResponse)
-
-  def getImageFileById: ServerEndpoint[Any, Eff] = endpoint
+  def getImageById: ServerEndpoint[Any, Eff] = endpoint
     .get
     .summary("Fetch an image with options to resize and crop")
     .description("Fetches a image with options to resize and crop")
@@ -62,6 +53,30 @@ class RawController(using
         case Success(None)           => notFoundWithMsg(s"Image with id $imageId not found").asLeft
         case Failure(ex)             => returnLeftError(ex)
       }
+    }
+
+  def getImageByFileName: ServerEndpoint[Any, Eff] = endpoint
+    .get
+    .summary("Fetch an image with options to resize and crop")
+    .description("Fetches a image with options to resize and crop")
+    .in(path[String]("image_name").description("The name of the image"))
+    .in(EndpointInput.derived[ImageParams])
+    .errorOut(errorOutputsFor(404))
+    .out(ImageResponse.endpointOutput)
+    .serverLogicPure(getImageResponse)
+
+  def getImageVariantByFileName: ServerEndpoint[Any, Eff] = endpoint
+    .get
+    .summary("Fetch an image variant")
+    .description("Fetches a specific image variant size")
+    .in(path[String]("image_name").description("The name of the image (without file extension)").example("foobar"))
+    .in(path[String]("variant_size").description("Image variant size (with file extension)").example("medium.webp"))
+    .errorOut(errorOutputsFor(404))
+    .out(ImageResponse.endpointOutput)
+    .serverLogicPure { (fileName, variantName) =>
+      imageStorage
+        .getRaw(s"$fileName/$variantName")
+        .map(s3Object => ImageResponse(s3Object.stream, s3Object.contentType, s3Object.contentLength.toString))
     }
 
   private def getImageResponse(fileName: String, imageParams: ImageParams): Try[ImageResponse] =

--- a/image-api/src/test/scala/no/ndla/imageapi/controller/RawControllerTest.scala
+++ b/image-api/src/test/scala/no/ndla/imageapi/controller/RawControllerTest.scala
@@ -285,4 +285,15 @@ class RawControllerTest extends UnitSuite with TestEnvironment with TapirControl
     res1.headers.find(_.is("cache-control")).get.value should be(props.RawControllerCacheControl)
     res2.headers.find(_.is("cache-control")).get.value should be(props.RawControllerCacheControl)
   }
+
+  test("that GET /image/medium.webp returns 200 if image variant was found") {
+    val fileName    = "image"
+    val variantName = "medium.webp"
+    when(imageStorage.getRaw(eqTo(s"$fileName/$variantName"))).thenReturn(Success(TestData.ndlaLogoImageS3Object))
+
+    val res = simpleHttpClient.send(req.get(uri"http://localhost:$serverPort/image-api/raw/$fileName/$variantName"))
+
+    res.code.code should be(200)
+    res.body should be(TestData.ndlaLogoImageS3Object.stream.readAllBytes())
+  }
 }


### PR DESCRIPTION
Legger til støtte for å hente ut bildevarianter fra `RawController` i image-api