### PR TITLE
feat: add Matomo popular articles tracking to subject pages

### DIFF
--- a/common/src/main/scala/no/ndla/common/model/api/frontpage/PopularArticleDTO.scala
+++ b/common/src/main/scala/no/ndla/common/model/api/frontpage/PopularArticleDTO.scala
@@ -1,0 +1,22 @@
+/*
+ * Part of NDLA common
+ * Copyright (C) 2026 NDLA
+ *
+ * See LICENSE
+ *
+ */
+
+package no.ndla.common.model.api.frontpage
+
+import io.circe.*
+import io.circe.generic.semiauto.*
+import sttp.tapir.Schema
+import sttp.tapir.generic.auto.*
+
+case class PopularArticleDTO(contextId: String, numHits: Long)
+
+object PopularArticleDTO {
+  implicit def encoder: Encoder[PopularArticleDTO] = deriveEncoder[PopularArticleDTO]
+  implicit def decoder: Decoder[PopularArticleDTO] = deriveDecoder[PopularArticleDTO]
+  implicit def schema: Schema[PopularArticleDTO]   = Schema.derived[PopularArticleDTO]
+}

--- a/common/src/main/scala/no/ndla/common/model/api/frontpage/SubjectPageDTO.scala
+++ b/common/src/main/scala/no/ndla/common/model/api/frontpage/SubjectPageDTO.scala
@@ -24,6 +24,7 @@ case class SubjectPageDTO(
     connectedTo: List[String],
     buildsOn: List[String],
     leadsTo: List[String],
+    popularArticles: Seq[PopularArticleDTO],
 )
 
 object SubjectPageDTO {

--- a/common/src/main/scala/no/ndla/common/model/domain/frontpage/PopularArticle.scala
+++ b/common/src/main/scala/no/ndla/common/model/domain/frontpage/PopularArticle.scala
@@ -1,0 +1,19 @@
+/*
+ * Part of NDLA common
+ * Copyright (C) 2026 NDLA
+ *
+ * See LICENSE
+ *
+ */
+
+package no.ndla.common.model.domain.frontpage
+
+import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
+import io.circe.{Decoder, Encoder}
+
+case class PopularArticle(contextId: String, numHits: Long)
+
+object PopularArticle {
+  implicit val decoder: Decoder[PopularArticle] = deriveDecoder
+  implicit val encoder: Encoder[PopularArticle] = deriveEncoder
+}

--- a/common/src/main/scala/no/ndla/common/model/domain/frontpage/SubjectPage.scala
+++ b/common/src/main/scala/no/ndla/common/model/domain/frontpage/SubjectPage.scala
@@ -26,6 +26,7 @@ case class SubjectPage(
     connectedTo: List[String],
     buildsOn: List[String],
     leadsTo: List[String],
+    popularArticles: Seq[PopularArticle] = Seq.empty,
 ) {
 
   def supportedLanguages: Seq[String] = getSupportedLanguages(about, metaDescription)
@@ -33,8 +34,15 @@ case class SubjectPage(
 }
 
 object SubjectPage {
-  implicit val decoder: Decoder[SubjectPage]               = deriveDecoder
-  implicit val encoder: Encoder[SubjectPage]               = deriveEncoder
+  implicit val encoder: Encoder[SubjectPage] = deriveEncoder
+  implicit val decoder: Decoder[SubjectPage] = deriveDecoder[SubjectPage].prepare(
+    _.withFocus(
+      _.mapObject(obj =>
+        if (obj.contains("popularArticles")) obj
+        else obj.add("popularArticles", io.circe.Json.arr())
+      )
+    )
+  )
   def decodeJson(json: String, id: Long): Try[SubjectPage] = {
     parse(json).flatMap(_.as[SubjectPage]).map(_.copy(id = id.some)).toTry
   }

--- a/common/src/main/scala/no/ndla/common/model/domain/frontpage/SubjectPage.scala
+++ b/common/src/main/scala/no/ndla/common/model/domain/frontpage/SubjectPage.scala
@@ -34,15 +34,8 @@ case class SubjectPage(
 }
 
 object SubjectPage {
-  implicit val encoder: Encoder[SubjectPage] = deriveEncoder
-  implicit val decoder: Decoder[SubjectPage] = deriveDecoder[SubjectPage].prepare(
-    _.withFocus(
-      _.mapObject(obj =>
-        if (obj.contains("popularArticles")) obj
-        else obj.add("popularArticles", io.circe.Json.arr())
-      )
-    )
-  )
+  implicit val encoder: Encoder[SubjectPage]               = deriveEncoder
+  implicit val decoder: Decoder[SubjectPage]               = deriveDecoder
   def decodeJson(json: String, id: Long): Try[SubjectPage] = {
     parse(json).flatMap(_.as[SubjectPage]).map(_.copy(id = id.some)).toTry
   }

--- a/frontpage-api/src/main/resources/no/ndla/frontpageapi/db/migration/V12__add_popular_articles.sql
+++ b/frontpage-api/src/main/resources/no/ndla/frontpageapi/db/migration/V12__add_popular_articles.sql
@@ -1,0 +1,3 @@
+update subjectpage
+set document = document || '{"popularArticles": []}'::jsonb
+where not (document ? 'popularArticles');

--- a/frontpage-api/src/main/scala/no/ndla/frontpageapi/ComponentRegistry.scala
+++ b/frontpage-api/src/main/scala/no/ndla/frontpageapi/ComponentRegistry.scala
@@ -13,9 +13,10 @@ import no.ndla.database.{DBMigrator, DataSource, DBUtility}
 import no.ndla.frontpageapi.controller.*
 import no.ndla.frontpageapi.model.domain.{DBFilmFrontPage, DBFrontPage, DBSubjectPage}
 import no.ndla.frontpageapi.repository.{FilmFrontPageRepository, FrontPageRepository, SubjectPageRepository}
-import no.ndla.frontpageapi.service.{ConverterService, ReadService, WriteService}
+import no.ndla.frontpageapi.service.{ConverterService, MatomoService, ReadService, WriteService}
 import no.ndla.network.NdlaClient
-import no.ndla.network.clients.MyNDLAApiClient
+import no.ndla.network.clients.{MyNDLAApiClient, TaxonomyApiClient}
+import no.ndla.network.clients.matomo.MatomoApiClient
 import no.ndla.network.tapir.{
   ErrorHandling,
   ErrorHelpers,
@@ -44,6 +45,9 @@ class ComponentRegistry(properties: FrontpageApiProperties) extends TapirApplica
   given filmFrontPageRepository: FilmFrontPageRepository = new FilmFrontPageRepository
   given converterService: ConverterService               = new ConverterService
   given myndlaApiClient: MyNDLAApiClient                 = new MyNDLAApiClient
+  given taxonomyApiClient: TaxonomyApiClient             = new TaxonomyApiClient(props.TaxonomyUrl)
+  given matomoApiClient: MatomoApiClient                 = new MatomoApiClient
+  given matomoService: MatomoService                     = new MatomoService
 
   given readService: ReadService   = new ReadService
   given writeService: WriteService = new WriteService

--- a/frontpage-api/src/main/scala/no/ndla/frontpageapi/FrontpageApiProperties.scala
+++ b/frontpage-api/src/main/scala/no/ndla/frontpageapi/FrontpageApiProperties.scala
@@ -11,12 +11,13 @@ package no.ndla.frontpageapi
 import no.ndla.common.configuration.{BaseProps, Prop}
 import no.ndla.network.{AuthUser, Domains}
 import no.ndla.database.DatabaseProps
+import no.ndla.network.clients.matomo.MatomoProps
 
 import scala.util.Properties.*
 
 type Props = FrontpageApiProperties
 
-class FrontpageApiProperties extends BaseProps with DatabaseProps {
+class FrontpageApiProperties extends BaseProps with DatabaseProps with MatomoProps {
   def ApplicationName            = "frontpage-api"
   val ApplicationPort: Int       = propOrElse("APPLICATION_PORT", "80").toInt
   val DefaultLanguage: String    = propOrElse("DEFAULT_LANGUAGE", "nb")

--- a/frontpage-api/src/main/scala/no/ndla/frontpageapi/controller/InternController.scala
+++ b/frontpage-api/src/main/scala/no/ndla/frontpageapi/controller/InternController.scala
@@ -12,7 +12,7 @@ import cats.implicits.*
 import io.circe.generic.auto.*
 import no.ndla.common.model.domain.frontpage.SubjectPage
 import no.ndla.frontpageapi.model.api.*
-import no.ndla.frontpageapi.service.ReadService
+import no.ndla.frontpageapi.service.{MatomoService, ReadService}
 import no.ndla.network.clients.MyNDLAApiClient
 import no.ndla.network.tapir.{ErrorHandling, ErrorHelpers, TapirController}
 import no.ndla.network.tapir.NoNullJsonPrinter.jsonBody
@@ -25,6 +25,7 @@ import scala.util.{Failure, Success}
 
 class InternController(using
     readService: ReadService,
+    matomoService: MatomoService,
     myNDLAApiClient: MyNDLAApiClient,
     errorHelpers: ErrorHelpers,
     errorHandling: ErrorHandling,
@@ -53,8 +54,9 @@ class InternController(using
       .in(query[Int]("page").default(1))
       .in(query[Int]("page-size").default(100))
       .out(jsonBody[SubjectPageDomainDumpDTO])
+      .errorOut(errorOutputsFor(400))
       .serverLogicPure { case (pageNo, pageSize) =>
-        readService.getSubjectPageDomainDump(pageNo, pageSize).asRight
+        readService.getSubjectPageDomainDump(pageNo, pageSize)
       },
     endpoint
       .get
@@ -63,6 +65,15 @@ class InternController(using
       .errorOut(errorOutputsFor(400, 404))
       .serverLogicPure { subjectId =>
         readService.domainSubjectPage(subjectId)
+      },
+    endpoint
+      .post
+      .in("matomo" / "popular-articles")
+      .summary("Trigger fetching popular articles from Matomo for subjectpages")
+      .out(jsonBody[List[PopularArticlesResultDTO]])
+      .errorOut(errorOutputsFor(400, 404, 502))
+      .serverLogicPure { _ =>
+        matomoService.updatePopularArticlesForAllSubjects()
       },
   )
 

--- a/frontpage-api/src/main/scala/no/ndla/frontpageapi/model/api/PopularArticlesResultDTO.scala
+++ b/frontpage-api/src/main/scala/no/ndla/frontpageapi/model/api/PopularArticlesResultDTO.scala
@@ -1,0 +1,19 @@
+/*
+ * Part of NDLA frontpage-api
+ * Copyright (C) 2026 NDLA
+ *
+ * See LICENSE
+ *
+ */
+
+package no.ndla.frontpageapi.model.api
+
+import io.circe.generic.semiauto.*
+import io.circe.{Decoder, Encoder}
+
+case class PopularArticlesResultDTO(subjectId: Long, articleCount: Int)
+
+object PopularArticlesResultDTO {
+  implicit def encoder: Encoder.AsObject[PopularArticlesResultDTO] = deriveEncoder[PopularArticlesResultDTO]
+  implicit def decoder: Decoder[PopularArticlesResultDTO]          = deriveDecoder[PopularArticlesResultDTO]
+}

--- a/frontpage-api/src/main/scala/no/ndla/frontpageapi/repository/SubjectPageRepository.scala
+++ b/frontpage-api/src/main/scala/no/ndla/frontpageapi/repository/SubjectPageRepository.scala
@@ -8,7 +8,7 @@
 
 package no.ndla.frontpageapi.repository
 
-import no.ndla.database.DBUtility
+import no.ndla.database.{DBUtility, ReadableDbSession}
 import com.typesafe.scalalogging.StrictLogging
 import io.circe.syntax.*
 import no.ndla.common.model.domain.frontpage.SubjectPage
@@ -17,7 +17,7 @@ import no.ndla.frontpageapi.model.domain.DBSubjectPage
 import org.postgresql.util.PGobject
 import scalikejdbc.*
 
-import scala.util.Try
+import scala.util.{Failure, Success, Try}
 
 class SubjectPageRepository(using dBSubjectPage: DBSubjectPage, dbUtility: DBUtility) extends StrictLogging {
   def newSubjectPage(subj: SubjectPage, externalId: String)(implicit
@@ -57,7 +57,8 @@ class SubjectPageRepository(using dBSubjectPage: DBSubjectPage, dbUtility: DBUti
          """.map(dBSubjectPage.DBSubjectPage.fromDb(su)).runListFlat()
   }
 
-  def withId(subjectId: Long): Try[Option[SubjectPage]] = subjectPageWhere(sqls"su.id=${subjectId.toInt}")
+  def withId(subjectId: Long)(implicit session: DBSession = dbUtility.readOnlySession): Try[Option[SubjectPage]] =
+    subjectPageWhere(sqls"su.id=${subjectId.toInt}")
 
   def withIds(subjectIds: List[Long], offset: Int, pageSize: Int)(implicit
       session: DBSession = dbUtility.autoSession
@@ -84,21 +85,45 @@ class SubjectPageRepository(using dBSubjectPage: DBSubjectPage, dbUtility: DBUti
       .runSingle()
       .map(_.isDefined)
 
-  def totalCount(implicit session: DBSession = dbUtility.readOnlySession): Long =
+  def totalCount(implicit session: DBSession = dbUtility.readOnlySession): Try[Long] =
     tsql"select count(*) from ${dBSubjectPage.DBSubjectPage.table} where document is not NULL"
       .map(rs => rs.long("count"))
       .runSingle()
       .map(_.getOrElse(0L))
-      .get
 
-  private def subjectPageWhere(
-      whereClause: SQLSyntax
-  )(implicit session: DBSession = dbUtility.readOnlySession): Try[Option[SubjectPage]] = {
+  private def subjectPageWhere(whereClause: SQLSyntax)(implicit session: DBSession): Try[Option[SubjectPage]] = {
     val su = dBSubjectPage.DBSubjectPage.syntax("su")
 
     tsql"select ${su.result.*} from ${dBSubjectPage.DBSubjectPage.as(su)} where su.document is not NULL and $whereClause"
       .map(dBSubjectPage.DBSubjectPage.fromDb(su))
       .runSingleFlat()
+  }
+
+  /** Lazily iterates over every stored [[SubjectPage]], fetching `pageSize` rows from the database at a time.
+    *
+    * The database is queried for the next batch only when the consumer drains the previous one, so this is safe to use
+    * for tables larger than memory and never holds more than one page worth of rows at once. Iteration terminates when
+    * a partial (or empty) page is returned.
+    *
+    * Each element is wrapped in a `Try` so a failed batch fetch surfaces as a single `Failure` and stops iteration,
+    * rather than throwing inside `next()`. The iterator must be consumed while the supplied session is still open.
+    */
+  def subjectPageIterator(implicit session: ReadableDbSession): Iterator[Try[SubjectPage]] = {
+    val pageSize = 100
+
+    Iterator
+      .unfold[Iterator[Try[SubjectPage]], Option[Int]](Some(0)) {
+        case None         => None
+        case Some(offset) => all(offset, pageSize) match {
+            case Success(Nil)   => None
+            case Success(pages) =>
+              val nextState     = Option.when(pages.sizeIs >= pageSize)(offset + pages.size)
+              val pagesIterator = pages.iterator.map(Success(_))
+              Some((pagesIterator, nextState))
+            case Failure(ex) => Some((Iterator.single(Failure(ex)), None))
+          }
+      }
+      .flatten
   }
 
 }

--- a/frontpage-api/src/main/scala/no/ndla/frontpageapi/service/ConverterService.scala
+++ b/frontpage-api/src/main/scala/no/ndla/frontpageapi/service/ConverterService.scala
@@ -15,7 +15,13 @@ import scala.util.{Failure, Success, Try}
 import cats.implicits.*
 import no.ndla.common.errors.MissingIdException
 import no.ndla.common.model
-import no.ndla.common.model.api.frontpage.{AboutSubjectDTO, BannerImageDTO, SubjectPageDTO, VisualElementDTO}
+import no.ndla.common.model.api.frontpage.{
+  AboutSubjectDTO,
+  BannerImageDTO,
+  PopularArticleDTO,
+  SubjectPageDTO,
+  VisualElementDTO,
+}
 import no.ndla.common.model.domain.frontpage
 import no.ndla.common.model.domain.frontpage.{
   AboutSubject,
@@ -65,6 +71,7 @@ class ConverterService(using props: Props) {
               sub.connectedTo,
               sub.buildsOn,
               sub.leadsTo,
+              sub.popularArticles.map(a => PopularArticleDTO(a.contextId, a.numHits)),
             )
           )
       }

--- a/frontpage-api/src/main/scala/no/ndla/frontpageapi/service/MatomoService.scala
+++ b/frontpage-api/src/main/scala/no/ndla/frontpageapi/service/MatomoService.scala
@@ -1,0 +1,150 @@
+/*
+ * Part of NDLA frontpage-api
+ * Copyright (C) 2026 NDLA
+ *
+ * See LICENSE
+ *
+ */
+
+package no.ndla.frontpageapi.service
+
+import cats.implicits.*
+import com.typesafe.scalalogging.StrictLogging
+import io.lemonlabs.uri.Uri
+import no.ndla.common.errors.MissingIdException
+import no.ndla.common.implicits.*
+import no.ndla.common.model.domain.frontpage.{PopularArticle, SubjectPage}
+import no.ndla.common.model.taxonomy.Node
+import no.ndla.database.{DBUtility, WriteableDbSession}
+import no.ndla.frontpageapi.model.api.PopularArticlesResultDTO
+import no.ndla.frontpageapi.repository.SubjectPageRepository
+import no.ndla.frontpageapi.service.MatomoService.*
+import no.ndla.network.clients.TaxonomyApiClient
+import no.ndla.network.clients.matomo.model.MatomoPageUrlResult
+import no.ndla.network.clients.matomo.MatomoApiClient
+
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import scala.util.{Failure, Success, Try}
+
+class MatomoService(using
+    matomoApiClient: MatomoApiClient,
+    subjectPageRepository: SubjectPageRepository,
+    dbUtility: DBUtility,
+    taxonomyApiClient: TaxonomyApiClient,
+) extends StrictLogging {
+
+  def extractContextId(url: String): Option[String] = for {
+    uri      <- Uri.parseTry(url).toOption
+    parts     = uri.path.parts.filter(_.nonEmpty).toList
+    typeIndex = parts.indexWhere(p => p == "e" || p == "r")
+    if typeIndex >= 0
+    contextId <- contextIdFromPath(parts.drop(typeIndex))
+    if ContextIdRegex.matches(contextId)
+  } yield contextId
+
+  private def contextIdFromPath(pathFromType: List[String]): Option[String] = pathFromType match {
+    case ("e" | "r") :: id :: Nil           => Some(id)
+    case "r" :: id :: _ :: Nil              => Some(id)
+    case ("e" | "r") :: _ :: _ :: id :: Nil => Some(id)
+    case "r" :: _ :: _ :: id :: _ :: Nil    => Some(id)
+    case _                                  => None
+  }
+
+  private def fetchTopMatomoPagesForSubject(
+      subjectId: String,
+      dateRange: String,
+      subtableIds: Map[String, Long],
+      dimensionId: String,
+  ): Try[List[MatomoPageUrlResult]] = subtableIds.get(subjectId) match {
+    case None             => Failure(MissingMatomoDataEx(s"No Matomo subtable ID found for subject slug '$subjectId'"))
+    case Some(subtableId) =>
+      matomoApiClient.getTopPageUrlsForSubject(subjectId, MatomoPeriod, dateRange, PageLimit, subtableId, dimensionId)
+  }
+
+  private def toPopularArticle(matomoResult: MatomoPageUrlResult): Option[PopularArticle] = {
+    val extractedContextId = extractContextId(matomoResult.label)
+    extractedContextId.map(ctxId => PopularArticle(ctxId, matomoResult.nb_hits))
+  }
+
+  private def fetchAndStorePopularArticlesForSubject(
+      subjectPage: SubjectPage,
+      taxNode: Node,
+      dateRange: String,
+      subtableIds: Map[String, Long],
+      dimensionId: String,
+  )(implicit session: WriteableDbSession): Try[Int] = for {
+    topPages           <- fetchTopMatomoPagesForSubject(taxNode.id, dateRange, subtableIds, dimensionId)
+    popularArticles     = topPages.flatMap(toPopularArticle).take(TopArticlesLimit)
+    subjectPageToUpdate = subjectPage.copy(popularArticles = popularArticles)
+    _                  <- subjectPageRepository.updateSubjectPage(subjectPageToUpdate)
+  } yield popularArticles.size
+
+  private def lastWeekDateRange: String = {
+    val today   = LocalDate.now()
+    val weekAgo = today.minusDays(DaysInDateRange)
+    s"${weekAgo.format(DateTimeFormatter.ISO_LOCAL_DATE)},${today.format(DateTimeFormatter.ISO_LOCAL_DATE)}"
+  }
+
+  def updatePopularArticlesForSubjectPage(
+      contentUriToNode: Map[String, Node],
+      subjectPageResult: Try[SubjectPage],
+      dateRange: String,
+      subtableIds: Map[String, Long],
+      dimensionId: String,
+  )(implicit session: WriteableDbSession): Try[Option[PopularArticlesResultDTO]] = permitTry {
+    val subjectPage   = subjectPageResult.?
+    val subjectPageId = subjectPage.id.toTry(MissingIdException("Subjectpage is missing ID")).?
+    val contentUri    = s"urn:frontpage:$subjectPageId"
+    contentUriToNode.get(contentUri) match {
+      case None =>
+        logger.info(s"No taxonomy node found for subjectpage $subjectPageId, skips updating popular articles")
+        Success(None)
+      case Some(taxNode) =>
+        fetchAndStorePopularArticlesForSubject(subjectPage, taxNode, dateRange, subtableIds, dimensionId) match {
+          case Success(count) =>
+            logger.info(s"Updated popular articles for subjectpage $subjectPageId")
+            Success(Some(PopularArticlesResultDTO(subjectPageId, count)))
+          case Failure(ex: MissingMatomoDataEx) =>
+            logger.info(s"Skipped updating popular articles for subjectpage $subjectPageId: ${ex.getMessage}")
+            Success(None)
+          case Failure(ex) =>
+            logger.error(s"Error updating popular articles for subjectpage $subjectPageId", ex)
+            Failure(ex)
+        }
+    }
+  }
+
+  private def updatePopularArticlesForEachSubjectPage(
+      contentUriToNode: Map[String, Node],
+      dateRange: String,
+      subtableIds: Map[String, Long],
+      dimensionId: String,
+  )(implicit session: WriteableDbSession) = subjectPageRepository
+    .subjectPageIterator
+    .to(LazyList)
+    .traverse(page => updatePopularArticlesForSubjectPage(contentUriToNode, page, dateRange, subtableIds, dimensionId))
+    .map(_.flatten.toList)
+
+  def updatePopularArticlesForAllSubjects(): Try[List[PopularArticlesResultDTO]] = dbUtility.writeSession {
+    implicit session =>
+      for {
+        taxonomySubjects <- taxonomyApiClient.getSubjects(true)
+        contentUriToNode  = taxonomySubjects.flatMap(node => node.contentUri.map(_ -> node)).toMap
+        dateRange         = lastWeekDateRange
+        dimensionId      <- matomoApiClient.getDimensionIdForSubjectId
+        subtableIds      <- matomoApiClient.getSubtableIds(MatomoPeriod, dateRange, dimensionId)
+        result           <- updatePopularArticlesForEachSubjectPage(contentUriToNode, dateRange, subtableIds, dimensionId)
+      } yield result
+  }
+}
+
+object MatomoService {
+  case class MissingMatomoDataEx(message: String) extends RuntimeException(message)
+
+  private val MatomoPeriod     = "range"
+  private val PageLimit        = 100
+  private val TopArticlesLimit = 20
+  private val DaysInDateRange  = 7
+  private val ContextIdRegex   = "[A-Fa-f0-9]{10}([A-Fa-f0-9]{2})?".r
+}

--- a/frontpage-api/src/main/scala/no/ndla/frontpageapi/service/ReadService.scala
+++ b/frontpage-api/src/main/scala/no/ndla/frontpageapi/service/ReadService.scala
@@ -54,7 +54,7 @@ class ReadService(using
     converted.toTry(SubjectPageNotFoundException(id))
   }
 
-  def subjectPages(page: Int, pageSize: Int, language: String, fallback: Boolean): Try[List[SubjectPageDTO]] =
+  def subjectPages(page: Int, pageSize: Int, language: String, fallback: Boolean): Try[List[SubjectPageDTO]] = {
     permitTry {
       val offset    = pageSize * (page - 1)
       val data      = subjectPageRepository.all(offset, pageSize).?
@@ -62,6 +62,7 @@ class ReadService(using
       val filtered  = filterOutNotFoundExceptions(converted)
       filtered.sequence
     }
+  }
 
   private def filterOutNotFoundExceptions[T](exceptions: List[Try[T]]): List[Try[T]] = {
     exceptions.filter {
@@ -86,10 +87,10 @@ class ReadService(using
     } yield api
   }
 
-  def getSubjectPageDomainDump(pageNo: Int, pageSize: Int): SubjectPageDomainDumpDTO = {
-    val results = subjectPageRepository.all(pageNo, pageSize).get
-    SubjectPageDomainDumpDTO(subjectPageRepository.totalCount, pageNo, pageSize, results)
-  }
+  def getSubjectPageDomainDump(pageNo: Int, pageSize: Int): Try[SubjectPageDomainDumpDTO] = for {
+    results    <- subjectPageRepository.all(pageNo, pageSize)
+    totalCount <- subjectPageRepository.totalCount
+  } yield SubjectPageDomainDumpDTO(totalCount, pageNo, pageSize, results)
 
   def getFrontPage: Try[FrontPageDTO] = {
     frontPageRepository

--- a/frontpage-api/src/test/scala/no/ndla/frontpageapi/TestData.scala
+++ b/frontpage-api/src/test/scala/no/ndla/frontpageapi/TestData.scala
@@ -92,6 +92,7 @@ object TestData {
       List("urn:resource:1:161411", "urn:resource:1:182176", "urn:resource:1:183636", "urn:resource:1:170204"),
       List("urn:resource:1:161411", "urn:resource:1:182176", "urn:resource:1:183636", "urn:resource:1:170204"),
       List("urn:resource:1:161411", "urn:resource:1:182176", "urn:resource:1:183636", "urn:resource:1:170204"),
+      Seq.empty,
     )
 
   val apiNewSubjectPage: NewSubjectPageDTO = api.NewSubjectPageDTO(

--- a/frontpage-api/src/test/scala/no/ndla/frontpageapi/TestEnvironment.scala
+++ b/frontpage-api/src/test/scala/no/ndla/frontpageapi/TestEnvironment.scala
@@ -9,7 +9,7 @@
 package no.ndla.frontpageapi
 
 import no.ndla.common.Clock
-import no.ndla.database.{DBMigrator, DataSource, DBUtility}
+import no.ndla.database.{DBMigrator, DBUtility, DataSource}
 import no.ndla.frontpageapi.controller.{
   ControllerErrorHandling,
   FilmPageController,
@@ -18,9 +18,10 @@ import no.ndla.frontpageapi.controller.{
 }
 import no.ndla.frontpageapi.model.domain.{DBFilmFrontPage, DBFrontPage, DBSubjectPage}
 import no.ndla.frontpageapi.repository.{FilmFrontPageRepository, FrontPageRepository, SubjectPageRepository}
-import no.ndla.frontpageapi.service.{ConverterService, ReadService, WriteService}
+import no.ndla.frontpageapi.service.{ConverterService, MatomoService, ReadService, WriteService}
 import no.ndla.network.NdlaClient
-import no.ndla.network.clients.MyNDLAApiClient
+import no.ndla.network.clients.{MyNDLAApiClient, TaxonomyApiClient}
+import no.ndla.network.clients.matomo.MatomoApiClient
 import no.ndla.network.tapir.{
   ErrorHandling,
   ErrorHelpers,
@@ -59,8 +60,11 @@ trait TestEnvironment extends TapirApplication[FrontpageApiProperties] with Mock
   implicit lazy val writeService: WriteService                       = mock[WriteService]
   implicit lazy val converterService: ConverterService               = mock[ConverterService]
 
-  implicit lazy val ndlaClient: NdlaClient           = mock[NdlaClient]
-  implicit lazy val myndlaApiClient: MyNDLAApiClient = mock[MyNDLAApiClient]
+  implicit lazy val ndlaClient: NdlaClient               = mock[NdlaClient]
+  implicit lazy val myndlaApiClient: MyNDLAApiClient     = mock[MyNDLAApiClient]
+  implicit lazy val matomoApiClient: MatomoApiClient     = mock[MatomoApiClient]
+  implicit lazy val matomoService: MatomoService         = mock[MatomoService]
+  implicit lazy val taxonomyApiClient: TaxonomyApiClient = mock[TaxonomyApiClient]
 
   implicit lazy val swagger: SwaggerController = mock[SwaggerController]
 }

--- a/frontpage-api/src/test/scala/no/ndla/frontpageapi/repository/SubjectPageRepositoryTest.scala
+++ b/frontpage-api/src/test/scala/no/ndla/frontpageapi/repository/SubjectPageRepositoryTest.scala
@@ -1,0 +1,163 @@
+/*
+ * Part of NDLA frontpage-api
+ * Copyright (C) 2026 NDLA
+ *
+ * See LICENSE
+ *
+ */
+
+package no.ndla.frontpageapi.repository
+
+import no.ndla.common.model.domain.frontpage.SubjectPage
+import no.ndla.database.{DBMigrator, DBUtility, DataSource}
+import no.ndla.frontpageapi.model.domain.DBSubjectPage
+import no.ndla.frontpageapi.{TestData, TestEnvironment}
+import no.ndla.scalatestsuite.DatabaseIntegrationSuite
+import org.mockito.Mockito.{spy, times, verify}
+import org.mockito.ArgumentMatchers.any
+import scalikejdbc.*
+
+import java.net.Socket
+import scala.util.{Success, Try}
+
+class SubjectPageRepositoryTest extends DatabaseIntegrationSuite with TestEnvironment {
+  override implicit lazy val dbUtility: DBUtility         = new DBUtility
+  override implicit lazy val dataSource: DataSource       = testDataSource.get
+  override implicit lazy val migrator: DBMigrator         = new DBMigrator
+  override implicit lazy val dBSubjectPage: DBSubjectPage = new DBSubjectPage
+  var repository: SubjectPageRepository                   = scala.compiletime.uninitialized
+
+  def emptyTestDatabase(): Unit = dbUtility.writeSession(implicit session => {
+    sql"delete from subjectpage;".execute()(using session)
+  })
+
+  def serverIsListening: Boolean = {
+    val server = props.MetaServer.unsafeGet
+    val port   = props.MetaPort.unsafeGet
+    Try(new Socket(server, port)) match {
+      case Success(c) =>
+        c.close()
+        true
+      case _ => false
+    }
+  }
+
+  override def beforeEach(): Unit = {
+    repository = new SubjectPageRepository()
+    if (serverIsListening) {
+      emptyTestDatabase()
+    }
+  }
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    dataSource.connectToDatabase()
+    if (serverIsListening) {
+      migrator.migrate()
+    }
+  }
+
+  private def insertSubject(externalId: String, name: String = "Samfunnsfag"): SubjectPage = {
+    val toInsert = TestData.domainSubjectPage.copy(id = None, name = name)
+    repository.newSubjectPage(toInsert, externalId).failIfFailure
+  }
+
+  test("withId should return None if no subject page exists") {
+    repository.withId(1234L) should be(Success(None))
+  }
+
+  test("newSubjectPage inserts the page and assigns an id retrievable via withId") {
+    val inserted = insertSubject("ext-1")
+    inserted.id should not be empty
+    repository.withId(inserted.id.get).failIfFailure should be(Some(inserted))
+  }
+
+  test("getIdFromExternalId returns the id of an inserted page, or None when missing") {
+    val inserted = insertSubject("external-42")
+    repository.getIdFromExternalId("external-42").failIfFailure should be(Some(inserted.id.get))
+    repository.getIdFromExternalId("does-not-exist").failIfFailure should be(None)
+  }
+
+  test("exists reflects whether a subject page id is stored") {
+    val inserted = insertSubject("ext-exists")
+    repository.exists(inserted.id.get).failIfFailure should be(true)
+    repository.exists(inserted.id.get + 9999L).failIfFailure should be(false)
+  }
+
+  test("updateSubjectPage replaces the stored document for that id") {
+    val inserted = insertSubject("ext-update")
+    val updated  = inserted.copy(name = "Endret navn")
+
+    repository.updateSubjectPage(updated).failIfFailure should be(updated)
+    repository.withId(inserted.id.get).failIfFailure should be(Some(updated))
+  }
+
+  test("totalCount returns the number of stored subject pages") {
+    repository.totalCount.failIfFailure should be(0L)
+    insertSubject("ext-a")
+    insertSubject("ext-b")
+    insertSubject("ext-c")
+    repository.totalCount.failIfFailure should be(3L)
+  }
+
+  test("all returns subject pages ordered by id, with offset and limit applied") {
+    val a = insertSubject("ext-a", "A")
+    val b = insertSubject("ext-b", "B")
+    val c = insertSubject("ext-c", "C")
+
+    repository.all(offset = 0, limit = 10).failIfFailure should be(List(a, b, c))
+    repository.all(offset = 1, limit = 1).failIfFailure should be(List(b))
+    repository.all(offset = 3, limit = 10).failIfFailure should be(List.empty)
+  }
+
+  test("withIds returns only the requested subject pages") {
+    val a = insertSubject("ext-a", "A")
+    val b = insertSubject("ext-b", "B")
+    val c = insertSubject("ext-c", "C")
+
+    repository
+      .withIds(List(a.id.get, c.id.get), offset = 0, pageSize = 10)
+      .failIfFailure should contain theSameElementsAs List(a, c)
+
+    repository.withIds(List(b.id.get), offset = 1, pageSize = 10).failIfFailure should be(List.empty)
+  }
+
+  test("subjectPageIterator yields every stored subject page exactly once") {
+    val pages = (
+      1 to 5
+    ).map(i => insertSubject(s"ext-$i", s"Subject $i")).toList
+
+    // Drain the iterator inside the read-only session so DB fetches happen while it's open.
+    val collected: List[SubjectPage] = dbUtility.readOnly { implicit session =>
+      repository.subjectPageIterator.map(_.failIfFailure).toList
+    }
+
+    collected should contain theSameElementsAs pages
+  }
+
+  test("subjectPageIterator on an empty table yields no elements") {
+    val collected: List[SubjectPage] = dbUtility.readOnly { implicit session =>
+      repository.subjectPageIterator.map(_.failIfFailure).toList
+    }
+
+    collected should be(List.empty)
+  }
+
+  test("subjectPageIterator only calls database once for each page") {
+    val repositorySpy = spy(new SubjectPageRepository())
+    repository = repositorySpy
+
+    verify(repositorySpy, times(0)).all(any, any)(using any)
+
+    val pages = (
+      1 to 5
+    ).map(i => insertSubject(s"ext-$i", s"Subject $i")).toList
+
+    val collected: List[SubjectPage] = dbUtility.readOnly { implicit session =>
+      repository.subjectPageIterator.map(_.failIfFailure).toList
+    }
+
+    collected should contain theSameElementsAs pages
+    verify(repositorySpy, times(1)).all(any, any)(using any)
+  }
+}

--- a/frontpage-api/src/test/scala/no/ndla/frontpageapi/service/MatomoServiceTest.scala
+++ b/frontpage-api/src/test/scala/no/ndla/frontpageapi/service/MatomoServiceTest.scala
@@ -1,0 +1,49 @@
+/*
+ * Part of NDLA frontpage-api
+ * Copyright (C) 2026 NDLA
+ *
+ * See LICENSE
+ *
+ */
+
+package no.ndla.frontpageapi.service
+
+import no.ndla.frontpageapi.{TestEnvironment, UnitSuite}
+
+class MatomoServiceTest extends UnitSuite with TestEnvironment {
+  override implicit lazy val matomoService: MatomoService = new MatomoService
+
+  test("taxonomy context id should be extracted from url") {
+    val ctxIds = List("f009643d3a", "223342990757")
+    ctxIds.foreach { ctxId =>
+      val toExtract = List(
+        s"https://ndla.no/r/verktoykassa---for-larere/planlegg-en-laringssti/$ctxId/6924",
+        s"https://ndla.no/nn/r/verktoykassa---for-larere/planlegg-en-laringssti/$ctxId/6924",
+        s"ndla.no/nn/r/verktoykassa---for-larere/planlegg-en-laringssti/$ctxId/6924",
+        s"https://ndla.no/r/verktoykassa---for-larere/planlegg-en-laringssti/$ctxId",
+        s"https://ndla.no/nb/r/verktoykassa---for-larere/planlegg-en-laringssti/$ctxId",
+        s"https://ndla.no/nb/e/verktoykassa---for-larere/planlegg-en-laringssti/$ctxId",
+        s"https://ndla.no/sma/e/verktoykassa---for-larere/planlegg-en-laringssti/$ctxId",
+        s"https://ndla.no/nb/e/$ctxId",
+      )
+
+      val toFail = List(
+        s"https://ndla.no/nb/utdanning/bygg--og-anleggsteknikk/$ctxId",
+        s"https://ndla.no/utdanning/bygg--og-anleggsteknikk/$ctxId",
+        s"https://ndla.no/f/praktisk-yrkesutovelse-ba-bat-vg1/$ctxId",
+        s"https://ndla.no/nn/f/praktisk-yrkesutovelse-ba-bat-vg1/$ctxId",
+      )
+
+      toExtract.foreach { url =>
+        val res = matomoService.extractContextId(url)
+        if (!res.contains(ctxId)) fail(s"Failed to extract context id from url: $url, got: $res\n")
+      }
+
+      toFail.foreach { url =>
+        val res = matomoService.extractContextId(url)
+        if (res.nonEmpty) fail(s"Should not have extracted context id from url: $url, got: $res\n")
+      }
+    }
+  }
+
+}

--- a/frontpage-api/src/test/scala/no/ndla/frontpageapi/service/WriteServiceTest.scala
+++ b/frontpage-api/src/test/scala/no/ndla/frontpageapi/service/WriteServiceTest.scala
@@ -29,7 +29,7 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
           TestData.domainSubjectPage.about ++ Seq(AboutSubject("Foo", "Bar", "nn", VisualElement(Image, "123", None))),
         metaDescription = TestData.domainSubjectPage.metaDescription ++ Seq(MetaDescription("Description", "nn")),
       )
-    when(subjectPageRepository.withId(any)).thenReturn(Success(Some(subjectPage)))
+    when(subjectPageRepository.withId(any)(using any)).thenReturn(Success(Some(subjectPage)))
     when(subjectPageRepository.updateSubjectPage(any)(using any)).thenAnswer(i => Success(i.getArgument(0)))
 
     val result = writeService.deleteSubjectPageLanguage(subjectPage.id.get, "nn")
@@ -43,7 +43,7 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
   }
 
   test("That deleting last language for subject page throws exception") {
-    when(subjectPageRepository.withId(any)).thenReturn(Success(Some(TestData.domainSubjectPage)))
+    when(subjectPageRepository.withId(any)(using any)).thenReturn(Success(Some(TestData.domainSubjectPage)))
     when(subjectPageRepository.updateSubjectPage(any)(using any)).thenAnswer(i => Success(i.getArgument(0)))
 
     val result = writeService.deleteSubjectPageLanguage(TestData.domainSubjectPage.id.get, "nb")

--- a/network/src/main/scala/no/ndla/network/clients/TaxonomyApiClient.scala
+++ b/network/src/main/scala/no/ndla/network/clients/TaxonomyApiClient.scala
@@ -27,6 +27,20 @@ class TaxonomyApiClient(taxonomyBaseUrl: String)(using ndlaClient: NdlaClient) e
   private val TaxonomyApiEndpoint = s"$taxonomyBaseUrl/v1"
   private val timeoutSeconds      = 600.seconds
 
+  def getSubjects(shouldUsePublishedTax: Boolean): Try[List[Node]] = {
+    val params = Seq(
+      "includeContexts" -> "true",
+      "isVisible"       -> getIsVisibleParam(shouldUsePublishedTax),
+      "nodeType"        -> NodeType.SUBJECT.entryName,
+    )
+
+    get[List[Node]](
+      url = s"$TaxonomyApiEndpoint/nodes",
+      headers = getVersionHashHeader(shouldUsePublishedTax),
+      params = params,
+    )
+  }
+
   def getNodesPage(page: Int, pageSize: Int, shouldUsePublishedTax: Boolean): Try[PaginationPage[Node]] =
     get[PaginationPage[Node]](
       s"$TaxonomyApiEndpoint/nodes/page",

--- a/network/src/main/scala/no/ndla/network/clients/TaxonomyApiClient.scala
+++ b/network/src/main/scala/no/ndla/network/clients/TaxonomyApiClient.scala
@@ -29,9 +29,9 @@ class TaxonomyApiClient(taxonomyBaseUrl: String)(using ndlaClient: NdlaClient) e
 
   def getSubjects(shouldUsePublishedTax: Boolean): Try[List[Node]] = {
     val params = Seq(
-      "includeContexts" -> "true",
-      "isVisible"       -> getIsVisibleParam(shouldUsePublishedTax),
-      "nodeType"        -> NodeType.SUBJECT.entryName,
+      "filterProgrammes" -> "true",
+      "isVisible"        -> getIsVisibleParam(shouldUsePublishedTax),
+      "nodeType"         -> NodeType.SUBJECT.entryName,
     )
 
     get[List[Node]](

--- a/network/src/main/scala/no/ndla/network/clients/matomo/MatomoApiClient.scala
+++ b/network/src/main/scala/no/ndla/network/clients/matomo/MatomoApiClient.scala
@@ -1,0 +1,103 @@
+/*
+ * Part of NDLA network
+ * Copyright (C) 2026 NDLA
+ *
+ * See LICENSE
+ *
+ */
+
+package no.ndla.network.clients.matomo
+
+import com.typesafe.scalalogging.StrictLogging
+import io.circe.Decoder
+import no.ndla.network.NdlaClient
+import no.ndla.network.clients.matomo.model.{MatomoDimensionResult, MatomoPageUrlResult, MatomoReportMetadata}
+import sttp.client3.quick.*
+
+import scala.concurrent.duration.*
+import scala.util.{Failure, Success, Try}
+
+class MatomoApiClient(using props: MatomoProps, client: NdlaClient) extends StrictLogging {
+  private val timeout: FiniteDuration = 30.seconds
+  private val baseUrl                 = uri"${props.MatomoUrl}/index.php"
+  private val dimensionName           = "subjectId"
+
+  def getDimensionIdForSubjectId: Try[String] = {
+    val params = Map[String, String](
+      "module"     -> "API",
+      "method"     -> "API.getReportMetadata",
+      "idSite"     -> props.MatomoSiteId,
+      "format"     -> "JSON",
+      "token_auth" -> props.MatomoTokenAuth,
+    )
+    val request = quickRequest.post(baseUrl).body(params).readTimeout(timeout)
+    logger.info(s"Looking up Matomo dimension ID for dimension '$dimensionName'")
+    client
+      .fetch[List[MatomoReportMetadata]](request)
+      .map { response =>
+        for {
+          foundMeta   <- response.find(_.name == dimensionName)
+          parameters  <- foundMeta.parameters
+          dimensionId <- parameters.idDimension
+        } yield dimensionId
+      } match {
+      case Failure(ex)   => Failure(ex)
+      case Success(None) =>
+        Failure(new RuntimeException(s"No dimension with name '$dimensionName' found in Matomo report metadata"))
+      case Success(Some(dimensionId)) => Success(dimensionId)
+    }
+  }
+
+  def getSubtableIds(period: String, date: String, dimensionId: String): Try[Map[String, Long]] = {
+    val params = Map[String, String](
+      "module"       -> "API",
+      "method"       -> "CustomDimensions.getCustomDimension",
+      "idSite"       -> props.MatomoSiteId,
+      "idDimension"  -> dimensionId,
+      "period"       -> period,
+      "date"         -> date,
+      "format"       -> "JSON",
+      "token_auth"   -> props.MatomoTokenAuth,
+      "filter_limit" -> "-1",
+    )
+
+    val request = quickRequest.post(baseUrl).body(params).readTimeout(timeout)
+    logger.info(s"Looking up Matomo subtable ID for subjects (period=$period, date=$date)")
+    client
+      .fetch[List[MatomoDimensionResult]](request)
+      .map { results =>
+        results.flatMap(dim => dim.idsubdatatable.map(subdataid => dim.label -> subdataid)).toMap
+      }
+  }
+
+  def getTopPageUrlsForSubject(
+      subjectId: String,
+      period: String,
+      date: String,
+      limit: Int,
+      subtableId: Long,
+      dimensionId: String,
+  ): Try[List[MatomoPageUrlResult]] = {
+    for {
+      results <- {
+        val params = Map[String, String](
+          "module"             -> "API",
+          "method"             -> "CustomDimensions.getCustomDimension",
+          "idSite"             -> props.MatomoSiteId,
+          "idDimension"        -> dimensionId,
+          "period"             -> period,
+          "date"               -> date,
+          "format"             -> "JSON",
+          "idSubtable"         -> subtableId.toString,
+          "filter_limit"       -> limit.toString,
+          "filter_sort_column" -> "nb_hits",
+          "token_auth"         -> props.MatomoTokenAuth,
+        )
+
+        val request = quickRequest.post(baseUrl).body(params).readTimeout(timeout)
+        logger.info(s"Fetching top pages from Matomo subtable $subtableId for subject '$subjectId'")
+        client.fetch[List[MatomoPageUrlResult]](request)
+      }
+    } yield results
+  }
+}

--- a/network/src/main/scala/no/ndla/network/clients/matomo/MatomoApiClient.scala
+++ b/network/src/main/scala/no/ndla/network/clients/matomo/MatomoApiClient.scala
@@ -18,32 +18,33 @@ import scala.concurrent.duration.*
 import scala.util.{Failure, Success, Try}
 
 class MatomoApiClient(using props: MatomoProps, client: NdlaClient) extends StrictLogging {
+  import props.{MatomoSubjectDimensionName, MatomoUrl, MatomoSiteId, MatomoTokenAuth}
   private val timeout: FiniteDuration = 30.seconds
-  private val baseUrl                 = uri"${props.MatomoUrl}/index.php"
-  private val dimensionName           = "subjectId"
+  private val baseUrl                 = uri"$MatomoUrl/index.php"
 
   def getDimensionIdForSubjectId: Try[String] = {
     val params = Map[String, String](
       "module"     -> "API",
       "method"     -> "API.getReportMetadata",
-      "idSite"     -> props.MatomoSiteId,
+      "idSite"     -> MatomoSiteId,
       "format"     -> "JSON",
-      "token_auth" -> props.MatomoTokenAuth,
+      "token_auth" -> MatomoTokenAuth,
     )
     val request = quickRequest.post(baseUrl).body(params).readTimeout(timeout)
-    logger.info(s"Looking up Matomo dimension ID for dimension '$dimensionName'")
+    logger.info(s"Looking up Matomo dimension ID for dimension '$MatomoSubjectDimensionName'")
     client
       .fetch[List[MatomoReportMetadata]](request)
       .map { response =>
         for {
-          foundMeta   <- response.find(_.name == dimensionName)
+          foundMeta   <- response.find(_.name == MatomoSubjectDimensionName)
           parameters  <- foundMeta.parameters
           dimensionId <- parameters.idDimension
         } yield dimensionId
       } match {
       case Failure(ex)   => Failure(ex)
-      case Success(None) =>
-        Failure(new RuntimeException(s"No dimension with name '$dimensionName' found in Matomo report metadata"))
+      case Success(None) => Failure(
+          new RuntimeException(s"No dimension with name '$MatomoSubjectDimensionName' found in Matomo report metadata")
+        )
       case Success(Some(dimensionId)) => Success(dimensionId)
     }
   }

--- a/network/src/main/scala/no/ndla/network/clients/matomo/MatomoProps.scala
+++ b/network/src/main/scala/no/ndla/network/clients/matomo/MatomoProps.scala
@@ -1,0 +1,17 @@
+/*
+ * Part of NDLA network
+ * Copyright (C) 2026 NDLA
+ *
+ * See LICENSE
+ *
+ */
+
+package no.ndla.network.clients.matomo
+
+import no.ndla.common.configuration.{BaseProps, Prop}
+
+trait MatomoProps extends BaseProps {
+  val MatomoUrl: Prop[String]       = prop("MATOMO_URL")
+  val MatomoSiteId: Prop[String]    = prop("MATOMO_SITE_ID")
+  val MatomoTokenAuth: Prop[String] = prop("MATOMO_TOKEN_AUTH")
+}

--- a/network/src/main/scala/no/ndla/network/clients/matomo/MatomoProps.scala
+++ b/network/src/main/scala/no/ndla/network/clients/matomo/MatomoProps.scala
@@ -13,5 +13,5 @@ import no.ndla.common.configuration.{BaseProps, Prop}
 trait MatomoProps extends BaseProps {
   val MatomoUrl: Prop[String]       = prop("MATOMO_URL")
   val MatomoSiteId: Prop[String]    = prop("MATOMO_SITE_ID")
-  val MatomoTokenAuth: Prop[String] = prop("MATOMO_TOKEN_AUTH")
+  val MatomoTokenAuth: Prop[String] = prop("MATOMO_API_TOKEN")
 }

--- a/network/src/main/scala/no/ndla/network/clients/matomo/MatomoProps.scala
+++ b/network/src/main/scala/no/ndla/network/clients/matomo/MatomoProps.scala
@@ -10,8 +10,11 @@ package no.ndla.network.clients.matomo
 
 import no.ndla.common.configuration.{BaseProps, Prop}
 
+import scala.util.Properties.propOrElse
+
 trait MatomoProps extends BaseProps {
-  val MatomoUrl: Prop[String]       = prop("MATOMO_URL")
-  val MatomoSiteId: Prop[String]    = prop("MATOMO_SITE_ID")
-  val MatomoTokenAuth: Prop[String] = prop("MATOMO_API_TOKEN")
+  val MatomoUrl: Prop[String]            = prop("MATOMO_URL")
+  val MatomoSiteId: Prop[String]         = prop("MATOMO_SITE_ID")
+  val MatomoTokenAuth: Prop[String]      = prop("MATOMO_API_TOKEN")
+  val MatomoSubjectDimensionName: String = propOrElse("MATOMO_SUBJECT_ID_DIMENSION_NAME", "subjectId")
 }

--- a/network/src/main/scala/no/ndla/network/clients/matomo/model/MatomoDimensionResult.scala
+++ b/network/src/main/scala/no/ndla/network/clients/matomo/model/MatomoDimensionResult.scala
@@ -1,0 +1,18 @@
+/*
+ * Part of NDLA network
+ * Copyright (C) 2026 NDLA
+ *
+ * See LICENSE
+ *
+ */
+
+package no.ndla.network.clients.matomo.model
+
+import io.circe.Decoder
+import io.circe.generic.semiauto.deriveDecoder
+
+case class MatomoDimensionResult(label: String, nb_hits: Long, nb_visits: Long, idsubdatatable: Option[Long])
+
+object MatomoDimensionResult {
+  implicit val decoder: Decoder[MatomoDimensionResult] = deriveDecoder
+}

--- a/network/src/main/scala/no/ndla/network/clients/matomo/model/MatomoPageUrlResult.scala
+++ b/network/src/main/scala/no/ndla/network/clients/matomo/model/MatomoPageUrlResult.scala
@@ -1,0 +1,18 @@
+/*
+ * Part of NDLA network
+ * Copyright (C) 2026 NDLA
+ *
+ * See LICENSE
+ *
+ */
+
+package no.ndla.network.clients.matomo.model
+
+import io.circe.Decoder
+import io.circe.generic.semiauto.deriveDecoder
+
+case class MatomoPageUrlResult(label: String, nb_hits: Long, nb_visits: Long)
+
+object MatomoPageUrlResult {
+  implicit val decoder: Decoder[MatomoPageUrlResult] = deriveDecoder
+}

--- a/network/src/main/scala/no/ndla/network/clients/matomo/model/MatomoReportMetadata.scala
+++ b/network/src/main/scala/no/ndla/network/clients/matomo/model/MatomoReportMetadata.scala
@@ -1,0 +1,24 @@
+/*
+ * Part of NDLA network
+ * Copyright (C) 2026 NDLA
+ *
+ * See LICENSE
+ *
+ */
+
+package no.ndla.network.clients.matomo.model
+
+import io.circe.Decoder
+import io.circe.generic.semiauto.deriveDecoder
+
+case class MatomoReportMetadata(name: String, parameters: Option[MatomoReportParameters])
+
+object MatomoReportMetadata {
+  implicit val decoder: Decoder[MatomoReportMetadata] = deriveDecoder
+}
+
+case class MatomoReportParameters(idDimension: Option[String])
+
+object MatomoReportParameters {
+  implicit val decoder: Decoder[MatomoReportParameters] = deriveDecoder
+}


### PR DESCRIPTION
Krever at vi legger inn en cronjob som kaller det nye endepunktet for å populere `popularArticles`