### PR TITLE
chore(db): set timeouts for pgJDBC connection

### DIFF
--- a/database/src/main/scala/no/ndla/database/DataSource.scala
+++ b/database/src/main/scala/no/ndla/database/DataSource.scala
@@ -33,6 +33,9 @@ object DataSource extends StrictLogging {
     dataSourceConfig.setPassword(props.MetaPassword)
     dataSourceConfig.setJdbcUrl(s"jdbc:postgresql://${props.MetaServer}:${props.MetaPort}/${props.MetaResource}")
     dataSourceConfig.setDriverClassName("org.postgresql.Driver")
+    dataSourceConfig.addDataSourceProperty("socketTimeout", "1800") // 30 minutes
+    dataSourceConfig.addDataSourceProperty("loginTimeout", "10")
+    dataSourceConfig.addDataSourceProperty("tcpKeepAlive", "true")
     dataSourceConfig.setSchema(props.MetaSchema)
     dataSourceConfig.setMaximumPoolSize(props.MetaMaxConnections)
     dataSourceConfig.setMetricsTrackerFactory(


### PR DESCRIPTION
Setter timeouts for lesing av socket og login for pgJDBC + skrur på TCP keepalive. Disse timeouts'ene har defaultverdi på 0, som betyr uendelig, og gjør at connections kan bli "stuck".