### PR TITLE
Feat/url checker

### DIFF
--- a/common/src/main/scala/no/ndla/common/model/NDLADate.scala
+++ b/common/src/main/scala/no/ndla/common/model/NDLADate.scala
@@ -32,6 +32,7 @@ case class NDLADate(underlying: ZonedDateTime) extends Ordered[NDLADate], Parame
   def plusSeconds(seconds: Long): NDLADate                     = withUnderlying(_.plusSeconds(seconds))
   def minusDays(days: Long): NDLADate                          = withUnderlying(_.minusDays(days))
   def plusDays(days: Long): NDLADate                           = withUnderlying(_.plusDays(days))
+  def plusMonths(months: Long): NDLADate                       = withUnderlying(_.plusMonths(months))
   def plusYears(years: Long): NDLADate                         = withUnderlying(_.plusYears(years))
   def minusYears(years: Long): NDLADate                        = withUnderlying(_.minusYears(years))
   def isAfter(date: NDLADate): Boolean                         = underlying.isAfter(date.underlying)

--- a/draft-api/src/main/scala/no/ndla/draftapi/ComponentRegistry.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/ComponentRegistry.scala
@@ -64,6 +64,7 @@ class ComponentRegistry(properties: DraftApiProperties) extends TapirApplication
   implicit lazy val traitUtil: TraitUtil                           = new TraitUtil
   implicit lazy val converterService: ConverterService             = new ConverterService
   implicit lazy val searchConverterService: SearchConverterService = new SearchConverterService
+  implicit lazy val urlCheckerService: UrlCheckerService           = new UrlCheckerService
   implicit lazy val readService: ReadService                       = new ReadService
   implicit lazy val writeService: WriteService                     = new WriteService
   implicit lazy val fileStorage: FileStorageService                = new FileStorageService

--- a/draft-api/src/main/scala/no/ndla/draftapi/DraftApiProperties.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/DraftApiProperties.scala
@@ -122,7 +122,13 @@ class DraftApiProperties extends BaseProps with DatabaseProps with StrictLogging
     ".step",
   )
 
-  def multipartFileSizeThresholdBytes: Int      = 1024 * 1024 * 30 // 30MB
+  def multipartFileSizeThresholdBytes: Int = 1024 * 1024 * 30 // 30MB
+
+  /** Number of "buckets" articles are spread across for yearly URL checking. article_id % UrlCheckDaysInYear ==
+    * dayOfYear selects today's slice. Set to 1 via the URL_CHECK_DAYS_IN_YEAR env-var to check every article on every
+    * run.
+    */
+  def UrlCheckDaysInYear: Int                   = propOrElse("URL_CHECK_DAYS_IN_YEAR", "365").toInt
   val auth0ManagementClientId: Prop[String]     = prop("AUTH0_MANAGEMENT_CLIENT_ID")
   val auth0ManagementClientSecret: Prop[String] = prop("AUTH0_MANAGEMENT_CLIENT_SECRET")
 

--- a/draft-api/src/main/scala/no/ndla/draftapi/controller/InternController.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/controller/InternController.scala
@@ -31,6 +31,7 @@ import sttp.model.StatusCode
 import sttp.tapir.*
 import sttp.tapir.server.ServerEndpoint
 
+import java.time.LocalDate
 import java.util.concurrent.{Executors, TimeUnit}
 import scala.annotation.{tailrec, unused}
 import scala.concurrent.*
@@ -44,6 +45,7 @@ class InternController(using
     articleIndexService: ArticleIndexService,
     tagIndexService: TagIndexService,
     articleApiClient: ArticleApiClient,
+    urlCheckerService: UrlCheckerService,
     props: DraftApiProperties,
     errorHandling: ErrorHandling,
     dbUtility: DBUtility,
@@ -86,6 +88,7 @@ class InternController(using
     dumpArticles,
     dumpSingleArticle,
     postDump,
+    checkUrls,
   )
 
   def postIndex: ServerEndpoint[Any, Eff] = endpoint
@@ -271,5 +274,34 @@ class InternController(using
     .out(jsonBody[Draft])
     .serverLogicPure { article =>
       writeService.insertDump(article)
+    }
+
+  /** POST /intern/check-urls
+    *
+    * Runs the URL checker for a slice of articles selected by modulus arithmetic on article_id.
+    *
+    * Query parameters:
+    *   - modulus (optional) – number of buckets; defaults to [[DraftApiProperties.UrlCheckDaysInYear]]. Set to 1 to
+    *     process every article in a single run.
+    *   - remainder (optional) – which bucket to process; defaults to the current day-of-year (1-based).
+    *
+    * Example – run today's scheduled slice: POST /intern/check-urls
+    *
+    * Example – force-check all articles right now: POST /intern/check-urls?modulus=1&remainder=0
+    */
+  def checkUrls: ServerEndpoint[Any, Eff] = endpoint
+    .post
+    .in("check-urls")
+    .in(query[Option[Int]]("modulus"))
+    .in(query[Option[Int]]("remainder"))
+    .out(stringBody)
+    .errorOut(stringInternalServerError)
+    .serverLogicPure { (modulusOpt, remainderOpt) =>
+      val modulus   = modulusOpt.getOrElse(props.UrlCheckDaysInYear)
+      val remainder = remainderOpt.getOrElse(LocalDate.now().getDayOfYear)
+      urlCheckerService.checkUrlsForArticleSlice(modulus, remainder) match {
+        case Failure(ex)      => ex.getMessage.asLeft
+        case Success(summary) => summary.toString.asRight
+      }
     }
 }

--- a/draft-api/src/main/scala/no/ndla/draftapi/controller/InternController.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/controller/InternController.scala
@@ -292,12 +292,11 @@ class InternController(using
   def checkUrls: ServerEndpoint[Any, Eff] = endpoint
     .post
     .in("check-urls")
-    .in(query[Option[Int]]("modulus"))
+    .in(query[Int]("modulus").default(props.UrlCheckDaysInYear).validate(Validator.positive))
     .in(query[Option[Int]]("remainder"))
     .out(stringBody)
     .errorOut(stringInternalServerError)
-    .serverLogicPure { (modulusOpt, remainderOpt) =>
-      val modulus   = modulusOpt.getOrElse(props.UrlCheckDaysInYear)
+    .serverLogicPure { (modulus, remainderOpt) =>
       val remainder = remainderOpt.getOrElse(LocalDate.now().getDayOfYear)
       urlCheckerService.checkUrlsForArticleSlice(modulus, remainder) match {
         case Failure(ex)      => ex.getMessage.asLeft

--- a/draft-api/src/main/scala/no/ndla/draftapi/repository/DraftRepository.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/repository/DraftRepository.scala
@@ -344,7 +344,6 @@ class DraftRepository(using draftErrorHelpers: DraftErrorHelpers, clock: Clock, 
       .runSingle()
       .map(_.getOrElse(0))
   }
-
   def getArticlesByPage(pageSize: Int, offset: Int)(using session: DBSession): Try[Seq[Draft]] = {
     val dr  = dbDraft.syntax("dr")
     val dr2 = dbDraft.syntax("dr2")
@@ -361,6 +360,27 @@ class DraftRepository(using draftErrorHelpers: DraftErrorHelpers, clock: Clock, 
       order by dr.id
       offset $offset
       limit $pageSize
+    """.map(dbDraft.fromResultSet(dr)).runList()
+  }
+
+  /** Fetch the latest revision of each article where {@code article_id % modulus == remainder % modulus}. Using a
+    * modulus of 365 and the day-of-year as the remainder spreads the full article corpus evenly across a year so that
+    * each article is visited roughly once per year. Setting modulus to 1 (remainder is ignored) returns every article.
+    */
+  def getArticlesByModulus(modulus: Int, remainder: Int)(using session: DBSession): Try[List[Draft]] = {
+    val dr  = dbDraft.syntax("dr")
+    val dr2 = dbDraft.syntax("dr2")
+    tsql"""
+      select ${dr.result.*}
+      from ${dbDraft.as(dr)}
+      where dr.document is not NULL
+      and (dr.article_id % $modulus) = ($remainder % $modulus)
+      and not exists (
+        select 1
+        from ${dbDraft.as(dr2)}
+        where dr2.article_id = dr.article_id
+        and dr2.revision > dr.revision
+      )
     """.map(dbDraft.fromResultSet(dr)).runList()
   }
 

--- a/draft-api/src/main/scala/no/ndla/draftapi/service/UrlCheckerService.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/service/UrlCheckerService.scala
@@ -50,7 +50,16 @@ class UrlCheckerService(using
   }
 
   private[service] def checkUrl(url: String): UrlCheckResult = {
-    Try(ndlaClient.client.send(quickRequest.head(uri"$url").followRedirects(false))) match {
+    Try(
+      ndlaClient
+        .client
+        .send(
+          quickRequest
+            .head(uri"$url")
+            .followRedirects(false)
+            .readTimeout(scala.concurrent.duration.Duration(10, "seconds"))
+        )
+    ) match {
       case Failure(ex) =>
         logger.warn(s"Failed to check URL '$url': ${ex.getMessage}")
         UrlCheckFailed(ex)

--- a/draft-api/src/main/scala/no/ndla/draftapi/service/UrlCheckerService.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/service/UrlCheckerService.scala
@@ -13,6 +13,8 @@ import no.ndla.common.Clock
 import no.ndla.common.model.domain.{EditorNote, Responsible, RevisionMeta, RevisionStatus}
 import no.ndla.common.model.domain.draft.{Draft, DraftStatus}
 import no.ndla.common.model.domain.Status
+import no.ndla.database.DBUtility
+import no.ndla.draftapi.repository.DraftRepository
 import no.ndla.network.NdlaClient
 import org.jsoup.Jsoup
 import sttp.client4.quick.*
@@ -27,7 +29,12 @@ case class UrlRedirected(newUrl: String)        extends UrlCheckResult
 case class UrlBroken(statusCode: Int)           extends UrlCheckResult
 case class UrlCheckFailed(exception: Throwable) extends UrlCheckResult
 
-class UrlCheckerService(using ndlaClient: NdlaClient, clock: Clock) extends StrictLogging {
+class UrlCheckerService(using
+    ndlaClient: NdlaClient,
+    clock: Clock,
+    draftRepository: DraftRepository,
+    dbUtility: DBUtility,
+) extends StrictLogging {
 
   private[service] def extractUrls(html: String): List[String] = {
     val doc        = Jsoup.parseBodyFragment(html)
@@ -155,4 +162,50 @@ class UrlCheckerService(using ndlaClient: NdlaClient, clock: Clock) extends Stri
       draft.copy(status = inProgressStatus, responsible = Some(newResponsible))
     } else draft
   }
+
+  /** Fetch articles using a modulus filter, run URL checks on each, and persist any changes.
+    *
+    * @param modulus
+    *   Divisor used for partitioning (e.g. 365 for yearly rotation).
+    * @param remainder
+    *   Only articles where {@code article_id % modulus == remainder % modulus} are processed.
+    * @return
+    *   A summary string describing how many articles were checked and updated.
+    */
+  def checkUrlsForArticleSlice(modulus: Int, remainder: Int): Try[UrlCheckSummary] = {
+    dbUtility
+      .readOnly { implicit session =>
+        draftRepository.getArticlesByModulus(modulus, remainder)
+      }
+      .flatMap { articles =>
+        logger.info(s"URL check: fetched ${articles.size} article(s) (modulus=$modulus, remainder=$remainder)")
+        val systemUser = "url-checker"
+        val results    = articles.map { draft =>
+          val updated = checkAndUpdateUrls(draft, systemUser)
+          val changed = updated != draft
+          if (changed) {
+            dbUtility
+              .rollbackOnFailure { implicit session =>
+                draftRepository.updateArticle(updated)
+              }
+              .map(_ => true)
+          } else {
+            Success(false)
+          }
+        }
+        val failures = results.collect { case Failure(ex) =>
+          ex
+        }
+        val updated = results.count(_.getOrElse(false))
+        if (failures.nonEmpty) {
+          failures.foreach(ex => logger.error("URL check: failed to persist article update", ex))
+        }
+        Success(UrlCheckSummary(checked = articles.size, updated = updated, errors = failures.size))
+      }
+  }
+}
+
+case class UrlCheckSummary(checked: Int, updated: Int, errors: Int) {
+  override def toString: String =
+    s"URL check complete: $checked article(s) checked, $updated updated, $errors error(s)."
 }

--- a/draft-api/src/main/scala/no/ndla/draftapi/service/UrlCheckerService.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/service/UrlCheckerService.scala
@@ -67,10 +67,14 @@ class UrlCheckerService(using
         val code = response.code.code
         if (code == 200) {
           UrlOk
-        } else if (Seq(301, 307, 308).contains(code)) {
+        } else if (code >= 300 && code < 400) {
           response.header("Location") match {
-            case Some(location) => UrlRedirected(location)
-            case None           =>
+            case Some(location) =>
+              val resolved =
+                if (location.startsWith("http://") || location.startsWith("https://")) location
+                else java.net.URI.create(url).resolve(location).toString
+              UrlRedirected(resolved)
+            case None =>
               logger.warn(s"Redirect response $code for URL '$url' had no Location header")
               UrlOk
           }

--- a/draft-api/src/main/scala/no/ndla/draftapi/service/UrlCheckerService.scala
+++ b/draft-api/src/main/scala/no/ndla/draftapi/service/UrlCheckerService.scala
@@ -1,0 +1,158 @@
+/*
+ * Part of NDLA draft-api
+ * Copyright (C) 2026 NDLA
+ *
+ * See LICENSE
+ *
+ */
+
+package no.ndla.draftapi.service
+
+import com.typesafe.scalalogging.StrictLogging
+import no.ndla.common.Clock
+import no.ndla.common.model.domain.{EditorNote, Responsible, RevisionMeta, RevisionStatus}
+import no.ndla.common.model.domain.draft.{Draft, DraftStatus}
+import no.ndla.common.model.domain.Status
+import no.ndla.network.NdlaClient
+import org.jsoup.Jsoup
+import sttp.client4.quick.*
+
+import java.util.UUID
+import scala.jdk.CollectionConverters.*
+import scala.util.{Failure, Success, Try}
+
+sealed trait UrlCheckResult
+case object UrlOk                               extends UrlCheckResult
+case class UrlRedirected(newUrl: String)        extends UrlCheckResult
+case class UrlBroken(statusCode: Int)           extends UrlCheckResult
+case class UrlCheckFailed(exception: Throwable) extends UrlCheckResult
+
+class UrlCheckerService(using ndlaClient: NdlaClient, clock: Clock) extends StrictLogging {
+
+  private[service] def extractUrls(html: String): List[String] = {
+    val doc        = Jsoup.parseBodyFragment(html)
+    val anchorUrls = doc.select("a[href]").asScala.toList.map(_.attr("href"))
+    val embedUrls  = doc
+      .select("ndlaembed[data-resource=related-content][data-url]")
+      .asScala
+      .toList
+      .map(_.attr("data-url"))
+    (
+      anchorUrls ++ embedUrls
+    ).filter(url => url.startsWith("http://") || url.startsWith("https://"))
+  }
+
+  private[service] def checkUrl(url: String): UrlCheckResult = {
+    Try(ndlaClient.client.send(quickRequest.head(uri"$url").followRedirects(false))) match {
+      case Failure(ex) =>
+        logger.warn(s"Failed to check URL '$url': ${ex.getMessage}")
+        UrlCheckFailed(ex)
+      case Success(response) =>
+        val code = response.code.code
+        if (code == 200) {
+          UrlOk
+        } else if (Seq(301, 307, 308).contains(code)) {
+          response.header("Location") match {
+            case Some(location) => UrlRedirected(location)
+            case None           =>
+              logger.warn(s"Redirect response $code for URL '$url' had no Location header")
+              UrlOk
+          }
+        } else if (code >= 400 && code < 600) {
+          UrlBroken(code)
+        } else {
+          UrlOk
+        }
+    }
+  }
+
+  private[service] def updateContentUrls(content: String, urlUpdates: Map[String, String]): String = {
+    if (urlUpdates.isEmpty) content
+    else {
+      val doc = Jsoup.parseBodyFragment(content)
+      doc
+        .select("a[href]")
+        .asScala
+        .foreach { element =>
+          val href = element.attr("href")
+          urlUpdates.get(href).foreach(newUrl => element.attr("href", newUrl))
+        }
+      doc
+        .select("ndlaembed[data-resource=related-content][data-url]")
+        .asScala
+        .foreach { element =>
+          val dataUrl = element.attr("data-url")
+          urlUpdates.get(dataUrl).foreach(newUrl => element.attr("data-url", newUrl))
+        }
+      doc.body().html()
+    }
+  }
+
+  def checkAndUpdateUrls(draft: Draft, user: String): Draft = {
+    val allUrls = draft.content.flatMap(ac => extractUrls(ac.content)).distinct.toList
+    if (allUrls.isEmpty) return draft
+
+    logger.info(s"Checking ${allUrls.size} URL(s) in draft ${draft.id.getOrElse("unknown")}")
+
+    val results: Map[String, UrlCheckResult] = allUrls.map(url => url -> checkUrl(url)).toMap
+
+    val urlRedirects: Map[String, String] = results.collect { case (url, UrlRedirected(newUrl)) =>
+      url -> newUrl
+    }
+
+    val brokenUrls: List[(String, String)] = results
+      .collect {
+        case (url, UrlBroken(code))           => url -> s"URL '$url' returnerte HTTP $code og må oppdateres."
+        case (url, UrlCheckFailed(exception)) =>
+          url -> s"URL '$url' kunne ikke nås (${exception.getMessage}) og må oppdateres."
+      }
+      .toList
+
+    // Update content with new URLs for redirects
+    val updatedContent =
+      if (urlRedirects.nonEmpty) draft.content.map(ac => ac.copy(content = updateContentUrls(ac.content, urlRedirects)))
+      else draft.content
+
+    // Add EditorNotes for redirected URLs
+    val redirectNotes: Seq[EditorNote] = urlRedirects
+      .map { case (oldUrl, newUrl) =>
+        EditorNote(s"URL '$oldUrl' ble automatisk oppdatert til '$newUrl'.", user, draft.status, clock.now())
+      }
+      .toSeq
+
+    // Add RevisionMeta for broken/unreachable URLs – only if a note for that URL does not already exist
+    val existingRevisionNotes              = draft.revisionMeta.map(_.note).toSet
+    val newRevisionMeta: Seq[RevisionMeta] = brokenUrls.flatMap { case (_, note) =>
+      if (existingRevisionNotes.contains(note)) None
+      else Some(
+        RevisionMeta(
+          id = UUID.randomUUID(),
+          revisionDate = clock.now().plusMonths(1).withNano(0),
+          note = note,
+          status = RevisionStatus.NeedsRevision,
+        )
+      )
+    }
+
+    val updated = draft.copy(
+      content = updatedContent,
+      notes = draft.notes ++ redirectNotes,
+      revisionMeta = draft.revisionMeta ++ newRevisionMeta,
+    )
+    // Adding revisionMeta alone (broken/unreachable links) does not constitute a meaningful
+    // change that requires republishing — only content/notes updates (redirects) do.
+    val draftContentUpdated = updated.copy(revisionMeta = draft.revisionMeta) != draft
+    changeStatusIfNeeded(updated, draftContentUpdated)
+  }
+
+  private def changeStatusIfNeeded(draft: Draft, changed: Boolean): Draft = {
+    if (changed && draft.status.current == DraftStatus.PUBLISHED) {
+      val inProgressStatus = Status(DraftStatus.IN_PROGRESS, draft.status.other)
+      val newResponsible   = Responsible(responsibleId = draft.updatedBy, lastUpdated = clock.now())
+      logger.info(
+        s"Draft ${draft.id.getOrElse("unknown")} has been modified by URL check — changing status and setting responsible to '${draft.updatedBy}'"
+      )
+      draft.copy(status = inProgressStatus, responsible = Some(newResponsible))
+    } else draft
+  }
+}

--- a/draft-api/src/test/scala/no/ndla/draftapi/TestEnvironment.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/TestEnvironment.scala
@@ -69,10 +69,11 @@ trait TestEnvironment extends TapirApplication[DraftApiProperties] with MockitoS
   implicit lazy val commonConverter: CommonConverter           = mock[CommonConverter]
   implicit lazy val stateTransitionRules: StateTransitionRules = mock[StateTransitionRules]
 
-  implicit lazy val readService: ReadService           = mock[ReadService]
-  implicit lazy val writeService: WriteService         = mock[WriteService]
-  implicit lazy val contentValidator: ContentValidator = mock[ContentValidator]
-  implicit lazy val reindexClient: ReindexClient       = mock[ReindexClient]
+  implicit lazy val readService: ReadService             = mock[ReadService]
+  implicit lazy val writeService: WriteService           = mock[WriteService]
+  implicit lazy val urlCheckerService: UrlCheckerService = mock[UrlCheckerService]
+  implicit lazy val contentValidator: ContentValidator   = mock[ContentValidator]
+  implicit lazy val reindexClient: ReindexClient         = mock[ReindexClient]
 
   implicit lazy val fileStorage: FileStorageService = mock[FileStorageService]
   implicit lazy val s3Client: NdlaS3Client          = mock[NdlaS3Client]

--- a/draft-api/src/test/scala/no/ndla/draftapi/controller/InternControllerTest.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/controller/InternControllerTest.scala
@@ -12,9 +12,10 @@ import no.ndla.common.Clock
 import no.ndla.draftapi.*
 import no.ndla.draftapi.model.api.{ContentIdDTO, NotFoundException}
 import no.ndla.draftapi.model.domain.ImportId
+import no.ndla.draftapi.service.UrlCheckSummary
 import no.ndla.network.tapir.{ErrorHandling, ErrorHelpers, Routes, TapirController}
 import no.ndla.tapirtesting.TapirControllerTest
-import org.mockito.ArgumentMatchers.{any, eq as eqTo}
+import org.mockito.ArgumentMatchers.{any, anyInt, eq as eqTo}
 import org.mockito.Mockito.{doReturn, never, reset, times, verify, verifyNoMoreInteractions, when}
 import sttp.client4.quick.*
 
@@ -142,5 +143,25 @@ class InternControllerTest extends UnitSuite with TestEnvironment with TapirCont
     verify(articleIndexService).deleteIndexWithName(Some("index2"))
     verify(tagIndexService).deleteIndexWithName(Some("index7"))
     verify(tagIndexService).deleteIndexWithName(Some("index8"))
+  }
+
+  test("That triggering url-checker works") {
+    {
+      // Happy days
+      when(urlCheckerService.checkUrlsForArticleSlice(anyInt, anyInt)).thenReturn(Success(UrlCheckSummary(1, 1, 0)))
+      val res = quickRequest.post(uri"http://localhost:$serverPort/intern/check-urls").send()
+      res.code.code should be(200)
+      res.body should equal("URL check complete: 1 article(s) checked, 1 updated, 0 error(s).")
+      verify(urlCheckerService).checkUrlsForArticleSlice(anyInt(), anyInt())
+    }
+    {
+      // Invalid modulus parameter
+      val res = quickRequest.post(uri"http://localhost:$serverPort/intern/check-urls?modulus=-1").send()
+      res.code.code should be(400)
+      res.body should include(
+        "Invalid value for: query parameter modulus (expected value to be greater than 0, but got -1)"
+      )
+    }
+
   }
 }

--- a/draft-api/src/test/scala/no/ndla/draftapi/service/UrlCheckerServiceTest.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/service/UrlCheckerServiceTest.scala
@@ -32,8 +32,9 @@ class UrlCheckerServiceTest extends UnitSuite with TestEnvironment {
 
   val service: UrlCheckerService = new UrlCheckerService
 
-  val testUrl        = "https://example.com/page"
-  val redirectTarget = "https://example.com/new-page"
+  val testUrl                = "https://example.com/page"
+  val redirectTarget         = "https://example.com/new-page"
+  val relativeRedirectTarget = "/new-page"
 
   private def mockResponse(
       statusCode: Int,
@@ -103,6 +104,11 @@ class UrlCheckerServiceTest extends UnitSuite with TestEnvironment {
 
   test("checkUrl returns UrlRedirected with new url for 301 response with Location header") {
     when(httpClientMock.send(any[NdlaRequest])).thenReturn(mockResponse(301, Some(redirectTarget)))
+    service.checkUrl(testUrl) shouldBe UrlRedirected(redirectTarget)
+  }
+
+  test("checkUrl returns UrlRedirected with new url for 302 response with Location header") {
+    when(httpClientMock.send(any[NdlaRequest])).thenReturn(mockResponse(302, Some(relativeRedirectTarget)))
     service.checkUrl(testUrl) shouldBe UrlRedirected(redirectTarget)
   }
 

--- a/draft-api/src/test/scala/no/ndla/draftapi/service/UrlCheckerServiceTest.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/service/UrlCheckerServiceTest.scala
@@ -13,12 +13,14 @@ import no.ndla.common.model.domain.draft.{Draft, DraftStatus}
 import no.ndla.draftapi.{TestData, TestEnvironment, UnitSuite}
 import no.ndla.network.NdlaClient
 import no.ndla.network.model.NdlaRequest
-import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.{any, eq as eqTo}
 import org.mockito.Mockito.{reset, times, verify, when}
+import scalikejdbc.DBSession
 import sttp.client4.{Response, WebSocketSyncBackend}
 import sttp.model.{Method, RequestMetadata, StatusCode, Uri}
 
 import java.util.UUID
+import scala.util.{Failure, Success}
 
 class UrlCheckerServiceTest extends UnitSuite with TestEnvironment {
 
@@ -55,6 +57,7 @@ class UrlCheckerServiceTest extends UnitSuite with TestEnvironment {
 
   override def beforeEach(): Unit = {
     reset(httpClientMock)
+    reset(draftRepository)
     when(clock.now()).thenReturn(TestData.today)
   }
 
@@ -433,5 +436,84 @@ class UrlCheckerServiceTest extends UnitSuite with TestEnvironment {
     result.status.current shouldBe DraftStatus.IN_PROGRESS
     // responsible was not set by url-checker
     result.responsible shouldBe None
+  }
+
+  test("checkUrlsForArticleSlice returns summary with correct counts when articles are unchanged") {
+    when(httpClientMock.send(any[NdlaRequest])).thenReturn(mockResponse(200))
+    val drafts = List(draftWithContent(s"""<a href="$testUrl">link</a>"""), draftWithContent("<p>no links</p>"))
+    when(draftRepository.getArticlesByModulus(eqTo(7), eqTo(3))(using any[DBSession])).thenReturn(Success(drafts))
+
+    val result = service.checkUrlsForArticleSlice(7, 3)
+    result.isSuccess shouldBe true
+    val summary = result.get
+    summary.checked shouldBe 2
+    summary.updated shouldBe 0
+    summary.errors shouldBe 0
+  }
+
+  test("checkUrlsForArticleSlice persists and counts updated articles") {
+    val redirectDraft = draftWithContent(s"""<a href="$testUrl">link</a>""")
+    val cleanDraft    = draftWithContent("<p>no links</p>")
+
+    when(httpClientMock.send(any[NdlaRequest])).thenReturn(mockResponse(301, Some(redirectTarget)))
+    when(draftRepository.getArticlesByModulus(eqTo(365), eqTo(42))(using any[DBSession])).thenReturn(
+      Success(List(redirectDraft, cleanDraft))
+    )
+    when(draftRepository.updateArticle(any[Draft])(using any[DBSession])).thenAnswer(invocation =>
+      Success(invocation.getArgument[Draft](0))
+    )
+
+    val result = service.checkUrlsForArticleSlice(365, 42)
+    result.isSuccess shouldBe true
+    val summary = result.get
+    summary.checked shouldBe 2
+    summary.updated shouldBe 1 // Only the redirected draft was changed
+    summary.errors shouldBe 0
+
+    verify(draftRepository, times(1)).updateArticle(any[Draft])(using any[DBSession])
+  }
+
+  test("checkUrlsForArticleSlice counts errors when repository update fails") {
+    val brokenDraft = draftWithContent(s"""<a href="$testUrl">link</a>""")
+
+    when(httpClientMock.send(any[NdlaRequest])).thenReturn(mockResponse(404))
+    when(draftRepository.getArticlesByModulus(eqTo(365), eqTo(1))(using any[DBSession])).thenReturn(
+      Success(List(brokenDraft))
+    )
+    when(draftRepository.updateArticle(any[Draft])(using any[DBSession])).thenReturn(
+      Failure(new RuntimeException("DB error"))
+    )
+
+    val result = service.checkUrlsForArticleSlice(365, 1)
+    result.isSuccess shouldBe true
+    val summary = result.get
+    summary.checked shouldBe 1
+    summary.updated shouldBe 0
+    summary.errors shouldBe 1
+  }
+
+  test("checkUrlsForArticleSlice returns empty summary when no articles match the slice") {
+    when(draftRepository.getArticlesByModulus(eqTo(365), eqTo(0))(using any[DBSession])).thenReturn(Success(List.empty))
+
+    val result = service.checkUrlsForArticleSlice(365, 0)
+    result.isSuccess shouldBe true
+    val summary = result.get
+    summary.checked shouldBe 0
+    summary.updated shouldBe 0
+    summary.errors shouldBe 0
+  }
+
+  test("checkUrlsForArticleSlice propagates failure when repository query fails") {
+    when(draftRepository.getArticlesByModulus(any[Int], any[Int])(using any[DBSession])).thenReturn(
+      Failure(new RuntimeException("DB connection lost"))
+    )
+
+    val result = service.checkUrlsForArticleSlice(365, 1)
+    result.isFailure shouldBe true
+  }
+
+  test("UrlCheckSummary toString produces a readable message") {
+    UrlCheckSummary(100, 5, 2).toString shouldBe
+      "URL check complete: 100 article(s) checked, 5 updated, 2 error(s)."
   }
 }

--- a/draft-api/src/test/scala/no/ndla/draftapi/service/UrlCheckerServiceTest.scala
+++ b/draft-api/src/test/scala/no/ndla/draftapi/service/UrlCheckerServiceTest.scala
@@ -1,0 +1,437 @@
+/*
+ * Part of NDLA draft-api
+ * Copyright (C) 2026 NDLA
+ *
+ * See LICENSE
+ *
+ */
+
+package no.ndla.draftapi.service
+
+import no.ndla.common.model.domain.{ArticleContent, Responsible, RevisionMeta, RevisionStatus, Status}
+import no.ndla.common.model.domain.draft.{Draft, DraftStatus}
+import no.ndla.draftapi.{TestData, TestEnvironment, UnitSuite}
+import no.ndla.network.NdlaClient
+import no.ndla.network.model.NdlaRequest
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.{reset, times, verify, when}
+import sttp.client4.{Response, WebSocketSyncBackend}
+import sttp.model.{Method, RequestMetadata, StatusCode, Uri}
+
+import java.util.UUID
+
+class UrlCheckerServiceTest extends UnitSuite with TestEnvironment {
+
+  // Override ndlaClient with a version that uses a mock sttp backend
+  val httpClientMock: WebSocketSyncBackend          = mock[WebSocketSyncBackend]
+  override implicit lazy val ndlaClient: NdlaClient = new NdlaClient {
+    override val client: WebSocketSyncBackend = httpClientMock
+  }
+
+  val service: UrlCheckerService = new UrlCheckerService
+
+  val testUrl        = "https://example.com/page"
+  val redirectTarget = "https://example.com/new-page"
+
+  private def mockResponse(
+      statusCode: Int,
+      locationHeader: Option[String] = None,
+      url: String = testUrl,
+  ): Response[String] = {
+    val headers = locationHeader.map(loc => sttp.model.Header("Location", loc)).toSeq
+    new Response(
+      body = "",
+      code = StatusCode(statusCode),
+      statusText = StatusCode(statusCode).toString,
+      headers = headers,
+      history = List.empty,
+      request = RequestMetadata(Method.HEAD, Uri.unsafeParse(url), List.empty),
+    )
+  }
+
+  private def draftWithContent(html: String): Draft = TestData
+    .sampleArticleWithPublicDomain
+    .copy(content = Seq(ArticleContent(html, "nb")), notes = Seq.empty, revisionMeta = Seq.empty)
+
+  override def beforeEach(): Unit = {
+    reset(httpClientMock)
+    when(clock.now()).thenReturn(TestData.today)
+  }
+
+  test("extractUrls returns http and https hrefs from anchor tags") {
+    val html = """<p><a href="https://example.com">link</a> and <a href="http://other.com/path">other</a></p>"""
+    service.extractUrls(html) should contain theSameElementsAs List("https://example.com", "http://other.com/path")
+  }
+
+  test("extractUrls extracts data-url from ndlaembed related-content tags") {
+    val html = """<ndlaembed data-resource="related-content" data-url="https://related.com/page"></ndlaembed>"""
+    service.extractUrls(html) should contain theSameElementsAs List("https://related.com/page")
+  }
+
+  test("extractUrls does not extract data-url from ndlaembed tags with other resource types") {
+    val html = """<ndlaembed data-resource="image" data-url="https://should-be-ignored.com"></ndlaembed>"""
+    service.extractUrls(html) shouldBe empty
+  }
+
+  test("extractUrls extracts urls from both a-tags and ndlaembed related-content tags") {
+    val html = """<p><a href="https://anchor.com">link</a></p>""" +
+      """<ndlaembed data-resource="related-content" data-url="https://related.com"></ndlaembed>"""
+    service.extractUrls(html) should contain theSameElementsAs List("https://anchor.com", "https://related.com")
+  }
+
+  test("extractUrls excludes relative and non-http hrefs") {
+    val html =
+      """<p><a href="/relative/path">rel</a><a href="mailto:foo@bar.com">mail</a><a href="ftp://ftp.example.com">ftp</a></p>"""
+    service.extractUrls(html) shouldBe empty
+  }
+
+  test("extractUrls returns empty list when there are no anchor tags") {
+    service.extractUrls("<div><p>No links here</p></div>") shouldBe empty
+  }
+
+  test("extractUrls returns empty list for empty html") {
+    service.extractUrls("") shouldBe empty
+  }
+
+  test("checkUrl returns UrlOk for a 200 response") {
+    when(httpClientMock.send(any[NdlaRequest])).thenReturn(mockResponse(200))
+    service.checkUrl(testUrl) shouldBe UrlOk
+  }
+
+  test("checkUrl returns UrlRedirected with new url for 301 response with Location header") {
+    when(httpClientMock.send(any[NdlaRequest])).thenReturn(mockResponse(301, Some(redirectTarget)))
+    service.checkUrl(testUrl) shouldBe UrlRedirected(redirectTarget)
+  }
+
+  test("checkUrl returns UrlRedirected for 307 response with Location header") {
+    when(httpClientMock.send(any[NdlaRequest])).thenReturn(mockResponse(307, Some(redirectTarget)))
+    service.checkUrl(testUrl) shouldBe UrlRedirected(redirectTarget)
+  }
+
+  test("checkUrl returns UrlRedirected for 308 response with Location header") {
+    when(httpClientMock.send(any[NdlaRequest])).thenReturn(mockResponse(308, Some(redirectTarget)))
+    service.checkUrl(testUrl) shouldBe UrlRedirected(redirectTarget)
+  }
+
+  test("checkUrl returns UrlOk for redirect response without Location header") {
+    when(httpClientMock.send(any[NdlaRequest])).thenReturn(mockResponse(301, None))
+    service.checkUrl(testUrl) shouldBe UrlOk
+  }
+
+  test("checkUrl returns UrlBroken for 404 response") {
+    when(httpClientMock.send(any[NdlaRequest])).thenReturn(mockResponse(404))
+    service.checkUrl(testUrl) shouldBe UrlBroken(404)
+  }
+
+  test("checkUrl returns UrlBroken for 500 response") {
+    when(httpClientMock.send(any[NdlaRequest])).thenReturn(mockResponse(500))
+    service.checkUrl(testUrl) shouldBe UrlBroken(500)
+  }
+
+  test("checkUrl returns UrlBroken for 410 Gone response") {
+    when(httpClientMock.send(any[NdlaRequest])).thenReturn(mockResponse(410))
+    service.checkUrl(testUrl) shouldBe UrlBroken(410)
+  }
+
+  test("checkUrl returns UrlCheckFailed when sttp throws an exception") {
+    when(httpClientMock.send(any[NdlaRequest])).thenThrow(new RuntimeException("Connection refused"))
+    service.checkUrl(testUrl) shouldBe a[UrlCheckFailed]
+  }
+
+  test("checkUrl returns UrlOk for 2xx responses other than 200") {
+    when(httpClientMock.send(any[NdlaRequest])).thenReturn(mockResponse(204))
+    service.checkUrl(testUrl) shouldBe UrlOk
+  }
+
+  test("checkUrl sends a HEAD request (not GET or POST)") {
+    when(httpClientMock.send(any[NdlaRequest])).thenReturn(mockResponse(200))
+    service.checkUrl(testUrl)
+    val captor = org.mockito.ArgumentCaptor.forClass(classOf[NdlaRequest])
+    verify(httpClientMock).send(captor.capture())
+    captor.getValue.method shouldBe Method.HEAD
+  }
+
+  test("updateContentUrls replaces matching href with new url") {
+    val html    = """<p><a href="https://old.com">text</a></p>"""
+    val updates = Map("https://old.com" -> "https://new.com")
+    val result  = service.updateContentUrls(html, updates)
+    result should include("https://new.com")
+    result should not include "https://old.com"
+  }
+
+  test("updateContentUrls replaces data-url on ndlaembed related-content") {
+    val html    = """<ndlaembed data-resource="related-content" data-url="https://old.com"></ndlaembed>"""
+    val updates = Map("https://old.com" -> "https://new.com")
+    val result  = service.updateContentUrls(html, updates)
+    result should include("https://new.com")
+    result should not include "https://old.com"
+  }
+
+  test("updateContentUrls replaces both a-tag href and ndlaembed data-url in the same content") {
+    val html = """<p><a href="https://old.com">link</a></p>""" +
+      """<ndlaembed data-resource="related-content" data-url="https://old.com"></ndlaembed>"""
+    val updates = Map("https://old.com" -> "https://new.com")
+    val result  = service.updateContentUrls(html, updates)
+    result should not include "https://old.com"
+    result.split("https://new.com").length - 1 shouldBe 2 // appears twice
+  }
+
+  test("updateContentUrls leaves urls not in the map unchanged") {
+    val html    = """<p><a href="https://keep.com">text</a><a href="https://old.com">text2</a></p>"""
+    val updates = Map("https://old.com" -> "https://new.com")
+    val result  = service.updateContentUrls(html, updates)
+    result should include("https://keep.com")
+    result should include("https://new.com")
+    result should not include "https://old.com"
+  }
+
+  test("updateContentUrls returns content unchanged when updates map is empty") {
+    val html   = """<p><a href="https://example.com">text</a></p>"""
+    val result = service.updateContentUrls(html, Map.empty)
+    result shouldBe html
+  }
+
+  test("updateContentUrls replaces all occurrences of the same url") {
+    val html    = """<p><a href="https://old.com">a</a><a href="https://old.com">b</a></p>"""
+    val updates = Map("https://old.com" -> "https://new.com")
+    val result  = service.updateContentUrls(html, updates)
+    result should not include "https://old.com"
+    result should include("https://new.com")
+  }
+
+  test("checkAndUpdateUrls updates ndlaembed data-url and adds EditorNote for redirect") {
+    when(httpClientMock.send(any[NdlaRequest])).thenReturn(mockResponse(301, Some(redirectTarget)))
+    val html   = s"""<ndlaembed data-resource="related-content" data-url="$testUrl"></ndlaembed>"""
+    val draft  = draftWithContent(html)
+    val result = service.checkAndUpdateUrls(draft, "test-user")
+
+    result.content.map(_.content).mkString should include(redirectTarget)
+    result.content.map(_.content).mkString should not include testUrl
+    result.notes should have size 1
+    result.notes.head.note should include(testUrl)
+    result.notes.head.note should include(redirectTarget)
+  }
+
+  test("checkAndUpdateUrls adds RevisionMeta for broken ndlaembed data-url") {
+    when(httpClientMock.send(any[NdlaRequest])).thenReturn(mockResponse(404))
+    val html   = s"""<ndlaembed data-resource="related-content" data-url="$testUrl"></ndlaembed>"""
+    val draft  = draftWithContent(html)
+    val result = service.checkAndUpdateUrls(draft, "test-user")
+
+    result.revisionMeta should have size 1
+    result.revisionMeta.head.note should include(testUrl)
+    result.revisionMeta.head.note should include("404")
+    result.revisionMeta.head.status shouldBe RevisionStatus.NeedsRevision
+  }
+
+  test("checkAndUpdateUrls deduplicates url appearing in both a-tag and ndlaembed") {
+    when(httpClientMock.send(any[NdlaRequest])).thenReturn(mockResponse(200))
+    val html = s"""<p><a href="$testUrl">link</a></p>""" +
+      s"""<ndlaembed data-resource="related-content" data-url="$testUrl"></ndlaembed>"""
+    val draft  = draftWithContent(html)
+    val result = service.checkAndUpdateUrls(draft, "test-user")
+    // URL deduplication means backend is called only once
+    verify(httpClientMock, times(1)).send(any[NdlaRequest])
+    result shouldBe draft
+  }
+
+  test("checkAndUpdateUrls returns draft unchanged when content has no http links") {
+    val draft  = draftWithContent("<p>No links here</p>")
+    val result = service.checkAndUpdateUrls(draft, "test-user")
+    result shouldBe draft
+  }
+
+  test("checkAndUpdateUrls returns draft unchanged for 200 responses") {
+    when(httpClientMock.send(any[NdlaRequest])).thenReturn(mockResponse(200))
+    val draft  = draftWithContent(s"""<p><a href="$testUrl">link</a></p>""")
+    val result = service.checkAndUpdateUrls(draft, "test-user")
+    result shouldBe draft
+  }
+
+  test("checkAndUpdateUrls updates href and adds EditorNote for 301 redirect") {
+    when(httpClientMock.send(any[NdlaRequest])).thenReturn(mockResponse(301, Some(redirectTarget)))
+    val draft  = draftWithContent(s"""<p><a href="$testUrl">link</a></p>""")
+    val result = service.checkAndUpdateUrls(draft, "test-user")
+
+    // Content should contain the redirect target URL
+    result.content.map(_.content).mkString should include(redirectTarget)
+    result.content.map(_.content).mkString should not include testUrl
+
+    // An EditorNote should have been added
+    result.notes should have size 1
+    result.notes.head.note should include(testUrl)
+    result.notes.head.note should include(redirectTarget)
+    result.notes.head.user shouldBe "test-user"
+
+    // No new RevisionMeta
+    result.revisionMeta shouldBe draft.revisionMeta
+  }
+
+  test("checkAndUpdateUrls adds RevisionMeta for 404 broken link") {
+    when(httpClientMock.send(any[NdlaRequest])).thenReturn(mockResponse(404))
+    val draft  = draftWithContent(s"""<p><a href="$testUrl">link</a></p>""")
+    val result = service.checkAndUpdateUrls(draft, "test-user")
+
+    // Content should be unchanged
+    result.content shouldBe draft.content
+
+    // No EditorNotes added
+    result.notes shouldBe draft.notes
+
+    // A RevisionMeta should have been added
+    result.revisionMeta should have size 1
+    result.revisionMeta.head.note should include(testUrl)
+    result.revisionMeta.head.note should include("404")
+    result.revisionMeta.head.status shouldBe RevisionStatus.NeedsRevision
+  }
+
+  test("checkAndUpdateUrls does not add duplicate RevisionMeta for already-noted broken url") {
+    when(httpClientMock.send(any[NdlaRequest])).thenReturn(mockResponse(404))
+    val existingNote = s"URL '$testUrl' returnerte HTTP 404 og må oppdateres."
+    val existingMeta = RevisionMeta(
+      id = UUID.randomUUID(),
+      revisionDate = TestData.today.plusYears(1).withNano(0),
+      note = existingNote,
+      status = RevisionStatus.NeedsRevision,
+    )
+    val draft  = draftWithContent(s"""<p><a href="$testUrl">link</a></p>""").copy(revisionMeta = Seq(existingMeta))
+    val result = service.checkAndUpdateUrls(draft, "test-user")
+
+    // Should still be just the one existing entry
+    result.revisionMeta should have size 1
+    result.revisionMeta.head.id shouldBe existingMeta.id
+  }
+
+  test("checkAndUpdateUrls deduplicates identical urls before checking") {
+    when(httpClientMock.send(any[NdlaRequest])).thenReturn(mockResponse(200))
+    val html   = s"""<p><a href="$testUrl">a</a><a href="$testUrl">b</a></p>"""
+    val draft  = draftWithContent(html)
+    val result = service.checkAndUpdateUrls(draft, "test-user")
+    // Should only call the backend once for the deduplicated URL
+    verify(httpClientMock, times(1)).send(any[NdlaRequest])
+    result shouldBe draft
+  }
+
+  test("checkAndUpdateUrls handles multiple content blocks across languages") {
+    when(httpClientMock.send(any[NdlaRequest])).thenReturn(mockResponse(301, Some(redirectTarget)))
+    val draft = TestData
+      .sampleArticleWithPublicDomain
+      .copy(
+        content = Seq(
+          ArticleContent(s"""<p><a href="$testUrl">link nb</a></p>""", "nb"),
+          ArticleContent(s"""<p><a href="$testUrl">link nn</a></p>""", "nn"),
+        ),
+        notes = Seq.empty,
+        revisionMeta = Seq.empty,
+      )
+    val result = service.checkAndUpdateUrls(draft, "test-user")
+
+    // Both content blocks should be updated
+    result.content.foreach(_.content should include(redirectTarget))
+    result.content.foreach(_.content should not include testUrl)
+
+    // URL is only checked once (deduplicated across language variants)
+    verify(httpClientMock, times(1)).send(any[NdlaRequest])
+
+    // One EditorNote (one unique URL was redirected)
+    result.notes should have size 1
+  }
+
+  test("checkAndUpdateUrls adds RevisionMeta for 500 server error") {
+    when(httpClientMock.send(any[NdlaRequest])).thenReturn(mockResponse(500))
+    val draft  = draftWithContent(s"""<a href="$testUrl">link</a>""")
+    val result = service.checkAndUpdateUrls(draft, "test-user")
+    result.revisionMeta should have size 1
+    result.revisionMeta.head.note should include("500")
+  }
+
+  test("checkAndUpdateUrls adds RevisionMeta for network errors (UrlCheckFailed)") {
+    when(httpClientMock.send(any[NdlaRequest])).thenThrow(new RuntimeException("Connection timed out"))
+    val draft  = draftWithContent(s"""<a href="$testUrl">link</a>""")
+    val result = service.checkAndUpdateUrls(draft, "test-user")
+    // Network failures (unreachable domain etc.) are treated like broken links
+    result.revisionMeta should have size 1
+    result.revisionMeta.head.note should include(testUrl)
+    result.revisionMeta.head.note should include("Connection timed out")
+    result.revisionMeta.head.status shouldBe RevisionStatus.NeedsRevision
+    // Content and notes are unchanged
+    result.content shouldBe draft.content
+    result.notes shouldBe draft.notes
+  }
+
+  test("checkAndUpdateUrls does not add duplicate RevisionMeta for already-noted unreachable url") {
+    val errorMsg     = "Connection timed out"
+    val existingNote = s"URL '$testUrl' kunne ikke nås ($errorMsg) og må oppdateres."
+    val existingMeta = RevisionMeta(
+      id = UUID.randomUUID(),
+      revisionDate = TestData.today.plusYears(1).withNano(0),
+      note = existingNote,
+      status = RevisionStatus.NeedsRevision,
+    )
+    when(httpClientMock.send(any[NdlaRequest])).thenThrow(new RuntimeException(errorMsg))
+    val draft  = draftWithContent(s"""<a href="$testUrl">link</a>""").copy(revisionMeta = Seq(existingMeta))
+    val result = service.checkAndUpdateUrls(draft, "test-user")
+    result.revisionMeta should have size 1
+    result.revisionMeta.head.id shouldBe existingMeta.id
+  }
+
+  private def publishedDraftWithContent(html: String): Draft = draftWithContent(html).copy(
+    status = Status(DraftStatus.PUBLISHED, Set.empty),
+    updatedBy = "editor-user",
+    responsible = None,
+  )
+
+  test("checkAndUpdateUrls sets status to IN_PROGRESS and responsible when PUBLISHED draft is modified by redirect") {
+    when(httpClientMock.send(any[NdlaRequest])).thenReturn(mockResponse(301, Some(redirectTarget)))
+    val draft  = publishedDraftWithContent(s"""<a href="$testUrl">link</a>""")
+    val result = service.checkAndUpdateUrls(draft, "url-checker")
+
+    result.status.current shouldBe DraftStatus.IN_PROGRESS
+    result.status.other shouldBe Set.empty
+    result.responsible shouldBe Some(Responsible("editor-user", TestData.today))
+  }
+
+  test("checkAndUpdateUrls does NOT change status when PUBLISHED draft only gets revisionMeta for a broken link") {
+    when(httpClientMock.send(any[NdlaRequest])).thenReturn(mockResponse(404))
+    val draft  = publishedDraftWithContent(s"""<a href="$testUrl">link</a>""")
+    val result = service.checkAndUpdateUrls(draft, "url-checker")
+
+    result.status.current shouldBe DraftStatus.PUBLISHED
+    result.responsible shouldBe None
+    // RevisionMeta is still added
+    result.revisionMeta should have size 1
+  }
+
+  test("checkAndUpdateUrls does NOT change status when PUBLISHED draft only gets revisionMeta for an unreachable url") {
+    when(httpClientMock.send(any[NdlaRequest])).thenThrow(new RuntimeException("Connection refused"))
+    val draft  = publishedDraftWithContent(s"""<a href="$testUrl">link</a>""")
+    val result = service.checkAndUpdateUrls(draft, "url-checker")
+
+    result.status.current shouldBe DraftStatus.PUBLISHED
+    result.responsible shouldBe None
+    // RevisionMeta is still added
+    result.revisionMeta should have size 1
+  }
+
+  test("checkAndUpdateUrls does not change status when PUBLISHED draft has only healthy links") {
+    when(httpClientMock.send(any[NdlaRequest])).thenReturn(mockResponse(200))
+    val draft  = publishedDraftWithContent(s"""<a href="$testUrl">link</a>""")
+    val result = service.checkAndUpdateUrls(draft, "url-checker")
+
+    result.status.current shouldBe DraftStatus.PUBLISHED
+    result.responsible shouldBe None
+  }
+
+  test("checkAndUpdateUrls does not change status when draft in IN_PROGRESS is modified") {
+    when(httpClientMock.send(any[NdlaRequest])).thenReturn(mockResponse(301, Some(redirectTarget)))
+    val draft = draftWithContent(s"""<a href="$testUrl">link</a>""").copy(
+      status = Status(DraftStatus.IN_PROGRESS, Set.empty),
+      updatedBy = "editor-user",
+    )
+    val result = service.checkAndUpdateUrls(draft, "url-checker")
+
+    result.status.current shouldBe DraftStatus.IN_PROGRESS
+    // responsible was not set by url-checker
+    result.responsible shouldBe None
+  }
+}


### PR DESCRIPTION
Legger til funksjonalitet for å sjekke urler i artikler. Bruker quickRequest for å sende head-spørring og gjør følgende basert på svar:
* 200: Alt er tipp topp
* 30x: Bytt ut url med erstatning. Legg inn endringsloggmelding og endre status til I arbeid.
* 40x og 50x: Legg til revisjonmeta en måned fram i tid der det legges til melding om url som ikkje fungerer.

Har også et endepunkt som kan kalles av en cronjobb for daglig vasking. Endepunktet kan også kalles for å gjøre en full vasking av databasen.