### PR TITLE
Fix: Add missing contributor to mapping

### DIFF
--- a/image-api/src/main/scala/no/ndla/imageapi/service/search/ImageIndexService.scala
+++ b/image-api/src/main/scala/no/ndla/imageapi/service/search/ImageIndexService.scala
@@ -60,6 +60,7 @@ class ImageIndexService(using
     val fields: Seq[ElasticField] = List(
       ObjectField("domainObject", enabled = Some(false)),
       intField("id"),
+      textField("contributors"),
       keywordField("license"),
       dateField("lastUpdated"),
       keywordField("defaultTitle"),


### PR DESCRIPTION
Vi har feltet i SearchableImage og vi forsøker å søke på det i SearchService, men det finnes ikkje i mappingen.