### PR TITLE
perf(search-api): speed up full reindex

### DIFF
--- a/network/src/main/scala/no/ndla/network/clients/TaxonomyApiClient.scala
+++ b/network/src/main/scala/no/ndla/network/clients/TaxonomyApiClient.scala
@@ -11,6 +11,7 @@ package no.ndla.network.clients
 import cats.implicits.toTraverseOps
 import com.typesafe.scalalogging.StrictLogging
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
+import io.circe.syntax.EncoderOps
 import io.circe.{Decoder, Encoder}
 import no.ndla.common.model.taxonomy.*
 import no.ndla.network.NdlaClient
@@ -43,18 +44,18 @@ class TaxonomyApiClient(taxonomyBaseUrl: String)(using ndlaClient: NdlaClient) e
     if (contentUris.isEmpty) Success(TaxonomyBundle.empty)
     else {
       val pageSize = Math.max(500, contentUris.size)
-      val nodes    = getPaginated[Node](
+      val body     = NodeSearchBody(
+        pageSize = pageSize,
+        page = 1,
+        contentUris = contentUris.toList,
+        nodeType = NodeType.values.toList,
+        includeContexts = true,
+      )
+      postPaginated[Node](
         s"$TaxonomyApiEndpoint/nodes/search",
         headers = getVersionHashHeader(shouldUsePublishedTax),
-        Seq(
-          "pageSize"        -> pageSize.toString,
-          "nodeType"        -> NodeType.values.mkString(","),
-          "includeContexts" -> "true",
-          "isVisible"       -> getIsVisibleParam(shouldUsePublishedTax),
-          "contentUris"     -> contentUris.mkString(","),
-        ),
-      )
-      nodes.map(TaxonomyBundle.fromNodeList)
+        body = body,
+      ).map(TaxonomyBundle.fromNodeList)
     }
   }
 
@@ -90,34 +91,55 @@ class TaxonomyApiClient(taxonomyBaseUrl: String)(using ndlaClient: NdlaClient) e
     )
   }
 
-  private def getPaginated[T: Decoder](
+  private def postPaginated[T: Decoder](
       url: String,
       headers: Map[String, String],
-      params: Seq[(String, String)],
+      body: NodeSearchBody,
   ): Try[List[T]] = {
-    def fetchPage(p: Seq[(String, String)]): Try[PaginationPage[T]] = get[PaginationPage[T]](url, headers, p)
+    def fetchPage(page: Int): Try[PaginationPage[T]] = {
+      val pageBody = body.copy(page = page).asJson.noSpaces
+      ndlaClient.fetchWithForwardedAuth[PaginationPage[T]](
+        quickRequest
+          .post(uri"$url")
+          .body(pageBody)
+          .header("Content-Type", "application/json")
+          .headers(headers)
+          .readTimeout(timeoutSeconds),
+        None,
+      )
+    }
 
-    val pageSize   = params.toMap.getOrElse("pageSize", "100").toInt
-    val pageParams = params :+ ("page" -> "1")
-
-    fetchPage(pageParams).flatMap(firstPage => {
-      val numPages  = Math.ceil(firstPage.totalCount.toDouble / pageSize.toDouble).toInt
-      val pageRange = 1 to numPages
-
-      val numThreads                                                 = Math.min(8, Math.max(1, numPages))
-      implicit val executionContext: ExecutionContextExecutorService =
-        ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(numThreads))
-
-      try {
-        val pages        = pageRange.map(pageNum => Future(fetchPage(params :+ ("page" -> s"$pageNum"))))
-        val mergedFuture = Future.sequence(pages)
-        val awaited      = Await.result(mergedFuture, timeoutSeconds)
-        awaited.toList.sequence.map(_.flatMap(_.results))
-      } finally {
-        executionContext.shutdown()
+    fetchPage(1).flatMap { firstPage =>
+      val numPages = Math.max(1, Math.ceil(firstPage.totalCount.toDouble / body.pageSize.toDouble).toInt)
+      if (numPages == 1) Success(firstPage.results)
+      else {
+        val numThreads                                                 = Math.min(8, numPages - 1)
+        implicit val executionContext: ExecutionContextExecutorService =
+          ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(numThreads))
+        try {
+          val tailPages = (
+            2 to numPages
+          ).map(p => Future(fetchPage(p)))
+          val mergedFuture = Future.sequence(tailPages)
+          val awaited      = Await.result(mergedFuture, timeoutSeconds)
+          awaited.toList.sequence.map(rest => firstPage.results ++ rest.flatMap(_.results))
+        } finally {
+          executionContext.shutdown()
+        }
       }
-    })
+    }
   }
+}
+
+case class NodeSearchBody(
+    pageSize: Int,
+    page: Int,
+    contentUris: List[String],
+    nodeType: List[NodeType],
+    includeContexts: Boolean,
+)
+object NodeSearchBody {
+  implicit val encoder: Encoder[NodeSearchBody] = deriveEncoder
 }
 
 case class PaginationPage[T](totalCount: Long, results: List[T])

--- a/search-api/src/main/scala/no/ndla/searchapi/SearchApiProperties.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/SearchApiProperties.scala
@@ -58,7 +58,7 @@ class SearchApiProperties extends BaseProps with StrictLogging {
 
   final val DefaultPageSize                      = 10
   def MaxPageSize                                = 10000
-  def IndexBulkSize: Int                         = propOrElse("INDEX_BULK_SIZE", "100").toInt
+  def IndexBulkSize: Int                         = propOrElse("INDEX_BULK_SIZE", "200").toInt
   def ElasticSearchIndexMaxResultWindow          = 10000
   def ElasticSearchScrollKeepAlive               = "1m"
   def InitialScrollContextKeywords: List[String] = List("0", "initial", "start", "first")

--- a/search-api/src/main/scala/no/ndla/searchapi/SearchApiProperties.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/SearchApiProperties.scala
@@ -59,6 +59,7 @@ class SearchApiProperties extends BaseProps with StrictLogging {
   final val DefaultPageSize                      = 10
   def MaxPageSize                                = 10000
   def IndexBulkSize: Int                         = propOrElse("INDEX_BULK_SIZE", "200").toInt
+  def IndexPipelineParallelism: Int              = propOrElse("INDEX_PIPELINE_PARALLELISM", "2").toInt
   def ElasticSearchIndexMaxResultWindow          = 10000
   def ElasticSearchScrollKeepAlive               = "1m"
   def InitialScrollContextKeywords: List[String] = List("0", "initial", "start", "first")

--- a/search-api/src/main/scala/no/ndla/searchapi/integration/SearchApiClient.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/integration/SearchApiClient.scala
@@ -60,6 +60,23 @@ trait SearchApiClient[T](using ndlaClient: NdlaClient, props: Props) extends Str
     }
   }
 
+  /** Returns the total document count and a function for fetching a specific page of results. Useful for callers that
+    * want to drive concurrent fetches themselves rather than walking the iterator returned by [[getChunks]].
+    */
+  def getChunkSource(implicit d: Decoder[T]): Try[ChunkSource[T]] = {
+    val pageSize = props.IndexBulkSize
+    getChunk(0, 0).map { initSearch =>
+      val totalCount = initSearch.totalCount
+      val numPages   = ceil(totalCount.toDouble / pageSize.toDouble).toInt
+      ChunkSource(
+        totalCount = totalCount,
+        pageSize = pageSize,
+        numPages = numPages,
+        fetchPage = (p: Int) => getChunk(p, pageSize).map(_.results),
+      )
+    }
+  }
+
   protected def getChunk(page: Int, pageSize: Int)(implicit d: Decoder[T]): Try[DomainDumpResults[T]] = {
     val params = Map("page" -> page.toString, "page-size" -> pageSize.toString)
     val reqs   = RequestInfo.fromThreadContext()
@@ -82,3 +99,5 @@ trait SearchApiClient[T](using ndlaClient: NdlaClient, props: Props) extends Str
     ndlaClient.fetchWithForwardedAuth[R](request, None)
   }
 }
+
+case class ChunkSource[T](totalCount: Long, pageSize: Int, numPages: Int, fetchPage: Int => Try[Seq[T]])

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/IndexService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/IndexService.scala
@@ -223,7 +223,14 @@ trait IndexService[D <: Content](using
                 case Failure(ex) =>
                   logger.error(s"Failed to fetch chunk $page from api client '${apiClient.name}'", ex)
                   Failure(ex)
-                case Success(chunk) => processChunk(chunk, indexName, indexingBundle)
+                case Success(chunk) =>
+                  val result = processChunk(chunk, indexName, indexingBundle)
+                  result
+                    .failed
+                    .foreach(ex =>
+                      logger.error(s"Failed to process chunk $page for $documentType: ${ex.getMessage}", ex)
+                    )
+                  result
               }
             }
           }

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/IndexService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/IndexService.scala
@@ -287,8 +287,8 @@ trait IndexService[D <: Content](using
 
       val filteredRequests = indexRequests.flatten
       if (filteredRequests.nonEmpty) {
-        val response = e4sClient.execute {
-          bulk(filteredRequests)
+        val response = retryOn429(s"bulk of ${filteredRequests.size} into $searchIndex ($documentType)") {
+          e4sClient.execute(bulk(filteredRequests))
         }
 
         response match {

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/IndexService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/IndexService.scala
@@ -22,6 +22,9 @@ import no.ndla.searchapi.Props
 import no.ndla.searchapi.integration.*
 import no.ndla.searchapi.model.domain.IndexingBundle
 
+import java.util.concurrent.{Executors, TimeUnit}
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
 
 abstract class BulkIndexingService(using props: Props, searchLanguage: SearchLanguage, e4sClient: NdlaE4sClient)
@@ -175,48 +178,69 @@ trait IndexService[D <: Content](using
     }
   }
 
+  private def processChunk(chunk: Seq[D], indexName: String, indexingBundle: IndexingBundle): Try[(Int, Int)] = {
+    val chunkIndexingBundle = indexingBundle.taxonomyBundle match {
+      case Some(_) => Success(indexingBundle)
+      case None    =>
+        val contentUris = taxonomyContentUris(chunk)
+        if (contentUris.nonEmpty) taxonomyApiClient
+          .getTaxonomyBundleForContentUris(contentUris, taxonomyShouldUsePublished)
+          .map(bundle => indexingBundle.copy(taxonomyBundle = Some(bundle)))
+        else Success(indexingBundle)
+    }
+
+    chunkIndexingBundle
+      .flatMap(bundle => indexDocuments(chunk, indexName, bundle))
+      .map(numIndexed => (numIndexed, chunk.size))
+  }
+
   private def sendToElastic(indexName: String, indexingBundle: IndexingBundle)(implicit
       d: Decoder[D]
   ): Try[BulkIndexResult] = {
+    apiClient.getChunkSource match {
+      case Failure(ex) =>
+        logger.error(s"Failed to determine chunk count from api client '${apiClient.name}'", ex)
+        Failure(ex)
+      case Success(source) =>
+        val parallelism                   = Math.max(1, Math.min(props.IndexPipelineParallelism, Math.max(1, source.numPages)))
+        val executor                      = Executors.newFixedThreadPool(parallelism)
+        implicit val ec: ExecutionContext = ExecutionContext.fromExecutor(executor)
 
-    val chunks  = apiClient.getChunks
-    val results = chunks
-      .map({
-        case Failure(ex) =>
-          logger.error(s"Failed to fetch chunk from with api client '${apiClient.name}'", ex)
-          Failure(ex)
-        case Success(c) =>
-          val chunkIndexingBundle = indexingBundle.taxonomyBundle match {
-            case Some(_) => Success(indexingBundle)
-            case None    =>
-              val contentUris = taxonomyContentUris(c)
-              if (contentUris.nonEmpty) taxonomyApiClient
-                .getTaxonomyBundleForContentUris(contentUris, taxonomyShouldUsePublished)
-                .map(bundle => indexingBundle.copy(taxonomyBundle = Some(bundle)))
-              else Success(indexingBundle)
+        try {
+          val futures = (
+            1 to source.numPages
+          ).map { page =>
+            Future {
+              source.fetchPage(page) match {
+                case Failure(ex) =>
+                  logger.error(s"Failed to fetch chunk $page from api client '${apiClient.name}'", ex)
+                  Failure(ex)
+                case Success(chunk) => processChunk(chunk, indexName, indexingBundle)
+              }
+            }
           }
 
-          chunkIndexingBundle
-            .flatMap(bundle => indexDocuments(c, indexName, bundle))
-            .map(numIndexed => (numIndexed, c.size))
-      })
-      .toList
+          val results = Await.result(Future.sequence(futures), Duration(60, TimeUnit.MINUTES))
 
-    results.collect { case Failure(ex) =>
-      Failure(ex)
-    } match {
-      case Nil =>
-        val successfulChunks = results.collect { case Success((chunkIndexed, chunkSize)) =>
-          (chunkIndexed, chunkSize)
+          results.collectFirst { case Failure(ex) =>
+            Failure(ex)
+          } match {
+            case Some(failure) => failure
+            case None          =>
+              val successfulChunks = results
+                .collect { case Success(pair) =>
+                  pair
+                }
+                .toList
+              val indexResult = countIndexed(successfulChunks)
+              logger.info(
+                s"${indexResult.count}/${indexResult.totalCount} documents ($documentType) were indexed successfully."
+              )
+              Success(indexResult)
+          }
+        } finally {
+          executor.shutdown()
         }
-
-        val indexResult = countIndexed(successfulChunks)
-        logger.info(
-          s"${indexResult.count}/${indexResult.totalCount} documents ($documentType) were indexed successfully."
-        )
-        Success(indexResult)
-
-      case notEmpty => notEmpty.head
     }
   }
 

--- a/search-api/src/main/scala/no/ndla/searchapi/service/search/IndexService.scala
+++ b/search-api/src/main/scala/no/ndla/searchapi/service/search/IndexService.scala
@@ -22,10 +22,18 @@ import no.ndla.searchapi.Props
 import no.ndla.searchapi.integration.*
 import no.ndla.searchapi.model.domain.IndexingBundle
 
-import java.util.concurrent.{Executors, TimeUnit}
+import java.util.concurrent.{Executors, ForkJoinPool, TimeUnit}
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
+
+/** Shared, CPU-bounded pool used for parallel JSON conversion of documents within a chunk. One pool per JVM, sized to
+  * the available cores, so that pipelining multiple chunks per index does not oversubscribe the CPUs.
+  */
+private object IndexConversionPool {
+  val executionContext: ExecutionContext =
+    ExecutionContext.fromExecutor(new ForkJoinPool(Math.max(2, Runtime.getRuntime.availableProcessors())))
+}
 
 abstract class BulkIndexingService(using props: Props, searchLanguage: SearchLanguage, e4sClient: NdlaE4sClient)
     extends BaseIndexService {
@@ -248,12 +256,20 @@ trait IndexService[D <: Content](using
     if (contents.isEmpty) {
       Success(0)
     } else {
-      val req = contents.map { content =>
-        createIndexRequest(content, indexName, indexingBundle).recoverWith({ case ex =>
-          logger.error(s"Failed to create indexRequest for $documentType with id: ${content.id}", ex)
-          Failure(ex)
-        })
-      }
+      // JSON conversion is CPU-bound (Jsoup HTML-stripping per language field per doc). Run it on the shared
+      // conversion pool so we get per-core utilization even when only one chunk is in flight.
+      implicit val ec: ExecutionContext = IndexConversionPool.executionContext
+      val req                           = Await.result(
+        Future.traverse(contents.toVector) { content =>
+          Future {
+            createIndexRequest(content, indexName, indexingBundle).recoverWith { case ex =>
+              logger.error(s"Failed to create indexRequest for $documentType with id: ${content.id}", ex)
+              Failure(ex)
+            }
+          }
+        },
+        Duration(60, TimeUnit.MINUTES),
+      )
 
       val indexRequests = req.collect { case Success(indexRequest) =>
         indexRequest

--- a/search/src/main/scala/no/ndla/search/BaseIndexService.scala
+++ b/search/src/main/scala/no/ndla/search/BaseIndexService.scala
@@ -22,8 +22,9 @@ import no.ndla.search.model.domain.{BulkIndexResult, ElasticIndexingException, R
 
 import java.text.SimpleDateFormat
 import java.util.Calendar
-import scala.util.{Failure, Success, Try}
+import scala.annotation.tailrec
 import scala.util.boundary
+import scala.util.{Failure, Random, Success, Try}
 
 abstract class BaseIndexService(using e4sClient: NdlaE4sClient, props: BaseProps, searchLanguage: SearchLanguage)
     extends StrictLogging {
@@ -63,6 +64,41 @@ abstract class BaseIndexService(using e4sClient: NdlaE4sClient, props: BaseProps
       .indexSetting("max_result_window", MaxResultWindowOption)
       .replicas(0) // Spawn with 0 replicas to make indexing faster
       .analysis(analysis)
+  }
+
+  private val MaxBulkRetries       = 6
+  private val InitialBackoffMillis = 500L
+  private val MaxBackoffMillis     = 30000L
+
+  /** Runs `body` and retries with exponential backoff + jitter when Elasticsearch rejects the request with HTTP 429
+    * (`es_rejected_execution_exception`, typically caused by `indexing_pressure.memory.limit`). Other failures pass
+    * through unchanged. Once retries are exhausted the last failure is returned.
+    */
+  protected def retryOn429[A](label: String)(body: => Try[A]): Try[A] = {
+    @tailrec
+    def go(attempt: Int): Try[A] = {
+      val result = body
+      result match {
+        case Failure(ex) if isThrottled(ex) && attempt < MaxBulkRetries =>
+          val delay = backoffDelayMillis(attempt)
+          logger.warn(s"$label rejected by ES (429), retrying in ${delay}ms (attempt ${attempt + 1}/$MaxBulkRetries)")
+          Thread.sleep(delay)
+          go(attempt + 1)
+        case other => other
+      }
+    }
+    go(0)
+  }
+
+  private def isThrottled(ex: Throwable): Boolean = ex match {
+    case nse: NdlaSearchException[?] => nse.rf.exists(_.status == 429)
+    case _                           => false
+  }
+
+  private def backoffDelayMillis(attempt: Int): Long = {
+    val exponential = InitialBackoffMillis * (1L << Math.min(attempt, 10))
+    val capped      = Math.min(MaxBackoffMillis, exponential)
+    capped + Random.nextInt(250).toLong
   }
 
   /** Applies bulk-load-friendly index settings (no periodic refresh, async translog). Must be paired with
@@ -375,13 +411,15 @@ abstract class BaseIndexService(using e4sClient: NdlaE4sClient, props: BaseProps
   protected def executeRequests(requests: Seq[IndexRequest]): Try[BulkIndexResult] = {
     requests match {
       case Nil         => Success(BulkIndexResult(0, requests.size))
-      case head :: Nil => e4sClient
-          .execute(head)
-          .map(r =>
-            if (r.isSuccess) BulkIndexResult(1, requests.size)
-            else BulkIndexResult(0, requests.size)
-          )
-      case reqs => e4sClient.execute(bulk(reqs)).map(r => BulkIndexResult(r.result.successes.size, requests.size))
+      case head :: Nil => retryOn429(s"single-doc index into $searchIndex") {
+          e4sClient.execute(head)
+        }.map(r =>
+          if (r.isSuccess) BulkIndexResult(1, requests.size)
+          else BulkIndexResult(0, requests.size)
+        )
+      case reqs => retryOn429(s"bulk of ${reqs.size} into $searchIndex") {
+          e4sClient.execute(bulk(reqs))
+        }.map(r => BulkIndexResult(r.result.successes.size, requests.size))
     }
   }
 }

--- a/search/src/main/scala/no/ndla/search/BaseIndexService.scala
+++ b/search/src/main/scala/no/ndla/search/BaseIndexService.scala
@@ -96,8 +96,8 @@ abstract class BaseIndexService(using e4sClient: NdlaE4sClient, props: BaseProps
   }
 
   private def backoffDelayMillis(attempt: Int): Long = {
-    val exponential = InitialBackoffMillis * (1L << Math.min(attempt, 10))
-    val capped      = Math.min(MaxBackoffMillis, exponential)
+    val exponential = InitialBackoffMillis * Math.pow(2, attempt)
+    val capped      = Math.min(MaxBackoffMillis, exponential.toLong)
     capped + Random.nextInt(250).toLong
   }
 

--- a/search/src/main/scala/no/ndla/search/BaseIndexService.scala
+++ b/search/src/main/scala/no/ndla/search/BaseIndexService.scala
@@ -96,8 +96,8 @@ abstract class BaseIndexService(using e4sClient: NdlaE4sClient, props: BaseProps
   }
 
   private def backoffDelayMillis(attempt: Int): Long = {
-    val exponential = InitialBackoffMillis * Math.pow(2, attempt)
-    val capped      = Math.min(MaxBackoffMillis, exponential.toLong)
+    val exponential = InitialBackoffMillis * Math.powExact(2L, attempt)
+    val capped      = Math.min(MaxBackoffMillis, exponential)
     capped + Random.nextInt(250).toLong
   }
 

--- a/search/src/main/scala/no/ndla/search/BaseIndexService.scala
+++ b/search/src/main/scala/no/ndla/search/BaseIndexService.scala
@@ -65,6 +65,25 @@ abstract class BaseIndexService(using e4sClient: NdlaE4sClient, props: BaseProps
       .analysis(analysis)
   }
 
+  /** Applies bulk-load-friendly index settings (no periodic refresh, async translog). Must be paired with
+    * [[restoreIndexSettingsAfterBulkLoad]] before the new index is exposed via alias swap.
+    */
+  private def applyBulkLoadIndexSettings(indexName: String): Try[?] = {
+    val bulkSettings: Map[String, String] = Map("refresh_interval" -> "-1", "translog.durability" -> "async")
+    e4sClient.execute(updateSettings(Indexes(indexName), bulkSettings))
+  }
+
+  /** Reverts the bulk-loading index settings set by [[applyBulkLoadIndexSettings]] and forces a refresh so the index is
+    * queryable once the alias points at it.
+    */
+  private def restoreIndexSettingsAfterBulkLoad(indexName: String): Try[?] = {
+    val restoreSettings: Map[String, String] = Map("refresh_interval" -> "1s", "translog.durability" -> "request")
+    for {
+      _ <- e4sClient.execute(updateSettings(Indexes(indexName), restoreSettings))
+      _ <- e4sClient.execute(refreshIndex(indexName))
+    } yield ()
+  }
+
   def createIndexWithName(indexName: String): Try[String] = createIndexWithName(indexName, None)
 
   def createIndexWithName(indexName: String, numShards: Option[Int]): Try[String] = {
@@ -128,8 +147,10 @@ abstract class BaseIndexService(using e4sClient: NdlaE4sClient, props: BaseProps
   def indexDocumentsInBulk(numShards: Option[Int])(sendToElasticFunction: SendToElastic): Try[ReindexResult] = for {
     start       <- Try(System.currentTimeMillis())
     indexName   <- createIndexWithGeneratedName(numShards)
+    _           <- applyBulkLoadIndexSettings(indexName)
     indexResult <- sendToElasticFunction(indexName)
     result      <- validateBulkIndexing(indexResult)
+    _           <- restoreIndexSettingsAfterBulkLoad(indexName)
     aliasTarget <- getAliasTarget
     _           <- updateAliasTarget(aliasTarget, indexName)
   } yield ReindexResult(documentType, result.failed, result.count, System.currentTimeMillis() - start)
@@ -150,7 +171,9 @@ abstract class BaseIndexService(using e4sClient: NdlaE4sClient, props: BaseProps
       for {
         newIndex <- createIndexWithGeneratedName(numShards.some)
         _         = logger.info(s"Created index $newIndex for internal reindexing")
+        _        <- applyBulkLoadIndexSettings(newIndex)
         _        <- e4sClient.execute(reindex(currentIndex, newIndex))
+        _        <- restoreIndexSettingsAfterBulkLoad(newIndex)
         _        <- updateAliasTarget(currentIndex.some, newIndex)
       } yield ()
     }

--- a/search/src/main/scala/no/ndla/search/NdlaSearchException.scala
+++ b/search/src/main/scala/no/ndla/search/NdlaSearchException.scala
@@ -19,10 +19,11 @@ case class NdlaSearchException[T](
 
 object NdlaSearchException {
   def apply[T](request: T, rf: RequestFailure): NdlaSearchException[T] = {
-    val msg = s"""Got error from elasticsearch:
+    val rstr = request.toString.slice(0, 1000)
+    val msg  = s"""Got error from elasticsearch:
         |  Status: ${rf.status}
         |  Error: ${rf.error}
-        |  Caused by request: $request
+        |  Caused by request: $rstr
         |""".stripMargin
 
     new NdlaSearchException(msg, Some(rf))


### PR DESCRIPTION
Full reindex kjørte chunkene helt sekvensielt. Denne PR-en parallelliserer den konverteringen, og tuner temp-indeksen for bulk load.

  - Pipeliner chunks per index på en thread pool. SearchApiClient får en ChunkSource (pageCount + fetchPage) så
  index-servicen kan styre parallelliteten selv istedenfor å bruke iteratoren.
  - Konverterer dokumenter i en chunk i parallell på en JVM-wide ForkJoinPool.
  - INDEX_BULK_SIZE bumpa fra 100 → 200. Halverer roundtrips både mot upstream-dump, taxonomy og ES bulk.
  - Skrur av periodic refresh og setter translog til async durability på temp-indeksen mens den fylles, restorer defaults og forcer en refresh før alias-oppdateringen.
  - Retry på 429 fra ES bulk med backoff + jitter (500ms → 30s, maks 6 retries).
  - Bytter /nodes/search mot taxonomy-api fra GET til POST så contentUris havner i body. Med større bulk size overgikk query-stringen tomcat sin limit i taxonomy-
  - Logger per-chunk-feil i sendToElastic så ting synes når /intern/index kalles med run-in-background=true.
  - Trunkerer request-body i NdlaSearchException-loggingen — fulle bulk-bodies gjorde loggene uleselige og trege.

Lokalt gikk en full reindeksering fra 4-5 -> 3 min
I test gikk en full reindeksering fra 18 -> 7 min