### PR TITLE
fix(tests): use default Postgres wait strategy to avoid startup race

### DIFF
--- a/scalatestsuite/src/main/scala/no/ndla/scalatestsuite/PgContainer.scala
+++ b/scalatestsuite/src/main/scala/no/ndla/scalatestsuite/PgContainer.scala
@@ -9,13 +9,12 @@
 package no.ndla.scalatestsuite
 
 import org.testcontainers.postgresql.PostgreSQLContainer
-import org.testcontainers.containers.wait.strategy.HostPortWaitStrategy
 
 import java.time.Duration
 
 case class PgContainer(PostgresqlVersion: String, username: String, password: String, dbName: String)
     extends PostgreSQLContainer(s"postgres:$PostgresqlVersion") {
-  this.setWaitStrategy(new HostPortWaitStrategy().withStartupTimeout(Duration.ofSeconds(100)))
+  this.withStartupTimeout(Duration.ofSeconds(100))
 
   def setPassword(password: String): Unit = this.withPassword(password): Unit
   def setUsername(username: String): Unit = this.withUsername(username): Unit


### PR DESCRIPTION
Ser vi relativt ofte får den "Failed to initialize pool: FATAL: the database system is starting up" flaken ved oppstart av database i testene.

Ser ut som den default strategien til testcontainers på `PostgreSQLContainer` er litt smartere og venter på en logmelding så dette _burde_ fikse det.
