### PR TITLE
fix(image-api): return raw S3 image if empty or download image params

### DIFF
--- a/image-api/src/main/scala/no/ndla/imageapi/controller/ImageParams.scala
+++ b/image-api/src/main/scala/no/ndla/imageapi/controller/ImageParams.scala
@@ -10,8 +10,8 @@ package no.ndla.imageapi.controller
 
 import sttp.tapir.EndpointIO.annotations.*
 
-// format: off
 case class ImageParams(
+// format: off
   @header("app-key")
   @description("Your app-key. May be omitted to access api anonymously, but rate limiting may apply on anonymous access.")
   appKey: Option[String],
@@ -51,11 +51,13 @@ case class ImageParams(
   @query
   @description("Whether the image should be downloaded or not. Only the presence of this parameter is needed.")
   download: Option[String],
-)
 // format: on
+) {
+  def isEmptyOrOnlyDownload: Boolean = copy(download = None) == ImageParams.empty
+}
 
 object ImageParams {
-  def empty: ImageParams = ImageParams(
+  val empty: ImageParams = ImageParams(
     appKey = None,
     width = None,
     height = None,

--- a/image-api/src/main/scala/no/ndla/imageapi/controller/RawController.scala
+++ b/image-api/src/main/scala/no/ndla/imageapi/controller/RawController.scala
@@ -79,18 +79,27 @@ class RawController(using
         .map(s3Object => ImageResponse(s3Object.stream, s3Object.contentType, s3Object.contentLength.toString, None))
     }
 
-  private def getImageResponse(fileName: String, imageParams: ImageParams): Try[ImageResponse] =
-    getRawImage(fileName, imageParams).map { imageStream =>
-      val contentDisposition = imageParams.download.map(_ => "attachment")
-      ImageResponse(
-        imageStream.stream,
-        imageStream.contentType.toString,
-        imageStream.contentLength.toString,
-        contentDisposition,
-      )
+  private def getImageResponse(fileName: String, imageParams: ImageParams): Try[ImageResponse] = {
+    val contentDisposition = imageParams.download.map(_ => "attachment")
+    if (imageParams.isEmptyOrOnlyDownload) {
+      imageStorage
+        .getRaw(fileName)
+        .map(s3Object =>
+          ImageResponse(s3Object.stream, s3Object.contentType, s3Object.contentLength.toString, contentDisposition)
+        )
+    } else {
+      getAndProcessImage(fileName, imageParams).map { imageStream =>
+        ImageResponse(
+          imageStream.stream,
+          imageStream.contentType.toString,
+          imageStream.contentLength.toString,
+          contentDisposition,
+        )
+      }
     }
+  }
 
-  private def getRawImage(imageName: String, imageParams: ImageParams): Try[ImageStream] = {
+  private def getAndProcessImage(imageName: String, imageParams: ImageParams): Try[ImageStream] = {
     val dynamicCropOrResize = {
       val canDynamicCrop = canDoDynamicCrop(imageParams)
       if (canDynamicCrop) dynamicCrop

--- a/image-api/src/test/scala/no/ndla/imageapi/controller/RawControllerTest.scala
+++ b/image-api/src/test/scala/no/ndla/imageapi/controller/RawControllerTest.scala
@@ -23,7 +23,6 @@ import javax.imageio.ImageIO
 import scala.util.{Failure, Success}
 
 class RawControllerTest extends UnitSuite with TestEnvironment with TapirControllerTest {
-  import TestData.{ccLogoSvgImageStream, ndlaLogoGifImageStream}
   val imageName    = "ndla_logo.jpg"
   val imageGifName = "ndla_logo.gif"
   val imageSvgName = "logo.svg"
@@ -43,12 +42,12 @@ class RawControllerTest extends UnitSuite with TestEnvironment with TapirControl
   override def beforeEach(): Unit = {
     reset(clock)
     when(imageRepository.withId(id)).thenReturn(Success(Some(TestData.bjorn)))
-    when(imageStorage.get(any[String])).thenAnswer(_ => Success(TestData.ndlaLogoImageStream))
     when(readService.getImageFileName(id, None)).thenReturn(Success(Some(TestData.bjorn.images.head.fileName)))
     when(clock.now()).thenCallRealMethod()
   }
 
   test("That GET /image.jpg returns 200 if image was found") {
+    when(imageStorage.getRaw(any[String])).thenReturn(Success(TestData.ndlaLogoImageS3Object))
     val res = simpleHttpClient.send(req.get(uri"http://localhost:$serverPort/image-api/raw/$imageName"))
     res.code.code should be(200)
 
@@ -58,12 +57,13 @@ class RawControllerTest extends UnitSuite with TestEnvironment with TapirControl
   }
 
   test("That GET /image.jpg returns 404 if image was not found") {
-    when(imageStorage.get(any[String])).thenReturn(Failure(new ImageNotFoundException("Image not found")))
+    when(imageStorage.getRaw(any[String])).thenReturn(Failure(new ImageNotFoundException("Image not found")))
     val res = simpleHttpClient.send[Array[Byte]](req.get(uri"http://localhost:$serverPort/image-api/raw/$imageName"))
     res.code.code should be(404)
   }
 
   test("That GET /image.jpg with width resizing returns a resized image") {
+    when(imageStorage.get(any[String])).thenReturn(Success(TestData.ndlaLogoImageStream))
     val res =
       simpleHttpClient.send[Array[Byte]](req.get(uri"http://localhost:$serverPort/image-api/raw/$imageName?width=100"))
     res.code.code should be(200)
@@ -72,6 +72,7 @@ class RawControllerTest extends UnitSuite with TestEnvironment with TapirControl
   }
 
   test("That GET /image.jpg with height resizing returns a resized image") {
+    when(imageStorage.get(any[String])).thenReturn(Success(TestData.ndlaLogoImageStream))
     val res =
       simpleHttpClient.send[Array[Byte]](req.get(uri"http://localhost:$serverPort/image-api/raw/$imageName?height=40"))
     res.code.code should be(200)
@@ -86,6 +87,7 @@ class RawControllerTest extends UnitSuite with TestEnvironment with TapirControl
   }
 
   test("That GET /image.jpg with cropping returns a cropped image") {
+    when(imageStorage.get(any[String])).thenReturn(Success(TestData.ndlaLogoImageStream))
     val res = simpleHttpClient.send(
       req.get(
         uri"http://localhost:$serverPort/image-api/raw/$imageName?cropStartX=0&cropStartY=0&cropEndX=50&cropEndY=50"
@@ -98,6 +100,7 @@ class RawControllerTest extends UnitSuite with TestEnvironment with TapirControl
   }
 
   test("That GET /image.jpg with cropping and resizing returns a cropped and resized image") {
+    when(imageStorage.get(any[String])).thenReturn(Success(TestData.ndlaLogoImageStream))
     val res = simpleHttpClient.send(
       req.get(
         uri"http://localhost:$serverPort/image-api/raw/$imageName?cropStartX=0&cropStartY=0&cropEndX=50&cropEndY=50&width=50"
@@ -110,6 +113,7 @@ class RawControllerTest extends UnitSuite with TestEnvironment with TapirControl
   }
 
   test("GET /id/1 returns 200 if the image was found") {
+    when(imageStorage.getRaw(any[String])).thenReturn(Success(TestData.ndlaLogoImageS3Object))
     val res = simpleHttpClient.send(req.get(uri"http://localhost:$serverPort/image-api/raw/id/$id"))
     res.code.code should be(200)
     val image = ImageIO.read(new ByteArrayInputStream(res.body))
@@ -118,12 +122,13 @@ class RawControllerTest extends UnitSuite with TestEnvironment with TapirControl
   }
 
   test("That GET /id/1 returns 404 if image was not found") {
-    when(imageStorage.get(any[String])).thenReturn(Failure(new ImageNotFoundException("Image not found")))
+    when(imageStorage.getRaw(any[String])).thenReturn(Failure(new ImageNotFoundException("Image not found")))
     val res = simpleHttpClient.send(req.get(uri"http://localhost:$serverPort/image-api/raw/id/$id"))
     res.code.code should be(404)
   }
 
   test("That GET /id/1 with width resizing returns a resized image") {
+    when(imageStorage.get(any[String])).thenReturn(Success(TestData.ndlaLogoImageStream))
     val res = simpleHttpClient.send(req.get(uri"http://localhost:$serverPort/image-api/raw/id/$id?width=100"))
     res.code.code should be(200)
     val image = ImageIO.read(new ByteArrayInputStream(res.body))
@@ -131,6 +136,7 @@ class RawControllerTest extends UnitSuite with TestEnvironment with TapirControl
   }
 
   test("That GET /id/1 with height resizing returns a resized image") {
+    when(imageStorage.get(any[String])).thenReturn(Success(TestData.ndlaLogoImageStream))
     val res = simpleHttpClient.send(req.get(uri"http://localhost:$serverPort/image-api/raw/id/$id?height=40"))
     res.code.code should be(200)
     val image = ImageIO.read(new ByteArrayInputStream(res.body))
@@ -144,6 +150,7 @@ class RawControllerTest extends UnitSuite with TestEnvironment with TapirControl
   }
 
   test("That GET /id/1 with cropping returns a cropped image") {
+    when(imageStorage.get(any[String])).thenReturn(Success(TestData.ndlaLogoImageStream))
     val res = simpleHttpClient.send(
       req.get(uri"http://localhost:$serverPort/image-api/raw/id/$id?cropStartX=0&cropStartY=0&cropEndX=50&cropEndY=50")
     )
@@ -154,6 +161,7 @@ class RawControllerTest extends UnitSuite with TestEnvironment with TapirControl
   }
 
   test("That GET /id/1 with cropping and resizing returns a cropped and resized image") {
+    when(imageStorage.get(any[String])).thenReturn(Success(TestData.ndlaLogoImageStream))
     val res = simpleHttpClient.send(
       req.get(
         uri"http://localhost:$serverPort/image-api/raw/id/$id?cropStartX=0&cropStartY=0&cropEndX=50&cropEndY=50&width=50"
@@ -166,7 +174,7 @@ class RawControllerTest extends UnitSuite with TestEnvironment with TapirControl
   }
 
   test("That GET /imageGif.gif with width resizing returns the original image") {
-    when(imageStorage.get(any[String])).thenReturn(Success(ndlaLogoGifImageStream))
+    when(imageStorage.get(any[String])).thenReturn(Success(TestData.ndlaLogoGifImageStream))
     val res = simpleHttpClient.send(req.get(uri"http://localhost:$serverPort/image-api/raw/$imageGifName?width=100"))
     res.code.code should be(200)
     val image = ImageIO.read(new ByteArrayInputStream(res.body))
@@ -175,7 +183,7 @@ class RawControllerTest extends UnitSuite with TestEnvironment with TapirControl
   }
 
   test("That GET /imageGif.gif with height resizing returns the original image") {
-    when(imageStorage.get(any[String])).thenReturn(Success(ndlaLogoGifImageStream))
+    when(imageStorage.get(any[String])).thenReturn(Success(TestData.ndlaLogoGifImageStream))
     val res = simpleHttpClient.send(req.get(uri"http://localhost:$serverPort/image-api/raw/$imageGifName?height=40"))
     res.code.code should be(200)
     val image = ImageIO.read(new ByteArrayInputStream(res.body))
@@ -184,7 +192,7 @@ class RawControllerTest extends UnitSuite with TestEnvironment with TapirControl
   }
 
   test("That GET /imageGif.gif with cropping returns the original image") {
-    when(imageStorage.get(any[String])).thenReturn(Success(ndlaLogoGifImageStream))
+    when(imageStorage.get(any[String])).thenReturn(Success(TestData.ndlaLogoGifImageStream))
     val res = simpleHttpClient.send(
       req.get(
         uri"http://localhost:$serverPort/image-api/raw/$imageGifName?cropStartX=0&cropStartY=0&cropEndX=50&cropEndY=50"
@@ -198,7 +206,7 @@ class RawControllerTest extends UnitSuite with TestEnvironment with TapirControl
   }
 
   test("That GET /imageGif.jpg with cropping and resizing returns the original image") {
-    when(imageStorage.get(any[String])).thenReturn(Success(ndlaLogoGifImageStream))
+    when(imageStorage.get(any[String])).thenReturn(Success(TestData.ndlaLogoGifImageStream))
     val res = simpleHttpClient.send(
       req.get(
         uri"http://localhost:$serverPort/image-api/raw/$imageGifName?cropStartX=0&cropStartY=0&cropEndX=50&cropEndY=50&width=50"
@@ -212,18 +220,18 @@ class RawControllerTest extends UnitSuite with TestEnvironment with TapirControl
   }
 
   test("That GET /logo.svg with cropping and resizing returns the original image") {
-    when(imageStorage.get(any[String])).thenReturn(Success(ccLogoSvgImageStream))
+    when(imageStorage.get(any[String])).thenReturn(Success(TestData.ccLogoSvgImageStream))
     val res = simpleHttpClient.send(
       req.get(
         uri"http://localhost:$serverPort/image-api/raw/$imageSvgName?cropStartX=0&cropStartY=0&cropEndX=50&cropEndY=50&width=50"
       )
     )
     res.code.code should equal(200)
-    res.body should equal(ccLogoSvgImageStream.stream.readAllBytes())
+    res.body should equal(TestData.ccLogoSvgImageStream.stream.readAllBytes())
   }
 
-  test("That GET /id/1 with width resizing returns the original image") {
-    when(imageStorage.get(any[String])).thenReturn(Success(ndlaLogoGifImageStream))
+  test("That GET /id/1 for GIF image with width resizing returns the original image") {
+    when(imageStorage.get(any[String])).thenReturn(Success(TestData.ndlaLogoGifImageStream))
     val res = simpleHttpClient.send(req.get(uri"http://localhost:$serverPort/image-api/raw/id/$idGif?width=100"))
     res.code.code should equal(200)
     val image = ImageIO.read(new ByteArrayInputStream(res.body))
@@ -231,8 +239,8 @@ class RawControllerTest extends UnitSuite with TestEnvironment with TapirControl
     image.getHeight should equal(60)
   }
 
-  test("That GET /id/1 with height resizing returns the original image") {
-    when(imageStorage.get(any[String])).thenReturn(Success(ndlaLogoGifImageStream))
+  test("That GET /id/1 for GIF image with height resizing returns the original image") {
+    when(imageStorage.get(any[String])).thenReturn(Success(TestData.ndlaLogoGifImageStream))
     val res = simpleHttpClient.send(req.get(uri"http://localhost:$serverPort/image-api/raw/id/$idGif?height=40"))
     res.code.code should equal(200)
     val image = ImageIO.read(new ByteArrayInputStream(res.body))
@@ -240,8 +248,8 @@ class RawControllerTest extends UnitSuite with TestEnvironment with TapirControl
     image.getHeight should equal(60)
   }
 
-  test("That GET /id/2 with cropping returns the original image") {
-    when(imageStorage.get(any[String])).thenReturn(Success(ndlaLogoGifImageStream))
+  test("That GET /id/2 for GIF image with cropping returns the original image") {
+    when(imageStorage.get(any[String])).thenReturn(Success(TestData.ndlaLogoGifImageStream))
     val res = simpleHttpClient.send(
       req.get(
         uri"http://localhost:$serverPort/image-api/raw/id/$idGif?cropStartX=0&cropStartY=0&cropEndX=50&cropEndY=50"
@@ -254,8 +262,8 @@ class RawControllerTest extends UnitSuite with TestEnvironment with TapirControl
     image.getHeight should equal(60)
   }
 
-  test("That GET /id/1 with cropping and resizing returns the original image") {
-    when(imageStorage.get(any[String])).thenReturn(Success(ndlaLogoGifImageStream))
+  test("That GET /id/1 for GIF image with cropping and resizing returns the original image") {
+    when(imageStorage.get(any[String])).thenReturn(Success(TestData.ndlaLogoGifImageStream))
     val res = simpleHttpClient.send(
       req.get(
         uri"http://localhost:$serverPort/image-api/raw/id/$idGif?cropStartX=0&cropStartY=0&cropEndX=50&cropEndY=50&width=50"
@@ -270,13 +278,14 @@ class RawControllerTest extends UnitSuite with TestEnvironment with TapirControl
 
   test("that image is found by filename with non-ASCII characters") {
     val fileNameWithNonAsciiChars = "file æøå.svg"
-    when(imageStorage.get(eqTo(fileNameWithNonAsciiChars))).thenReturn(Success(ccLogoSvgImageStream))
+    when(imageStorage.getRaw(eqTo(fileNameWithNonAsciiChars))).thenReturn(Success(TestData.ccLogoSvgImageS3Object))
     val res = simpleHttpClient.send(req.get(uri"http://localhost:$serverPort/image-api/raw/$fileNameWithNonAsciiChars"))
     res.code.code should equal(200)
-    res.body should equal(ccLogoSvgImageStream.stream.readAllBytes())
+    res.body should equal(TestData.ccLogoSvgImageStream.stream.readAllBytes())
   }
 
   test("That GET /image.jpg | /id/1 sets Cache-Control headers") {
+    when(imageStorage.getRaw(any[String])).thenAnswer(_ => Success(TestData.ndlaLogoImageS3Object))
     val res1 = simpleHttpClient.send(req.get(uri"http://localhost:$serverPort/image-api/raw/$imageName"))
     val res2 = simpleHttpClient.send(req.get(uri"http://localhost:$serverPort/image-api/raw/id/$id"))
 
@@ -297,12 +306,24 @@ class RawControllerTest extends UnitSuite with TestEnvironment with TapirControl
     res.body should be(TestData.ndlaLogoImageS3Object.stream.readAllBytes())
   }
 
-  test("that GET /image.jpeg?download | /id/1?download sets Content-Disposition") {
-    when(imageStorage.get(any[String])).thenReturn(Success(ndlaLogoGifImageStream))
+  test("that GET /image.jpeg?download | /id/1?download sets Content-Disposition and returns raw unprocessed image") {
+    when(imageStorage.getRaw(any[String])).thenAnswer(_ => Success(TestData.ndlaLogoImageS3Object))
     val res1 = simpleHttpClient.send(req.get(uri"http://localhost:$serverPort/image-api/raw/image.jpg?download"))
-
-    when(imageStorage.get(any[String])).thenReturn(Success(ndlaLogoGifImageStream))
     val res2 = simpleHttpClient.send(req.get(uri"http://localhost:$serverPort/image-api/raw/id/1?download"))
+
+    res1.code.code should be(200)
+    res2.code.code should be(200)
+    res1.headers.find(_.is("content-disposition")).get.value should be("attachment")
+    res2.headers.find(_.is("content-disposition")).get.value should be("attachment")
+    res1.body should be(TestData.ndlaLogoImageS3Object.stream.readAllBytes())
+    res2.body should be(TestData.ndlaLogoImageS3Object.stream.readAllBytes())
+  }
+
+  test("that GET /image.jpeg?width=100&download | /id/1?width=100&download sets Content-Disposition") {
+    when(imageStorage.get(any[String])).thenAnswer(_ => Success(TestData.ndlaLogoImageStream))
+    val res1 =
+      simpleHttpClient.send(req.get(uri"http://localhost:$serverPort/image-api/raw/image.jpg?width=100&download"))
+    val res2 = simpleHttpClient.send(req.get(uri"http://localhost:$serverPort/image-api/raw/id/1?width=100&download"))
 
     res1.code.code should be(200)
     res2.code.code should be(200)


### PR DESCRIPTION
Sørger for at requests uten bildeparametere (bortsett fra `download`) får tilbake bildet direkte fra S3, uten noen form for prosessering