### PR TITLE
feat: expose sql metrics through prometheus

### DIFF
--- a/database/src/main/scala/no/ndla/database/DataSource.scala
+++ b/database/src/main/scala/no/ndla/database/DataSource.scala
@@ -20,6 +20,7 @@ class DataSource(hikariConfig: HikariConfig)(using props: DatabaseProps)
     val connectionPool = new DataSourceConnectionPool(this)
     ConnectionPool.add(props.ApplicationName, connectionPool)
     ConnectionPool.singleton(connectionPool)
+    SqlMetrics.install()
   }
 }
 

--- a/database/src/main/scala/no/ndla/database/SqlMetrics.scala
+++ b/database/src/main/scala/no/ndla/database/SqlMetrics.scala
@@ -1,0 +1,57 @@
+/*
+ * Part of NDLA database
+ * Copyright (C) 2026 NDLA
+ *
+ * See LICENSE
+ *
+ */
+
+package no.ndla.database
+
+import io.prometheus.metrics.core.metrics.{Counter, Histogram}
+import no.ndla.network.tapir.NdlaPrometheusRegistry
+import scalikejdbc.GlobalSettings
+
+object SqlMetrics {
+  private val whitespace = "\\s+".r
+
+  private def normalize(stmt: String): String = whitespace.replaceAllIn(stmt, " ").trim
+
+  private val queriesTotal: Counter = Counter
+    .builder()
+    .name("ndla_sql_queries_total")
+    .help("Successful SQL queries executed, by prepared statement.")
+    .labelNames("statement")
+    .register(NdlaPrometheusRegistry.registry)
+
+  private val queryFailuresTotal: Counter = Counter
+    .builder()
+    .name("ndla_sql_query_failures_total")
+    .help("Failed SQL queries, by prepared statement and exception class.")
+    .labelNames("statement", "exception")
+    .register(NdlaPrometheusRegistry.registry)
+
+  private val queryDurationSeconds: Histogram = Histogram
+    .builder()
+    .name("ndla_sql_query_duration_seconds")
+    .help("SQL query duration in seconds, by prepared statement (successful queries only).")
+    .labelNames("statement")
+    .classicUpperBounds(0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0)
+    .register(NdlaPrometheusRegistry.registry)
+
+  @volatile
+  private var installed = false
+
+  def install(): Unit = synchronized {
+    if (installed) return
+    GlobalSettings.taggedQueryCompletionListener = (stmt, _, millis, _) => {
+      val s = normalize(stmt)
+      queriesTotal.labelValues(s).inc()
+      queryDurationSeconds.labelValues(s).observe(millis / 1000.0)
+    }
+    GlobalSettings.queryFailureListener = (stmt, _, t) => {
+      queryFailuresTotal.labelValues(normalize(stmt), t.getClass.getSimpleName).inc()
+    }
+    installed = true
+  }
+}

--- a/network/src/main/scala/no/ndla/network/tapir/NdlaPrometheusRegistry.scala
+++ b/network/src/main/scala/no/ndla/network/tapir/NdlaPrometheusRegistry.scala
@@ -1,0 +1,39 @@
+/*
+ * Part of NDLA network
+ * Copyright (C) 2026 NDLA
+ *
+ * See LICENSE
+ *
+ */
+
+package no.ndla.network.tapir
+
+import com.typesafe.scalalogging.StrictLogging
+import io.prometheus.metrics.model.registry.PrometheusRegistry
+import no.ndla.common.TryUtil
+import sttp.shared.Identity
+import sttp.tapir.server.metrics.MetricLabels
+import sttp.tapir.server.metrics.prometheus.PrometheusMetrics
+
+object NdlaPrometheusRegistry extends StrictLogging {
+  val registry: PrometheusRegistry = new PrometheusRegistry()
+
+  private val tapirClosedErrorMessage    = "Client disconnected, request timed out, or request cancelled"
+  private val metricLabels: MetricLabels = MetricLabels(
+    forRequest = List("path" -> (req => req.pathSegments.mkString("/")), "method" -> (req => req.method.method)),
+    forEndpoint = List.empty,
+    forResponse = List(
+      "status" -> {
+        case Right(r)                                                               => Some(r.code.code.toString)
+        case Left(ex: RuntimeException) if ex.getMessage == tapirClosedErrorMessage =>
+          logger.info("Mapping closed request exception to status code 499 for metrics")
+          Some("499")
+        case Left(ex) if TryUtil.containsInterruptedException(ex) => Some("499")
+        case Left(_)                                              => Some("5xx")
+      }
+    ),
+  )
+
+  lazy val tapirPrometheusMetrics: PrometheusMetrics[Identity] =
+    PrometheusMetrics.default[Identity](namespace = "tapir", registry = registry, labels = metricLabels)
+}

--- a/network/src/main/scala/no/ndla/network/tapir/Routes.scala
+++ b/network/src/main/scala/no/ndla/network/tapir/Routes.scala
@@ -10,8 +10,7 @@ package no.ndla.network.tapir
 
 import com.typesafe.scalalogging.StrictLogging
 import io.circe.generic.auto.*
-import io.prometheus.metrics.model.registry.PrometheusRegistry
-import no.ndla.common.{RequestLogger, TryUtil}
+import no.ndla.common.RequestLogger
 import no.ndla.network.TaxonomyData
 import no.ndla.network.model.RequestInfo
 import no.ndla.network.tapir.NoNullJsonPrinter.*
@@ -30,8 +29,6 @@ import sttp.tapir.server.interceptor.decodefailure.DefaultDecodeFailureHandler
 import sttp.tapir.server.interceptor.exception.{ExceptionContext, ExceptionHandler}
 import sttp.tapir.server.interceptor.reject.{RejectContext, RejectHandler}
 import sttp.tapir.server.interceptor.{RequestInterceptor, RequestResult}
-import sttp.tapir.server.metrics.MetricLabels
-import sttp.tapir.server.metrics.prometheus.PrometheusMetrics
 import sttp.tapir.server.model.ValuedEndpointOutput
 import sttp.tapir.server.netty.NettyConfig
 import sttp.tapir.server.netty.sync.{NettySyncServer, NettySyncServerBinding, NettySyncServerOptions}
@@ -202,8 +199,7 @@ class Routes(using errorHelpers: ErrorHelpers, errorHandling: ErrorHandling, ser
   def startServerAndWait(name: String, port: Int, gracefulShutdownTimeout: FiniteDuration = 30.seconds)(
       onStartup: NettySyncServerBinding => Unit
   ): Unit = {
-    val prometheusMetrics =
-      PrometheusMetrics.default[Identity](namespace = "tapir", registry = registry, labels = metricLabels)
+    val prometheusMetrics = NdlaPrometheusRegistry.tapirPrometheusMetrics
 
     val options = NettySyncServerOptions
       .customiseInterceptors
@@ -240,21 +236,4 @@ class Routes(using errorHelpers: ErrorHelpers, errorHandling: ErrorHandling, ser
       never
     }
   }
-
-  private val tapirClosedErrorMessage             = "Client disconnected, request timed out, or request cancelled"
-  private[tapir] val registry: PrometheusRegistry = new PrometheusRegistry()
-  private val metricLabels: MetricLabels          = MetricLabels(
-    forRequest = List("path" -> (req => req.pathSegments.mkString("/")), "method" -> (req => req.method.method)),
-    forEndpoint = List.empty,
-    forResponse = List(
-      "status" -> {
-        case Right(r)                                                               => Some(r.code.code.toString)
-        case Left(ex: RuntimeException) if ex.getMessage == tapirClosedErrorMessage =>
-          logger.info("Mapping closed request exception to status code 499 for metrics")
-          Some("499")
-        case Left(ex) if TryUtil.containsInterruptedException(ex) => Some("499")
-        case Left(_)                                              => Some("5xx")
-      }
-    ),
-  )
 }

--- a/network/src/test/scala/no/ndla/network/tapir/RoutesTest.scala
+++ b/network/src/test/scala/no/ndla/network/tapir/RoutesTest.scala
@@ -61,11 +61,15 @@ class RoutesTest extends UnitTestSuite, TapirControllerTest {
 
   def req: PartialRequest[Array[Byte]] = basicRequest.response(asByteArrayAlways)
 
-  private def getTapirRequestCounterDataPoints: Seq[CounterDataPointSnapshot] =
-    routes.registry.scrape().iterator().asScala.find(_.getMetadata.getPrometheusName == "tapir_request") match {
-      case Some(cs: CounterSnapshot) => cs.getDataPoints.asScala.toSeq
-      case _                         => fail("Could not find tapir_request counter in Prometheus registry")
-    }
+  private def getTapirRequestCounterDataPoints: Seq[CounterDataPointSnapshot] = NdlaPrometheusRegistry
+    .registry
+    .scrape()
+    .iterator()
+    .asScala
+    .find(_.getMetadata.getPrometheusName == "tapir_request") match {
+    case Some(cs: CounterSnapshot) => cs.getDataPoints.asScala.toSeq
+    case _                         => fail("Could not find tapir_request counter in Prometheus registry")
+  }
 
   test("that aborting the request only increases the 499 error code metric") {
     Try(req.get(uri"http://localhost:$serverPort/routes/aborted-request").readTimeout(500.millis).send())


### PR DESCRIPTION
Dette burde gjøre at vi kan erstatte sql biten av javamelody med grafana for scala appene.

Testa det litt i test og ser ut som vi klarer å lage alt vi trenger(?).
(Man kan forresten hovre queryene så får man se hele prepared statementen)

<img width="1422" height="221" alt="image" src="https://github.com/user-attachments/assets/8c0234e8-b0a4-4024-ada0-ba52650ef942" />
