### PR TITLE
fix(prometheus): make endpoints use template instead of called url

### DIFF
--- a/network/src/main/scala/no/ndla/network/tapir/NdlaPrometheusRegistry.scala
+++ b/network/src/main/scala/no/ndla/network/tapir/NdlaPrometheusRegistry.scala
@@ -20,8 +20,8 @@ object NdlaPrometheusRegistry extends StrictLogging {
 
   private val tapirClosedErrorMessage    = "Client disconnected, request timed out, or request cancelled"
   private val metricLabels: MetricLabels = MetricLabels(
-    forRequest = List("path" -> (req => req.pathSegments.mkString("/")), "method" -> (req => req.method.method)),
-    forEndpoint = List.empty,
+    forRequest = List("method" -> (req => req.method.method)),
+    forEndpoint = List("path" -> (ep => ep.showPathTemplate(showQueryParam = None))),
     forResponse = List(
       "status" -> {
         case Right(r)                                                               => Some(r.code.code.toString)


### PR DESCRIPTION
Lagde en bug når jeg oppdaterte tapir hvor _alle_ pather blir med i labels i prometheus.
Dvs `/article-api/v2/articles/5` er en annen label enn `/article-api/v2/articles/10`.

Det blir fort veldig tungt for prometheus i prod, så fikser så vi er tilbake til `/article-api/v2/articles/{article_id}` 