### PR TITLE
fix(network): defer Matomo URL interpolation to fix openapi generation

### DIFF
--- a/network/src/main/scala/no/ndla/network/clients/matomo/MatomoApiClient.scala
+++ b/network/src/main/scala/no/ndla/network/clients/matomo/MatomoApiClient.scala
@@ -20,7 +20,7 @@ import scala.util.{Failure, Success, Try}
 class MatomoApiClient(using props: MatomoProps, client: NdlaClient) extends StrictLogging {
   import props.{MatomoSubjectDimensionName, MatomoUrl, MatomoSiteId, MatomoTokenAuth}
   private val timeout: FiniteDuration = 30.seconds
-  private val baseUrl                 = uri"$MatomoUrl/index.php"
+  private lazy val baseUrl            = uri"$MatomoUrl/index.php"
 
   def getDimensionIdForSubjectId: Try[String] = {
     val params = Map[String, String](


### PR DESCRIPTION
Brakk visst typescript generering også 😅 