### PR TITLE
perf(taxonomy-api): reduce sql queries/req

### DIFF
--- a/taxonomy-api/compile-resources/application.yml
+++ b/taxonomy-api/compile-resources/application.yml
@@ -48,6 +48,10 @@ spring:
     activate:
       on-profile: junit
 
+# Tests create and publish versions directly via repositories, bypassing cache invalidation,
+# so disable the version schema cache to keep test isolation intact.
+taxonomy.version-schema-cache-ttl-seconds: 0
+
 logging.level:
   liquibase: WARN
   org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping: WARN

--- a/taxonomy-api/src/main/java/no/ndla/taxonomy/domain/Node.java
+++ b/taxonomy-api/src/main/java/no/ndla/taxonomy/domain/Node.java
@@ -17,6 +17,7 @@ import no.ndla.taxonomy.config.Constants;
 import no.ndla.taxonomy.domain.exceptions.ChildNotFoundException;
 import no.ndla.taxonomy.domain.exceptions.DuplicateIdException;
 import no.ndla.taxonomy.util.PrettyUrlUtil;
+import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.Type;
 
 @Entity
@@ -24,9 +25,11 @@ public class Node extends DomainObject implements EntityWithMetadata {
     private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(Node.class);
 
     @OneToMany(mappedBy = "child", cascade = CascadeType.ALL, orphanRemoval = true)
+    @BatchSize(size = 100)
     private final Set<NodeConnection> parentConnections = new TreeSet<>();
 
     @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL, orphanRemoval = true)
+    @BatchSize(size = 100)
     private final Set<NodeConnection> childConnections = new TreeSet<>();
 
     @Column
@@ -49,6 +52,7 @@ public class Node extends DomainObject implements EntityWithMetadata {
     private boolean context;
 
     @OneToMany(mappedBy = "node", cascade = CascadeType.ALL, orphanRemoval = true)
+    @BatchSize(size = 100)
     private Set<ResourceResourceType> resourceResourceTypes = new TreeSet<>();
 
     @Column

--- a/taxonomy-api/src/main/java/no/ndla/taxonomy/repositories/NodeConnectionRepository.java
+++ b/taxonomy-api/src/main/java/no/ndla/taxonomy/repositories/NodeConnectionRepository.java
@@ -77,17 +77,20 @@ public interface NodeConnectionRepository extends TaxonomyRepository<NodeConnect
     @Query("""
             SELECT DISTINCT nc
             FROM NodeConnection nc
-            JOIN FETCH nc.parent n
             JOIN FETCH nc.child c
-            WHERE nc.child.publicId IN :nodeId""")
-    List<NodeConnection> doFindAllByChildIdIncludeTranslationsAndCachedUrlsAndFilters(Collection<URI> nodeId);
+            LEFT JOIN FETCH c.resourceResourceTypes rrt
+            LEFT JOIN FETCH rrt.resourceType
+            WHERE nc.child.publicId IN :childIds
+            AND nc.parent.publicId IN :parentIds
+            """)
+    List<NodeConnection> doFindChildConnections(Collection<URI> childIds, Collection<URI> parentIds);
 
-    default List<NodeConnection> findAllByChildIdIncludeTranslationsAndCachedUrlsAndFilters(Collection<URI> nodeId) {
-        if (nodeId.isEmpty()) {
+    default List<NodeConnection> findChildConnections(Collection<URI> childIds, Collection<URI> parentIds) {
+        if (childIds.isEmpty()) {
             return List.of();
         }
 
-        return doFindAllByChildIdIncludeTranslationsAndCachedUrlsAndFilters(nodeId);
+        return doFindChildConnections(childIds, parentIds);
     }
 
     Optional<NodeConnection> findFirstByPublicId(URI publicId);

--- a/taxonomy-api/src/main/java/no/ndla/taxonomy/repositories/NodeRepository.java
+++ b/taxonomy-api/src/main/java/no/ndla/taxonomy/repositories/NodeRepository.java
@@ -32,10 +32,12 @@ public interface NodeRepository extends TaxonomyRepository<Node> {
             SELECT DISTINCT n FROM Node n
             LEFT JOIN FETCH n.resourceResourceTypes rrt
             LEFT JOIN FETCH rrt.resourceType rt
-            LEFT JOIN FETCH n.parentConnections pc
             WHERE n.id in :ids
             """)
     List<Node> findByIds(Collection<Integer> ids);
+
+    @Query("SELECT n FROM Node n WHERE n.publicId IN :ids")
+    List<Node> findByPublicIds(Collection<URI> ids);
 
     @Query("""
             SELECT n

--- a/taxonomy-api/src/main/java/no/ndla/taxonomy/service/NodeService.java
+++ b/taxonomy-api/src/main/java/no/ndla/taxonomy/service/NodeService.java
@@ -118,6 +118,9 @@ public class NodeService {
                 .values()
                 .forEach(idChunk -> {
                     final var nodes = nodeRepository.findByIds(idChunk);
+                    var parentContexts = includeParents
+                            ? Optional.of(prefetchParentContexts(nodes))
+                            : Optional.<Set<TaxonomyContext>>empty();
                     var dtos = nodes.stream()
                             .map(node -> new NodeDTO(
                                     root,
@@ -129,12 +132,27 @@ public class NodeService {
                                     includeContexts,
                                     filterProgrammes,
                                     metadataFilters.getVisible().orElse(false),
-                                    includeParents))
+                                    includeParents,
+                                    parentContexts))
                             .toList();
                     listToReturn.addAll(dtos);
                 });
 
         return listToReturn;
+    }
+
+    private Set<TaxonomyContext> prefetchParentContexts(Collection<Node> nodes) {
+        var ancestorIds = nodes.stream()
+                .flatMap(node -> node.getContexts().stream())
+                .flatMap(ctx -> ctx.parentIds().stream())
+                .map(URI::create)
+                .collect(Collectors.toSet());
+        if (ancestorIds.isEmpty()) {
+            return Set.of();
+        }
+        return nodeRepository.findByPublicIds(ancestorIds).stream()
+                .flatMap(ancestor -> ancestor.getContexts().stream())
+                .collect(Collectors.toSet());
     }
 
     public List<ConnectionDTO> getAllConnections(URI nodePublicId) {
@@ -169,7 +187,8 @@ public class NodeService {
                 includeContexts,
                 filterProgrammes,
                 isVisible,
-                true);
+                true,
+                Optional.of(prefetchParentContexts(List.of(node))));
     }
 
     public Optional<Node> getMaybeNode(URI publicId) {
@@ -332,6 +351,7 @@ public class NodeService {
     }
 
     public List<TaxonomyContextDTO> nodesToContexts(List<Node> nodes, boolean filterVisibles, String language) {
+        var allParentContexts = prefetchParentContexts(nodes);
         return nodes.stream()
                 .flatMap(node -> {
                     var contexts = filterVisibles
@@ -349,7 +369,7 @@ public class NodeService {
                                 .map(SearchableTaxonomyResourceType::new)
                                 .toList();
                         var breadcrumbs = context.breadcrumbs();
-                        var parentContexts = node.getAllParentContexts();
+                        var parentContexts = allParentContexts;
                         var parents = context.parentContextIds().stream()
                                 .map(parentCtxId -> {
                                     var parent = parentContexts.stream()

--- a/taxonomy-api/src/main/java/no/ndla/taxonomy/service/dtos/NodeDTO.java
+++ b/taxonomy-api/src/main/java/no/ndla/taxonomy/service/dtos/NodeDTO.java
@@ -149,6 +149,32 @@ public class NodeDTO {
             boolean filterProgrammes,
             boolean isVisible,
             boolean includeParents) {
+        this(
+                root,
+                parent,
+                entity,
+                connectionType,
+                languageCode,
+                contextId,
+                includeContexts,
+                filterProgrammes,
+                isVisible,
+                includeParents,
+                Optional.empty());
+    }
+
+    public NodeDTO(
+            Optional<Node> root,
+            Optional<Node> parent,
+            Node entity,
+            NodeConnectionType connectionType,
+            String languageCode,
+            Optional<String> contextId,
+            boolean includeContexts,
+            boolean filterProgrammes,
+            boolean isVisible,
+            boolean includeParents,
+            Optional<Set<TaxonomyContext>> prefetchedParentContexts) {
 
         var contexts = entity.getContexts();
         var visibleContexts =
@@ -194,7 +220,8 @@ public class NodeDTO {
         this.contextids = entity.getContextIds();
         this.updatedAt = entity.getUpdatedAt();
 
-        Set<TaxonomyContext> parentContexts = includeParents ? entity.getAllParentContexts() : Set.of();
+        Set<TaxonomyContext> parentContexts =
+                includeParents ? prefetchedParentContexts.orElseGet(entity::getAllParentContexts) : Set.of();
         Optional<TaxonomyContext> selected =
                 entity.pickContext(contextId, parent, root, connectionType, filteredContexts);
         selected.ifPresent(ctx -> {

--- a/taxonomy-api/src/main/kotlin/no/ndla/taxonomy/rest/v1/Nodes.kt
+++ b/taxonomy-api/src/main/kotlin/no/ndla/taxonomy/rest/v1/Nodes.kt
@@ -446,9 +446,9 @@ class Nodes(
               .filter { nodeTypes.contains(it.nodeType) }
               .map { it.publicId }
         }
-    val children =
-        nodeConnectionRepository.findAllByChildIdIncludeTranslationsAndCachedUrlsAndFilters(
-            childrenIds)
+
+    val parentIds = if (recursive) childrenIds + node.publicId else listOf(node.publicId)
+    val children = nodeConnectionRepository.findChildConnections(childrenIds, parentIds)
 
     val returnList =
         children.map { nodeConnection ->
@@ -462,10 +462,7 @@ class Nodes(
           )
         }
 
-    val filtered =
-        returnList.filter { childrenIds.contains(it.parentId) || node.publicId == it.parentId }
-
-    return treeSorter.sortList(filtered).distinct()
+    return treeSorter.sortList(returnList).distinct()
   }
 
   @GetMapping("/{id}/connections")

--- a/taxonomy-api/src/main/kotlin/no/ndla/taxonomy/service/VersionHeaderExtractor.kt
+++ b/taxonomy-api/src/main/kotlin/no/ndla/taxonomy/service/VersionHeaderExtractor.kt
@@ -8,17 +8,12 @@
 package no.ndla.taxonomy.service
 
 import jakarta.servlet.http.HttpServletRequest
-import no.ndla.taxonomy.domain.VersionType
-import no.ndla.taxonomy.repositories.VersionRepository
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 
 /** Takes an http request and extracts a given header. Returns a database schema name. */
 @Component
-class VersionHeaderExtractor(
-    private val versionService: VersionService,
-    private val versionRepository: VersionRepository
-) {
+class VersionHeaderExtractor(private val versionResolver: VersionResolver) {
 
   @Value("\${spring.datasource.hikari.schema:taxonomy_api}")
   private lateinit var defaultSchema: String
@@ -31,16 +26,10 @@ class VersionHeaderExtractor(
       val versionHash = req.getHeader("VersionHash")
       when {
         // Header supplied, use that version if in database. Else use default.
-        versionHash != null ->
-            versionRepository.findFirstByHash(versionHash)?.let {
-              versionService.schemaFromHash(it.hash)
-            } ?: defaultSchema
+        versionHash != null -> versionResolver.versionSchemaForHash(versionHash) ?: defaultSchema
 
         // No header, check published and use for gets
-        req.method == "GET" ->
-            versionRepository.findFirstByVersionType(VersionType.PUBLISHED)?.let {
-              versionService.schemaFromHash(it.hash)
-            } ?: defaultSchema
+        req.method == "GET" -> versionResolver.publishedVersionSchema() ?: defaultSchema
 
         else -> defaultSchema
       }

--- a/taxonomy-api/src/main/kotlin/no/ndla/taxonomy/service/VersionResolver.kt
+++ b/taxonomy-api/src/main/kotlin/no/ndla/taxonomy/service/VersionResolver.kt
@@ -23,7 +23,8 @@ import org.springframework.stereotype.Component
 class VersionResolver(
     private val versionRepository: VersionRepository,
     @Value("\${taxonomy.version-schema-cache-ttl-seconds:30}") ttlSeconds: Long,
-    @Value("\${spring.datasource.hikari.schema:taxonomy_api}") private val defaultSchema: String,
+    @param:Value("\${spring.datasource.hikari.schema:taxonomy_api}")
+    private val defaultSchema: String,
 ) {
 
   private val ttlNanos = Duration.ofSeconds(ttlSeconds).toNanos()

--- a/taxonomy-api/src/main/kotlin/no/ndla/taxonomy/service/VersionResolver.kt
+++ b/taxonomy-api/src/main/kotlin/no/ndla/taxonomy/service/VersionResolver.kt
@@ -1,0 +1,80 @@
+/*
+ * Part of NDLA taxonomy-api
+ * Copyright (C) 2026 NDLA
+ *
+ * See LICENSE
+ */
+
+package no.ndla.taxonomy.service
+
+import java.time.Duration
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicReference
+import no.ndla.taxonomy.domain.VersionType
+import no.ndla.taxonomy.repositories.VersionRepository
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+
+/**
+ * Resolves version hashes to database schema names, caching lookups for a short TTL so the version
+ * table is not queried on every request.
+ */
+@Component
+class VersionResolver(
+    private val versionRepository: VersionRepository,
+    @Value("\${taxonomy.version-schema-cache-ttl-seconds:30}") ttlSeconds: Long,
+    @Value("\${spring.datasource.hikari.schema:taxonomy_api}") private val defaultSchema: String,
+) {
+
+  private val ttlNanos = Duration.ofSeconds(ttlSeconds).toNanos()
+
+  private data class CachedSchema(val schema: String?, val expiresAtNanos: Long)
+
+  private val publishedSchema = AtomicReference<CachedSchema?>()
+  private val schemaByHash = ConcurrentHashMap<String, CachedSchema>()
+
+  fun schemaFromHash(hash: String?): String = hash?.let { "${defaultSchema}_$it" } ?: defaultSchema
+
+  /** Schema of the currently published version, or null if no version is published. */
+  fun publishedVersionSchema(): String? {
+    publishedSchema
+        .get()
+        ?.takeIf { it.expiresAtNanos > System.nanoTime() }
+        ?.let {
+          return it.schema
+        }
+    val schema =
+        versionRepository.findFirstByVersionType(VersionType.PUBLISHED)?.let {
+          schemaFromHash(it.hash)
+        }
+    publishedSchema.set(CachedSchema(schema, System.nanoTime() + ttlNanos))
+    return schema
+  }
+
+  /** Schema of the version with the given hash, or null if no such version exists. */
+  fun versionSchemaForHash(hash: String): String? {
+    schemaByHash[hash]
+        ?.takeIf { it.expiresAtNanos > System.nanoTime() }
+        ?.let {
+          return it.schema
+        }
+    // Hashes come from a client-supplied header, so bound the map to avoid unbounded growth
+    if (schemaByHash.size >= MAX_HASH_ENTRIES) schemaByHash.clear()
+    val schema = versionRepository.findFirstByHash(hash)?.let { schemaFromHash(it.hash) }
+    schemaByHash[hash] = CachedSchema(schema, System.nanoTime() + ttlNanos)
+    return schema
+  }
+
+  /**
+   * Mutations to the versions should call this, but since we scale horizontally, the TTL still
+   * needs to be quite short to keep all the pods in sync after a publication
+   */
+  fun invalidate() {
+    publishedSchema.set(null)
+    schemaByHash.clear()
+  }
+
+  companion object {
+    private const val MAX_HASH_ENTRIES = 1000
+  }
+}

--- a/taxonomy-api/src/main/kotlin/no/ndla/taxonomy/service/VersionService.kt
+++ b/taxonomy-api/src/main/kotlin/no/ndla/taxonomy/service/VersionService.kt
@@ -31,6 +31,7 @@ class VersionService(
     private val entityManager: EntityManager,
     private val versionRepository: VersionRepository,
     private val nodeConnectionService: NodeConnectionService,
+    private val versionResolver: VersionResolver,
 ) {
   private val logger = LoggerFactory.getLogger(javaClass)
   private val validator = URNValidator()
@@ -54,6 +55,7 @@ class VersionService(
       logger.warn("Failed to drop schema. Possible manual cleanup required")
     }
     versionRepository.delete(versionToDelete)
+    versionResolver.invalidate()
   }
 
   fun getVersions(): List<VersionDTO> = versionRepository.findAll().map(::VersionDTO)
@@ -77,6 +79,7 @@ class VersionService(
     // TODO: Replace this with Clock.System.now() at some point
     beta.published = Instant.now()
     versionRepository.saveAndFlush(beta)
+    versionResolver.invalidate()
 
     disconnectAllInvisibleNodes(beta.hash)
   }
@@ -118,8 +121,9 @@ class VersionService(
             "SELECT count(*) from clone_schema('$sourceSchema', '$schema', true, false)")
         .singleResult
 
+    versionResolver.invalidate()
     return version
   }
 
-  fun schemaFromHash(hash: String?) = hash?.let { "${defaultSchema}_$it" } ?: defaultSchema
+  fun schemaFromHash(hash: String?) = versionResolver.schemaFromHash(hash)
 }

--- a/taxonomy-api/src/test/java/no/ndla/taxonomy/rest/v1/NodesQueryCountTest.java
+++ b/taxonomy-api/src/test/java/no/ndla/taxonomy/rest/v1/NodesQueryCountTest.java
@@ -1,0 +1,153 @@
+/*
+ * Part of NDLA taxonomy-api
+ * Copyright (C) 2026 NDLA
+ *
+ * See LICENSE
+ */
+
+package no.ndla.taxonomy.rest.v1;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import jakarta.persistence.EntityManager;
+import no.ndla.taxonomy.domain.Node;
+import no.ndla.taxonomy.domain.NodeType;
+import no.ndla.taxonomy.service.dtos.NodeChildDTO;
+import no.ndla.taxonomy.service.dtos.NodeDTO;
+import org.hibernate.SessionFactory;
+import org.hibernate.stat.Statistics;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Guards against N+1 query regressions on the hot read endpoints. The bounds are deliberately
+ * generous; the point is that the query count must not scale with the number of nodes returned.
+ */
+public class NodesQueryCountTest extends RestTest {
+    @Autowired
+    EntityManager entityManager;
+
+    @BeforeEach
+    void clearAllRepos() {
+        nodeRepository.deleteAllAndFlush();
+        nodeConnectionRepository.deleteAllAndFlush();
+        resourceTypeRepository.deleteAllAndFlush();
+        resourceResourceTypeRepository.deleteAllAndFlush();
+    }
+
+    private Statistics statistics() {
+        var statistics = entityManager
+                .getEntityManagerFactory()
+                .unwrap(SessionFactory.class)
+                .getStatistics();
+        statistics.setStatisticsEnabled(true);
+        return statistics;
+    }
+
+    /**
+     * Flushes builder-created entities and empties the persistence context so the measured request
+     * cannot be served from the first-level cache.
+     */
+    private Statistics freshStatistics() {
+        entityManager.flush();
+        entityManager.clear();
+        var statistics = statistics();
+        statistics.clear();
+        return statistics;
+    }
+
+    @Test
+    public void get_children_query_count_does_not_scale_with_child_count() throws Exception {
+        Node subject = builder.node(NodeType.SUBJECT, s -> {
+            s.isContext(true).name("subject");
+            for (int i = 0; i < 30; i++) {
+                final var n = i;
+                s.child(NodeType.TOPIC, t -> t.name("topic " + n).resource(r -> r.name("resource " + n)));
+            }
+        });
+
+        var statistics = freshStatistics();
+        var response = testUtils.getResource("/v1/nodes/" + subject.getPublicId() + "/nodes");
+        var nodes = testUtils.getObject(NodeChildDTO[].class, response);
+
+        assertEquals(30, nodes.length);
+        long queries = statistics.getPrepareStatementCount();
+        assertTrue(queries >= 2, "statistics do not seem to measure anything, ran " + queries);
+        assertTrue(queries <= 8, "expected getChildren to run at most 8 SQL statements, ran " + queries);
+    }
+
+    @Test
+    public void recursive_get_children_query_count_does_not_scale_with_subtree_size() throws Exception {
+        Node subject = builder.node(NodeType.SUBJECT, s -> {
+            s.isContext(true).name("subject");
+            for (int i = 0; i < 15; i++) {
+                final var n = i;
+                s.child(
+                        NodeType.TOPIC,
+                        t -> t.name("topic " + n)
+                                .child(
+                                        NodeType.TOPIC,
+                                        st -> st.name("subtopic " + n).resource(r -> r.name("resource " + n))));
+            }
+        });
+
+        var statistics = freshStatistics();
+        var response = testUtils.getResource(
+                "/v1/nodes/" + subject.getPublicId() + "/nodes?recursive=true&nodeType=TOPIC,RESOURCE");
+        var nodes = testUtils.getObject(NodeChildDTO[].class, response);
+
+        assertEquals(45, nodes.length);
+        long queries = statistics.getPrepareStatementCount();
+        assertTrue(queries >= 2, "statistics do not seem to measure anything, ran " + queries);
+        assertTrue(queries <= 12, "expected recursive getChildren to run at most 12 SQL statements, ran " + queries);
+    }
+
+    @Test
+    public void get_all_nodes_query_count_does_not_scale_with_node_count() throws Exception {
+        builder.node(NodeType.SUBJECT, s -> {
+            s.isContext(true).name("subject");
+            for (int i = 0; i < 10; i++) {
+                final var n = i;
+                s.child(
+                        NodeType.TOPIC,
+                        t -> t.name("topic " + n)
+                                .child(
+                                        NodeType.TOPIC,
+                                        st -> st.name("subtopic " + n).resource(r -> r.name("resource " + n))));
+            }
+        });
+
+        var statistics = freshStatistics();
+        var response = testUtils.getResource("/v1/nodes?nodeType=RESOURCE");
+        var nodes = testUtils.getObject(NodeDTO[].class, response);
+
+        assertEquals(10, nodes.length);
+        long queries = statistics.getPrepareStatementCount();
+        assertTrue(queries >= 2, "statistics do not seem to measure anything, ran " + queries);
+        assertTrue(queries <= 8, "expected getAllNodes to run at most 8 SQL statements, ran " + queries);
+    }
+
+    @Test
+    public void get_all_nodes_returns_parent_crumbs_from_batched_ancestor_fetch() throws Exception {
+        Node subject = builder.node(
+                NodeType.SUBJECT,
+                s -> s.isContext(true)
+                        .name("subject")
+                        .child(NodeType.TOPIC, t -> t.name("topic").resource(r -> r.name("resource"))));
+        Node topic = subject.getChildNodes().iterator().next();
+
+        freshStatistics();
+        var response = testUtils.getResource("/v1/nodes?nodeType=RESOURCE");
+        var nodes = testUtils.getObject(NodeDTO[].class, response);
+
+        assertEquals(1, nodes.length);
+        var contexts = nodes[0].getContexts();
+        assertEquals(1, contexts.size());
+        var parents = contexts.getFirst().parents();
+        assertEquals(2, parents.size());
+        assertEquals(subject.getPublicId(), parents.get(0).id());
+        assertEquals(topic.getPublicId(), parents.get(1).id());
+        assertEquals(contexts.getFirst().rootId(), parents.get(0).id());
+    }
+}

--- a/taxonomy-api/src/test/kotlin/no/ndla/taxonomy/service/VersionResolverTest.kt
+++ b/taxonomy-api/src/test/kotlin/no/ndla/taxonomy/service/VersionResolverTest.kt
@@ -1,0 +1,91 @@
+/*
+ * Part of NDLA taxonomy-api
+ * Copyright (C) 2026 NDLA
+ *
+ * See LICENSE
+ */
+
+package no.ndla.taxonomy.service
+
+import no.ndla.taxonomy.domain.Version
+import no.ndla.taxonomy.domain.VersionType
+import no.ndla.taxonomy.repositories.VersionRepository
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+
+class VersionResolverTest {
+  private val defaultSchema = "taxonomy_api"
+
+  private fun resolver(repository: VersionRepository, ttlSeconds: Long = 60) =
+      VersionResolver(repository, ttlSeconds, defaultSchema)
+
+  @Test
+  fun published_schema_is_cached_within_ttl() {
+    val version = Version().apply { versionType = VersionType.PUBLISHED }
+    val repository = mock(VersionRepository::class.java)
+    `when`(repository.findFirstByVersionType(VersionType.PUBLISHED)).thenReturn(version)
+
+    val resolver = resolver(repository)
+    assertEquals("${defaultSchema}_${version.hash}", resolver.publishedVersionSchema())
+    assertEquals("${defaultSchema}_${version.hash}", resolver.publishedVersionSchema())
+    verify(repository, times(1)).findFirstByVersionType(VersionType.PUBLISHED)
+  }
+
+  @Test
+  fun missing_published_version_is_cached_as_null() {
+    val repository = mock(VersionRepository::class.java)
+    `when`(repository.findFirstByVersionType(VersionType.PUBLISHED)).thenReturn(null)
+
+    val resolver = resolver(repository)
+    assertNull(resolver.publishedVersionSchema())
+    assertNull(resolver.publishedVersionSchema())
+    verify(repository, times(1)).findFirstByVersionType(VersionType.PUBLISHED)
+  }
+
+  @Test
+  fun hash_schema_is_cached_within_ttl() {
+    val version = Version()
+    val repository = mock(VersionRepository::class.java)
+    `when`(repository.findFirstByHash(version.hash)).thenReturn(version)
+
+    val resolver = resolver(repository)
+    assertEquals("${defaultSchema}_${version.hash}", resolver.versionSchemaForHash(version.hash))
+    assertEquals("${defaultSchema}_${version.hash}", resolver.versionSchemaForHash(version.hash))
+    verify(repository, times(1)).findFirstByHash(version.hash)
+  }
+
+  @Test
+  fun invalidate_clears_cached_values() {
+    val version = Version().apply { versionType = VersionType.PUBLISHED }
+    val repository = mock(VersionRepository::class.java)
+    `when`(repository.findFirstByVersionType(VersionType.PUBLISHED)).thenReturn(version)
+    `when`(repository.findFirstByHash(version.hash)).thenReturn(version)
+
+    val resolver = resolver(repository)
+    resolver.publishedVersionSchema()
+    resolver.versionSchemaForHash(version.hash)
+    resolver.invalidate()
+    resolver.publishedVersionSchema()
+    resolver.versionSchemaForHash(version.hash)
+
+    verify(repository, times(2)).findFirstByVersionType(VersionType.PUBLISHED)
+    verify(repository, times(2)).findFirstByHash(version.hash)
+  }
+
+  @Test
+  fun zero_ttl_disables_caching() {
+    val version = Version().apply { versionType = VersionType.PUBLISHED }
+    val repository = mock(VersionRepository::class.java)
+    `when`(repository.findFirstByVersionType(VersionType.PUBLISHED)).thenReturn(version)
+
+    val resolver = resolver(repository, ttlSeconds = 0)
+    resolver.publishedVersionSchema()
+    resolver.publishedVersionSchema()
+    verify(repository, times(2)).findFirstByVersionType(VersionType.PUBLISHED)
+  }
+}


### PR DESCRIPTION
Denne PR'en gjør litt forskjellig:
1. Bare hente barn i `getChildren` som vi trenger.
    - Tidligere så hentet vi all parent koblinger (inkludert urelaterte parents) for barnene og bygde opp hele DTO klassene for hver av de for så å kaste de bort. Reduserer SQL/req drastisk i mange tilfeller.
2. Endre på måten `getAllParentContexts` henter ut contexts. Nå henter vi med `WHERE publicId IN (...)`. Tidligere itererte vi treet med `parentConnections`.
3. Hive på `@BatchSize` på collections i `Node`. 
    - Gjør at de stedene vi fremdeles bruker lazy loading fra hibernate vil batches. Potensielt reduserer vi sql kall rimelig drastisk på noen requests.  
4. cache versjons schema i minnet.
    - Dette er den jeg er mest usikker på av endringene. Hver eneste request tidligere gjorde jo en lookup i databasen for å finne versjonen. Denne endringen gjør at vi cacher det i minnet med TTL på 30 sekunder som jo vil redusere sql lookup med en god del, men det vil også gjøre at vi henter fra gammelt schema i 30 sekunder etter en publisering. Tanker? 

Sikkert ganske nyttig å reviewe commit for commit på denne.

Fikk claude til å benchmarke dette for meg med `wrk` og det ser ut som ytelsen har gått opp ganske bra over hele fjøla (med unntak av p99 på `children` testen, men der har også RPS gått opp 59% så det det er nok i stor grad derfor).

`master` -> `denne`
  | Endpoint | SQL/req | seq. mean | RPS | p50 | p99 |
  |---|--:|--:|--:|--:|--:|
  | children | 19 → **4** | 26 → 14 ms | +59% | 34 → 18 ms | 439 → 558 ms |
  | children_recursive | 862 → **8** | 530 → 168 ms | +248% | 1500 → 419 ms | 1880 → 731 ms |
  | all_topics | 80 → **4** | 140 → 109 ms | +69% | 368 → 207 ms | 1210 → 335 ms |
  | single_node | 7 → **4** | ~11 ms | +21% | 17 → 14 ms | 127 → 118 ms |
  | node_page | 22 → **5** | 39 → 31 ms | +57% | 67 → 42 ms | 210 → 201 ms |

